### PR TITLE
Cross-workspace observability + trace deep-dive overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Trace discovery: Tier 2a (AI Gateway / Model Serving inference logs from `*_payload` UC tables) and Tier 2b (UC-stored MLflow traces from both `*_otel_spans` and `trace_logs_*` table formats), both account-wide via Unity Catalog SQL
+- Gateway Requests panel in Observability with payload deep-dive
+- Trace deep-dive view now serves UC-stored traces from the Lakebase cache (no MLflow REST round-trip)
+- Trace and gateway-log time-window selectors extended to 180d / 365d
+
+### Changed
+- Trace discovery's visibility model and run-as principal recommendation documented in README and installation guide
+- `observability_trace_details` lookup falls back to request_id-only when workspace_id is empty (UC traces have no owning workspace)
+
+### Notes
+- Tier 3 (cross-workspace MLflow REST fan-out for default-backend traces) is on the roadmap. Until then, default-backend traces are visible only from within their owning workspace; UC-stored traces and AI Gateway logs are covered account-wide.
+
 ## [0.2.0] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,7 +45,33 @@ Combined monitoring for Vector Search and Lakebase. Overview tab shows total cos
 
 ### Observability
 
-Cross-workspace MLflow experiments, evaluation runs, and traces. Queries `system.mlflow.experiments_latest` and `system.mlflow.runs_latest` for account-wide visibility. Filter by workspace, view trace details, and identify which data source (system table or REST API) each record came from.
+Cross-workspace MLflow experiments, evaluation runs, and agent traces. Queries `system.mlflow.experiments_latest` and `system.mlflow.runs_latest` for account-wide visibility. Filter by workspace, view trace details, and identify which source each record came from.
+
+Trace discovery uses three complementary paths so coverage doesn't depend on a single backend:
+
+| Tier | Source | What it covers |
+|------|--------|----------------|
+| **1. Local default-backend MLflow** | MLflow tracking REST in the deploy workspace | Traces written to the workspace's default control-plane backend |
+| **2a. AI Gateway / Model Serving inference logs** | Unity Catalog SQL on `*_payload` tables | Request/response payloads + latency/status from any served endpoint with inference logging enabled, account-wide |
+| **2b. UC-stored MLflow traces** | Unity Catalog SQL on `*_otel_spans` and `trace_logs_*` tables | MLflow traces stored directly in UC (both OTel-spans and Databricks-native row-per-trace formats), account-wide |
+
+Tier 2a/2b are the cross-workspace path — UC governance is the only auth boundary, so a single discovery run can pull traces from any workspace whose tables are in the same metastore.
+
+**Tier 3 (cross-workspace REST fan-out for default-backend traces)** is on the roadmap and currently disabled. It would extend Tier 1 to remote workspaces by calling each workspace's MLflow tracking REST API directly, and is required for default-backend traces in workspaces other than where the discovery job runs.
+
+#### What your agents need to do for traces to exist
+
+The discovery tiers find what's already being written. To populate them, opt agents into the relevant Databricks feature:
+
+| Tier | What to enable on your agent / endpoint |
+|------|-----------------------------------------|
+| **1** | Use MLflow tracing in your agent code (`mlflow.trace`/autolog). Traces land in the deploy workspace's default MLflow tracking backend automatically. |
+| **2a** | Enable **inference table logging** on your Model Serving endpoint (or the equivalent **AI Gateway request logging** if the endpoint sits behind AI Gateway). Both write request/response payloads to a `<endpoint>_payload` Delta table in Unity Catalog. |
+| **2b** | Either (i) bind your MLflow experiment to a Unity Catalog trace location so traces materialize as `*_otel_spans` tables, or (ii) use Databricks-managed MLflow with a UC-bound experiment, which writes `trace_logs_<experiment_id>` tables. Either format is picked up automatically. |
+
+If none of these are enabled for an agent, no trace data will exist for the workflow to discover — the gap is upstream of the control plane.
+
+> **Coverage depends on what the discovery principal can read.** The Tier 2 paths use `system.information_schema.tables`, which is principal-filtered: a table only appears if the principal has at least `BROWSE`/`USE` along the catalog → schema → table chain. Reading rows additionally requires `SELECT` (or ownership). For account-wide coverage that auto-extends to new catalogs, run the discovery workflow as a **metastore admin** (or as a service principal that's a member of the metastore admin group). See [installation guide → Step 7](docs/installation.md#step-7-deploy-the-discovery-workflows) for the run-as configuration.
 
 ![Observability](docs/gifs/observability.gif)
 

--- a/control-plane-app/backend/api/admin.py
+++ b/control-plane-app/backend/api/admin.py
@@ -1,0 +1,104 @@
+"""Admin probe endpoints — for ad-hoc diagnostics, not for steady-state use."""
+from typing import Optional
+from fastapi import APIRouter, Query
+import httpx
+from databricks.sdk import WorkspaceClient
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/probe-cross-workspace")
+async def probe_cross_workspace(
+    target_host: str = Query(
+        "https://dbc-c1ba6c29-075e.cloud.databricks.com",
+        description="Target workspace host (https://...)",
+    ),
+    secret_scope: str = Query("acp-discovery"),
+    client_id_key: str = Query("client_id"),
+    client_secret_key: str = Query("client_secret"),
+):
+    """Probe whether App Compute can call /api/2.0/mlflow/* on another workspace.
+
+    Tests three things in sequence and reports each independently:
+      1. Can the app SP read the discovery SP creds from the secret scope?
+      2. Can we exchange those creds for a workspace token at the target host?
+      3. Can we call /api/2.0/mlflow/experiments/search on the target as the SP?
+    """
+    out = {"target_host": target_host.rstrip("/"), "steps": {}}
+
+    # 1. Read SP creds from secret scope
+    try:
+        w = WorkspaceClient()
+        cid = w.secrets.get_secret(scope=secret_scope, key=client_id_key).value
+        csec = w.secrets.get_secret(scope=secret_scope, key=client_secret_key).value
+        # SDK returns base64-encoded value
+        import base64
+        client_id = base64.b64decode(cid).decode()
+        client_secret = base64.b64decode(csec).decode()
+        out["steps"]["secret_read"] = {
+            "ok": True,
+            "client_id_length": len(client_id),
+            "client_secret_length": len(client_secret),
+        }
+    except Exception as exc:
+        out["steps"]["secret_read"] = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return out
+
+    # 2. OIDC token exchange at target workspace
+    try:
+        r = httpx.post(
+            f"{out['target_host']}/oidc/v1/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": "all-apis",
+            },
+            timeout=30,
+        )
+        if r.status_code == 200:
+            sp_token = r.json().get("access_token", "")
+            out["steps"]["oidc_exchange"] = {
+                "ok": bool(sp_token),
+                "status": r.status_code,
+                "token_length": len(sp_token),
+            }
+        else:
+            out["steps"]["oidc_exchange"] = {
+                "ok": False,
+                "status": r.status_code,
+                "body": r.text[:300],
+            }
+            return out
+    except Exception as exc:
+        out["steps"]["oidc_exchange"] = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return out
+
+    # 3. Cross-workspace MLflow API call as SP
+    try:
+        r = httpx.post(
+            f"{out['target_host']}/api/2.0/mlflow/experiments/search",
+            headers={"Authorization": f"Bearer {sp_token}", "Content-Type": "application/json"},
+            json={"max_results": 5},
+            timeout=30,
+        )
+        body = r.text[:500]
+        if r.status_code == 200:
+            data = r.json()
+            exps = data.get("experiments", [])
+            out["steps"]["mlflow_call"] = {
+                "ok": True,
+                "status": 200,
+                "experiment_count": len(exps),
+                "first_experiment_name": (exps[0].get("name", "") if exps else None),
+            }
+        else:
+            out["steps"]["mlflow_call"] = {
+                "ok": False,
+                "status": r.status_code,
+                "body": body,
+            }
+    except Exception as exc:
+        out["steps"]["mlflow_call"] = {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+    return out

--- a/control-plane-app/backend/api/gateway_logs.py
+++ b/control-plane-app/backend/api/gateway_logs.py
@@ -1,0 +1,53 @@
+"""API routes for AI Gateway / Model Serving inference logs (Tier 2a)."""
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from backend.services import gateway_logs_service
+from backend.utils.auth import get_current_user
+
+router = APIRouter(
+    prefix="/gateway-logs",
+    tags=["gateway-logs"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+@router.get("")
+async def list_logs(
+    source_table: Optional[str] = Query(None, description="Filter to a single source table"),
+    window_days: Optional[int] = Query(None, ge=1, le=365),
+    limit: int = Query(500, le=10000),
+):
+    """List gateway inference-log rows (lightweight — payload sizes only)."""
+    try:
+        return gateway_logs_service.list_gateway_logs(
+            source_table=source_table,
+            window_days=window_days,
+            limit=limit,
+            include_payload=False,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Lakebase query failed: {e}")
+
+
+@router.get("/sources")
+async def list_sources():
+    """List distinct source tables with row counts + recency."""
+    try:
+        return gateway_logs_service.list_source_tables()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Lakebase query failed: {e}")
+
+
+@router.get("/{source_table:path}/{request_id}")
+async def get_log(source_table: str, request_id: str):
+    """Get a single inference-log row including the full request and response payloads."""
+    try:
+        row = gateway_logs_service.get_gateway_log(source_table, request_id)
+        if not row:
+            raise HTTPException(status_code=404, detail="Log row not found")
+        return row
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Lakebase query failed: {e}")

--- a/control-plane-app/backend/api/gateway_logs.py
+++ b/control-plane-app/backend/api/gateway_logs.py
@@ -39,6 +39,23 @@ async def list_sources():
         raise HTTPException(status_code=502, detail=f"Lakebase query failed: {e}")
 
 
+@router.get("/timeseries")
+async def gateway_timeseries(
+    source_table: Optional[str] = Query(None),
+    window_days: int = Query(7, ge=1, le=365),
+    bucket: str = Query("hour", pattern="^(hour|day)$"),
+):
+    """Return per-bucket aggregates for the Gateway Requests time-series chart."""
+    try:
+        return gateway_logs_service.gateway_timeseries(
+            source_table=source_table,
+            window_days=window_days,
+            bucket=bucket,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Lakebase query failed: {e}")
+
+
 @router.get("/{source_table:path}/{request_id}")
 async def get_log(source_table: str, request_id: str):
     """Get a single inference-log row including the full request and response payloads."""

--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -39,20 +39,11 @@ async def list_experiments(
     try:
         token = _obo_token(request)
         if workspace_id == "all":
-            # Read from Lakebase cache (populated by scheduled workflow)
-            cached = mlflow_service.get_cached_experiments(None, max_results)
-            # Also include current workspace live data
-            current = mlflow_service.search_experiments(200, user_token=token)
-            seen = set()
-            merged = []
-            # Cached cross-workspace data first, then current workspace
-            for e in cached + current:
-                eid = e.get("experiment_id", "")
-                if eid and eid not in seen:
-                    seen.add(eid)
-                    merged.append(e)
-            merged.sort(key=lambda e: int(e.get("last_update_time") or 0), reverse=True)
-            return merged
+            # Account-wide view — read from Lakebase cache only. The live
+            # MLflow REST merge against the deploy workspace was adding
+            # 1-2s of unnecessary latency (and a single point of failure)
+            # while not surfacing anything the cache doesn't already have.
+            return mlflow_service.get_cached_experiments(None, max_results)
         elif workspace_id:
             return mlflow_service.get_cached_experiments(workspace_id, max_results)
         else:

--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -113,22 +113,19 @@ async def list_traces(
     filter_string: str = Query(""),
     max_results: int = Query(10000, le=100000),
     workspace_id: Optional[str] = Query(None, description="Workspace ID, 'all' for all workspaces"),
+    window_days: Optional[int] = Query(None, ge=1, le=365, description="Time window in days (e.g. 7/14/30/90)"),
 ):
     """Search MLflow traces. All data comes from Lakebase cache (populated by scheduled workflow)."""
     try:
-        if workspace_id == "all" or not workspace_id:
-            # All workspaces (including current) — read everything from cache
-            return mlflow_service.get_cached_traces(None, max_results)
-        else:
-            # Specific workspace
-            return mlflow_service.get_cached_traces(workspace_id, max_results)
+        ws = None if (workspace_id == "all" or not workspace_id) else workspace_id
+        return mlflow_service.get_cached_traces(ws, max_results, window_days=window_days)
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"MLflow API error: {e}")
 
 
-@router.get("/traces/{request_id}")
+@router.get("/traces/{request_id:path}")
 async def get_trace_detail(
     request_id: str,
     request: Request,
@@ -195,6 +192,20 @@ async def list_observability_workspaces():
         return mlflow_service.get_observability_workspaces()
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"MLflow API error: {e}")
+
+
+@router.get("/workspace-hosts")
+async def list_workspace_hosts():
+    """Return the workspace_id → host URL map from the registry.
+
+    Used by the frontend to build "Open in MLflow" links that route to the
+    correct workspace, not the deploy workspace.
+    """
+    try:
+        from backend.services.workspace_registry import get_all_workspace_hosts
+        return get_all_workspace_hosts()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Workspace registry error: {e}")
 
 
 @router.post("/refresh-cache")

--- a/control-plane-app/backend/main.py
+++ b/control-plane-app/backend/main.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from backend.config import settings, get_databricks_host
-from backend.api import agents, requests, kpis, analytics, health, websocket, gateway, mlflow, billing, tools, access, playground, workspaces, user_analytics, topology, operations, vector_search
+from backend.api import agents, requests, kpis, analytics, health, websocket, gateway, mlflow, billing, tools, access, playground, workspaces, user_analytics, topology, operations, vector_search, admin, gateway_logs
 from backend.utils.auth import get_current_user
 
 
@@ -127,6 +127,13 @@ async def lifespan(app: FastAPI):
         except Exception as exc:
             logger.warning("Vector search startup init skipped: %s", exc)
 
+    def _init_gateway_logs():
+        try:
+            from backend.services.gateway_logs_service import ensure_gateway_logs_table
+            ensure_gateway_logs_table()
+        except Exception as exc:
+            logger.warning("Gateway logs startup init skipped: %s", exc)
+
     # Run all init in a background thread with a timeout so a hanging
     # DB connection doesn't prevent the server from starting.
     def _run_all_inits():
@@ -138,6 +145,7 @@ async def lifespan(app: FastAPI):
         _init_gateway()
         _init_observability()
         _init_vector_search()
+        _init_gateway_logs()
 
     t = threading.Thread(target=_run_all_inits, daemon=True)
     t.start()
@@ -279,6 +287,8 @@ app.include_router(user_analytics.router, prefix=settings.api_prefix)
 app.include_router(topology.router, prefix=settings.api_prefix)
 app.include_router(operations.router, prefix=settings.api_prefix)
 app.include_router(vector_search.router, prefix=settings.api_prefix)
+app.include_router(gateway_logs.router, prefix=settings.api_prefix)
+app.include_router(admin.router, prefix=settings.api_prefix)
 app.include_router(websocket.router)
 
 # ── Serve React SPA from the built dist/ folder ──────────────────

--- a/control-plane-app/backend/services/gateway_logs_service.py
+++ b/control-plane-app/backend/services/gateway_logs_service.py
@@ -1,0 +1,113 @@
+"""Reads AI Gateway / Model Serving inference-log rows cached in Lakebase
+(`gateway_inference_logs` table, populated by the discovery workflow's Tier 2a
+SQL discovery — see workflows/08_discover_gateway_inference_logs.py).
+
+The cache is populated account-wide via Unity Catalog; rows here originate
+from any UC `<prefix>_payload` table the discovery principal could SELECT.
+"""
+from typing import Any, Dict, List, Optional
+import logging
+import time as _time
+
+from backend.database import execute_query, execute_update
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_gateway_logs_table() -> None:
+    """Idempotent DDL — mirrors the schema written by the workflow sync task."""
+    ddl = [
+        """
+        CREATE TABLE IF NOT EXISTS gateway_inference_logs (
+            request_id          TEXT NOT NULL,
+            source_table        TEXT NOT NULL,
+            client_request_id   TEXT,
+            request_time        TIMESTAMP WITH TIME ZONE,
+            status_code         INTEGER,
+            execution_ms        BIGINT,
+            request_payload     TEXT,
+            response_payload    TEXT,
+            request_size_bytes  BIGINT,
+            response_size_bytes BIGINT,
+            served_entity_id    TEXT,
+            requester           TEXT,
+            last_synced         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (source_table, request_id)
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS idx_gil_time   ON gateway_inference_logs (request_time DESC)",
+        "CREATE INDEX IF NOT EXISTS idx_gil_source ON gateway_inference_logs (source_table)",
+        "CREATE INDEX IF NOT EXISTS idx_gil_status ON gateway_inference_logs (status_code)",
+    ]
+    for stmt in ddl:
+        try:
+            execute_update(stmt)
+        except Exception as exc:
+            logger.warning("gateway_inference_logs DDL warning: %s", exc)
+
+
+def list_gateway_logs(
+    *,
+    source_table: Optional[str] = None,
+    window_days: Optional[int] = None,
+    limit: int = 500,
+    include_payload: bool = False,
+) -> List[Dict[str, Any]]:
+    """List gateway inference-log rows with optional filters.
+
+    `include_payload=False` (default) returns lightweight rows with payload
+    sizes only — suitable for the list view. Use `get_gateway_log` for the
+    full request/response on a single row.
+    """
+    where: List[str] = []
+    params: List[Any] = []
+    if source_table:
+        where.append("source_table = %s")
+        params.append(source_table)
+    if window_days:
+        cutoff = int((_time.time() - window_days * 86400) * 1000)
+        where.append("EXTRACT(EPOCH FROM request_time) * 1000 >= %s")
+        params.append(cutoff)
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+
+    cols = (
+        "request_id, source_table, client_request_id, request_time, status_code, "
+        "execution_ms, request_size_bytes, response_size_bytes, served_entity_id, "
+        "requester, model, input_tokens, output_tokens, total_tokens, "
+        "finish_reason, tool_call_count, last_synced"
+    )
+    if include_payload:
+        cols += ", request_payload, response_payload"
+
+    params.append(limit)
+    return execute_query(
+        f"SELECT {cols} FROM gateway_inference_logs{where_sql} "
+        f"ORDER BY request_time DESC NULLS LAST LIMIT %s",
+        tuple(params),
+    )
+
+
+def get_gateway_log(source_table: str, request_id: str) -> Optional[Dict[str, Any]]:
+    """Return a single inference-log row with full payloads."""
+    rows = execute_query(
+        "SELECT * FROM gateway_inference_logs "
+        "WHERE source_table = %s AND request_id = %s",
+        (source_table, request_id),
+    )
+    return rows[0] if rows else None
+
+
+def list_source_tables() -> List[Dict[str, Any]]:
+    """Return distinct source tables with row counts and recency stats —
+    useful for a high-level breakdown by served endpoint."""
+    return execute_query(
+        """
+        SELECT source_table,
+               COUNT(*)         AS row_count,
+               MAX(request_time) AS last_request_time,
+               COUNT(*) FILTER (WHERE status_code >= 400) AS error_count
+        FROM gateway_inference_logs
+        GROUP BY source_table
+        ORDER BY last_request_time DESC NULLS LAST
+        """
+    )

--- a/control-plane-app/backend/services/gateway_logs_service.py
+++ b/control-plane-app/backend/services/gateway_logs_service.py
@@ -97,6 +97,47 @@ def get_gateway_log(source_table: str, request_id: str) -> Optional[Dict[str, An
     return rows[0] if rows else None
 
 
+def gateway_timeseries(
+    *,
+    source_table: Optional[str] = None,
+    window_days: int = 7,
+    bucket: str = "hour",
+) -> List[Dict[str, Any]]:
+    """Return per-bucket aggregates over `gateway_inference_logs`.
+
+    One row per (bucket, source_table). Used by the Gateway Requests panel
+    chart to plot request rate / P95 latency / error rate / token volume
+    over time. `bucket` is one of 'hour' | 'day'.
+    """
+    if bucket not in ("hour", "day"):
+        bucket = "hour"
+    where = ["request_time >= NOW() - %s::interval"]
+    params: List[Any] = [f"{int(window_days)} days"]
+    if source_table:
+        where.append("source_table = %s")
+        params.append(source_table)
+    where_sql = " WHERE " + " AND ".join(where)
+    sql = f"""
+        SELECT date_trunc('{bucket}', request_time) AS bucket,
+               source_table,
+               COUNT(*)                                   AS requests,
+               COUNT(*) FILTER (WHERE status_code >= 400) AS errors,
+               PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY execution_ms) AS p50_ms,
+               PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY execution_ms) AS p95_ms,
+               AVG(execution_ms)                          AS avg_ms,
+               COALESCE(SUM(input_tokens),  0)            AS input_tokens,
+               COALESCE(SUM(output_tokens), 0)            AS output_tokens,
+               COALESCE(SUM(total_tokens),  0)            AS total_tokens,
+               COALESCE(SUM(request_size_bytes),  0)      AS request_bytes,
+               COALESCE(SUM(response_size_bytes), 0)      AS response_bytes
+        FROM gateway_inference_logs
+        {where_sql}
+        GROUP BY bucket, source_table
+        ORDER BY bucket
+    """
+    return execute_query(sql, tuple(params))
+
+
 def list_source_tables() -> List[Dict[str, Any]]:
     """Return distinct source tables with row counts and recency stats —
     useful for a high-level breakdown by served endpoint."""

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -93,6 +93,23 @@ def ensure_observability_tables():
         )
         """,
         "CREATE INDEX IF NOT EXISTS idx_or_ws ON observability_runs (workspace_id)",
+        """
+        CREATE TABLE IF NOT EXISTS observability_trace_details (
+            workspace_id   TEXT NOT NULL,
+            request_id     TEXT NOT NULL,
+            experiment_id  TEXT,
+            trace_info     JSONB,
+            trace_data     JSONB,
+            request_raw    TEXT,
+            response_raw   TEXT,
+            size_bytes     INTEGER,
+            source_type    TEXT,
+            cached_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (workspace_id, request_id)
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS idx_otd_ws     ON observability_trace_details (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_otd_cached ON observability_trace_details (cached_at DESC)",
         # Add columns to existing tables (idempotent)
         "ALTER TABLE observability_experiments ADD COLUMN IF NOT EXISTS data_source TEXT DEFAULT 'system_table'",
         "ALTER TABLE observability_experiments ADD COLUMN IF NOT EXISTS tags JSONB",
@@ -516,72 +533,24 @@ def get_trace_spans(request_id: str) -> List[Dict[str, Any]]:
 
 
 def get_trace_detail(request_id: str, *, user_token: Optional[str] = None) -> Optional[Dict[str, Any]]:
-    """Get full trace info with parsed metadata for a single trace."""
+    """Get full trace info with parsed metadata for a single trace.
+
+    Cache-first: UC-stored traces (request_id starts with `trace:/`) and any
+    other traces that landed in `observability_trace_details` are served from
+    Lakebase. Falls back to a live MLflow REST call for default-backend traces
+    that haven't been cached yet.
+    """
+    # UC traces are uniquely identified by their `trace:/cat.sch.tbl/<id>` URI
+    # — workspace_id is empty for them. Look up by request_id alone first.
+    cached = _get_trace_detail_from_cache_any(request_id)
+    if cached is not None:
+        return cached
+
     data = _get(f"/api/2.0/mlflow/traces/{request_id}", user_token=user_token)
     trace_info = data.get("trace", {}).get("trace_info", {})
     if not trace_info:
         return None
-
-    meta = trace_info.get("trace_metadata", {})
-    tags = trace_info.get("tags", {})
-
-    # Parse token usage
-    token_usage = {}
-    try:
-        token_usage = _json.loads(meta.get("mlflow.trace.tokenUsage", "{}"))
-    except Exception:
-        pass
-
-    # Parse size stats
-    size_stats = {}
-    try:
-        size_stats = _json.loads(meta.get("mlflow.trace.sizeStats", "{}"))
-    except Exception:
-        pass
-
-    # Parse request JSON to extract user messages
-    request_raw = trace_info.get("request", "")
-    user_message = None
-    try:
-        request_parsed = _json.loads(request_raw)
-        inputs = request_parsed.get("input", [])
-        for inp in inputs:
-            if isinstance(inp, dict) and inp.get("role") == "user":
-                content = inp.get("content", [])
-                if isinstance(content, list):
-                    for c in content:
-                        if isinstance(c, dict) and c.get("text"):
-                            user_message = c["text"]
-                            break
-                elif isinstance(content, str):
-                    user_message = content
-    except Exception:
-        pass
-
-    return {
-        "request_id": request_id,
-        "trace_name": tags.get("mlflow.traceName", "—"),
-        "experiment_id": trace_info.get("trace_location", {}).get(
-            "mlflow_experiment", {}
-        ).get("experiment_id"),
-        "state": trace_info.get("state", "—"),
-        "request_time": trace_info.get("request_time"),
-        "execution_duration": trace_info.get("execution_duration"),
-        "user_message": user_message,
-        "response": trace_info.get("response", ""),
-        "response_preview": trace_info.get("response_preview", ""),
-        "request_raw": request_raw,
-        "token_usage": token_usage,
-        "size_stats": size_stats,
-        "model_id": meta.get("mlflow.modelId"),
-        "session_id": meta.get("mlflow.trace.session"),
-        "user": meta.get("mlflow.user"),
-        "source": meta.get("mlflow.source.name"),
-        "trace_schema_version": meta.get("mlflow.trace_schema.version"),
-        "artifact_location": tags.get("mlflow.artifactLocation"),
-        "tags": tags,
-        "metadata": meta,
-    }
+    return _parse_trace_info_to_detail(trace_info, request_id)
 
 
 # ── Cross-workspace helpers ────────────────────────────────────
@@ -734,34 +703,28 @@ def search_traces_all_workspaces(
 
 # ── Cross-workspace: Trace detail ──────────────────────────────
 
-def get_trace_detail_for_workspace(
+def _parse_trace_info_to_detail(
+    trace_info: Dict[str, Any],
     request_id: str,
-    workspace_id: str,
-    *,
-    user_token: str,
-) -> Optional[Dict[str, Any]]:
-    """Get full trace detail from a specific remote workspace."""
-    data = _get_for_workspace(
-        f"/api/2.0/mlflow/traces/{request_id}", None, workspace_id, user_token,
-    )
-    trace_info = data.get("trace", {}).get("trace_info", {})
-    if not trace_info:
-        return None
+    workspace_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Shared parsing for live + cached trace detail responses."""
+    meta = trace_info.get("trace_metadata", {}) or {}
+    tags = trace_info.get("tags", {}) or {}
 
-    # Reuse the same parsing logic as get_trace_detail
-    meta = trace_info.get("trace_metadata", {})
-    tags = trace_info.get("tags", {})
-    token_usage = {}
+    token_usage: Dict[str, Any] = {}
     try:
         token_usage = _json.loads(meta.get("mlflow.trace.tokenUsage", "{}"))
     except Exception:
         pass
-    size_stats = {}
+
+    size_stats: Dict[str, Any] = {}
     try:
         size_stats = _json.loads(meta.get("mlflow.trace.sizeStats", "{}"))
     except Exception:
         pass
-    request_raw = trace_info.get("request", "")
+
+    request_raw = trace_info.get("request", "") or ""
     user_message = None
     try:
         request_parsed = _json.loads(request_raw)
@@ -779,17 +742,26 @@ def get_trace_detail_for_workspace(
     except Exception:
         pass
 
-    result = {
+    # UC-discovered traces store summary fields directly on trace_info under
+    # different keys (see workflows/07_discover_uc_otel_traces.py). Fall back
+    # to those when the standard MLflow keys are missing.
+    request_time_uc = trace_info.get("request_time_ms")
+    if request_time_uc is None and trace_info.get("start_time_unix_nano"):
+        request_time_uc = int(trace_info["start_time_unix_nano"]) // 1_000_000
+    duration_uc = trace_info.get("duration_ms")
+    if duration_uc is None and trace_info.get("start_time_unix_nano") and trace_info.get("end_time_unix_nano"):
+        duration_uc = (int(trace_info["end_time_unix_nano"]) - int(trace_info["start_time_unix_nano"])) // 1_000_000
+
+    result: Dict[str, Any] = {
         "request_id": request_id,
-        "workspace_id": workspace_id,
-        "trace_name": tags.get("mlflow.traceName", "—"),
+        "trace_name": tags.get("mlflow.traceName") or trace_info.get("name") or "—",
         "experiment_id": trace_info.get("trace_location", {}).get(
             "mlflow_experiment", {}
         ).get("experiment_id"),
         "state": trace_info.get("state", "—"),
-        "request_time": trace_info.get("request_time"),
-        "execution_duration": trace_info.get("execution_duration"),
-        "user_message": user_message,
+        "request_time": trace_info.get("request_time") or (str(request_time_uc) if request_time_uc else None),
+        "execution_duration": trace_info.get("execution_duration") or duration_uc,
+        "user_message": user_message or trace_info.get("request_preview") or None,
         "response": trace_info.get("response", ""),
         "response_preview": trace_info.get("response_preview", ""),
         "request_raw": request_raw,
@@ -804,7 +776,126 @@ def get_trace_detail_for_workspace(
         "tags": tags,
         "metadata": meta,
     }
+    if workspace_id:
+        result["workspace_id"] = workspace_id
     return result
+
+
+def _row_to_trace_detail(
+    row: Dict[str, Any], request_id: str, workspace_id: str
+) -> Optional[Dict[str, Any]]:
+    """Shared mapping from `observability_trace_details` row → detail dict."""
+    trace_info = row.get("trace_info")
+    if isinstance(trace_info, str):
+        try:
+            trace_info = _json.loads(trace_info)
+        except Exception:
+            trace_info = {}
+    if not trace_info:
+        return None
+    detail = _parse_trace_info_to_detail(trace_info, request_id, workspace_id)
+    if not detail.get("request_raw") and row.get("request_raw"):
+        detail["request_raw"] = row["request_raw"]
+    if not detail.get("response") and row.get("response_raw"):
+        detail["response"] = row["response_raw"]
+    if not detail.get("experiment_id") and row.get("experiment_id"):
+        detail["experiment_id"] = row["experiment_id"]
+    # Surface the parsed spans array for the waterfall view. trace_data is a
+    # JSONB blob with shape {spans_json: <stringified array>, ...} for UC
+    # row-per-trace traces, or {spans: [...], trace_id: ...} for OTel-spans.
+    td_raw = row.get("trace_data")
+    if isinstance(td_raw, str):
+        try:
+            td = _json.loads(td_raw)
+        except Exception:
+            td = {}
+    else:
+        td = td_raw or {}
+    spans = None
+    sj = td.get("spans_json") if isinstance(td, dict) else None
+    if isinstance(sj, str) and sj:
+        try:
+            spans = _json.loads(sj)
+        except Exception:
+            spans = None
+    if spans is None and isinstance(td, dict):
+        spans = td.get("spans")
+    if isinstance(spans, list):
+        detail["spans"] = spans
+    detail["data_source"] = "cache"
+    return detail
+
+
+def _get_trace_detail_from_cache_any(request_id: str) -> Optional[Dict[str, Any]]:
+    """Look up a cached trace detail by request_id alone.
+
+    UC-stored traces (request_id `trace:/cat.sch.tbl/<id>`) are globally
+    unique by URI and have empty workspace_id. Pick the most recent cached
+    row if multiple exist.
+    """
+    try:
+        rows = execute_query(
+            "SELECT workspace_id, trace_info, trace_data, experiment_id, request_raw, response_raw "
+            "FROM observability_trace_details "
+            "WHERE request_id = %s "
+            "ORDER BY cached_at DESC LIMIT 1",
+            (request_id,),
+        )
+    except Exception as exc:
+        logger.warning("Trace detail cache read (any) failed (rid=%s): %s",
+                       request_id, exc)
+        return None
+    if not rows:
+        return None
+    row = rows[0]
+    return _row_to_trace_detail(row, request_id, row.get("workspace_id") or "")
+
+
+def _get_trace_detail_from_cache(
+    workspace_id: str, request_id: str
+) -> Optional[Dict[str, Any]]:
+    """Read a cached trace detail from observability_trace_details. Returns None on miss."""
+    try:
+        rows = execute_query(
+            "SELECT trace_info, trace_data, experiment_id, request_raw, response_raw "
+            "FROM observability_trace_details "
+            "WHERE workspace_id = %s AND request_id = %s",
+            (workspace_id, request_id),
+        )
+    except Exception as exc:
+        logger.warning("Trace detail cache read failed (ws=%s rid=%s): %s",
+                       workspace_id, request_id, exc)
+        return None
+    if not rows:
+        return None
+    return _row_to_trace_detail(rows[0], request_id, workspace_id)
+
+
+def get_trace_detail_for_workspace(
+    request_id: str,
+    workspace_id: str,
+    *,
+    user_token: str,
+) -> Optional[Dict[str, Any]]:
+    """Get full trace detail for a specific workspace.
+
+    Cache-first: read from `observability_trace_details` (populated by the
+    `04_discover_observability` workflow). Falls back to a live OBO REST call
+    if the cache doesn't have it yet.
+    """
+    cached = _get_trace_detail_from_cache(workspace_id, request_id)
+    if cached is not None:
+        return cached
+
+    data = _get_for_workspace(
+        f"/api/2.0/mlflow/traces/{request_id}", None, workspace_id, user_token,
+    )
+    trace_info = data.get("trace", {}).get("trace_info", {})
+    if not trace_info:
+        return None
+    detail = _parse_trace_info_to_detail(trace_info, request_id, workspace_id)
+    detail["data_source"] = "live"
+    return detail
 
 
 # ── Cross-workspace: Models ────────────────────────────────────
@@ -1014,19 +1105,32 @@ def refresh_observability_cache(*, user_token: str) -> Dict[str, int]:
 
 # ── Lakebase cache: read ───────────────────────────────────────
 
-def get_cached_traces(workspace_id: Optional[str] = None, limit: int = 10000) -> List[Dict[str, Any]]:
-    """Read traces from the Lakebase cache, optionally filtered by workspace."""
+def get_cached_traces(
+    workspace_id: Optional[str] = None,
+    limit: int = 10000,
+    window_days: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Read traces from the Lakebase cache, optionally filtered by workspace and time window.
+
+    `window_days` filters by `request_time` (TEXT epoch-ms). Rows with non-numeric
+    or missing timestamps are excluded when a window is specified.
+    """
+    import time as _time
+    where_clauses = []
+    params: List[Any] = []
     if workspace_id:
-        rows = execute_query(
-            "SELECT * FROM observability_traces WHERE workspace_id = %s ORDER BY request_time DESC LIMIT %s",
-            (workspace_id, limit),
-        )
-    else:
-        rows = execute_query(
-            "SELECT * FROM observability_traces ORDER BY request_time DESC LIMIT %s",
-            (limit,),
-        )
-    return rows
+        where_clauses.append("workspace_id = %s")
+        params.append(workspace_id)
+    if window_days:
+        cutoff_ms = int((_time.time() - window_days * 86400) * 1000)
+        where_clauses.append("request_time ~ '^[0-9]+$' AND CAST(request_time AS BIGINT) >= %s")
+        params.append(cutoff_ms)
+    where_sql = (" WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+    params.append(limit)
+    return execute_query(
+        f"SELECT * FROM observability_traces{where_sql} ORDER BY request_time DESC LIMIT %s",
+        tuple(params),
+    )
 
 
 def get_cached_experiments(workspace_id: Optional[str] = None, limit: int = 10000) -> List[Dict[str, Any]]:

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -709,8 +709,20 @@ def _parse_trace_info_to_detail(
     workspace_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Shared parsing for live + cached trace detail responses."""
-    meta = trace_info.get("trace_metadata", {}) or {}
-    tags = trace_info.get("tags", {}) or {}
+    # MLflow returns metadata + tags in two shapes depending on source:
+    #   - dict: {"key": "value", ...}                     (UC, MLflow 3.x cache)
+    #   - list: [{"key": "k", "value": "v"}, ...]         (MLflow REST raw)
+    # And there are two key names for the metadata bag: `trace_metadata`
+    # (older / cache) and `request_metadata` (MLflow REST). Normalize all
+    # variants to a flat dict before any `.get(...)` calls.
+    def _to_dict(v):
+        if isinstance(v, dict): return v
+        if isinstance(v, list):
+            return {p.get("key", ""): p.get("value", "") for p in v if isinstance(p, dict)}
+        return {}
+
+    meta = _to_dict(trace_info.get("trace_metadata") or trace_info.get("request_metadata"))
+    tags = _to_dict(trace_info.get("tags"))
 
     token_usage: Dict[str, Any] = {}
     try:
@@ -752,6 +764,46 @@ def _parse_trace_info_to_detail(
     if duration_uc is None and trace_info.get("start_time_unix_nano") and trace_info.get("end_time_unix_nano"):
         duration_uc = (int(trace_info["end_time_unix_nano"]) - int(trace_info["start_time_unix_nano"])) // 1_000_000
 
+    # Normalize timestamp + duration to ms — MLflow returns these in three
+    # different shapes across versions: numeric ms (search hit), ISO string
+    # (3.x detail), or "0.374s" duration string (3.x detail). Pick the
+    # numeric shape when present, parse the strings otherwise.
+    def _ts_to_ms(v):
+        if v is None or v == "": return None
+        if isinstance(v, (int, float)): return int(v)
+        if isinstance(v, str):
+            try: return int(v)
+            except ValueError: pass
+            try:
+                from datetime import datetime as _dt
+                return int(_dt.fromisoformat(v.replace("Z", "+00:00")).timestamp() * 1000)
+            except Exception: return None
+        return None
+
+    def _dur_to_ms(v):
+        if v is None or v == "": return None
+        if isinstance(v, (int, float)): return int(v)
+        if isinstance(v, str):
+            try: return int(v)
+            except ValueError: pass
+            # "0.374s" / "1.2s"
+            if v.endswith("s"):
+                try: return int(float(v[:-1]) * 1000)
+                except Exception: return None
+        return None
+
+    # Prefer the numeric search-hit fields over the string detail fields.
+    ts_ms = (
+        _ts_to_ms(trace_info.get("timestamp_ms"))
+        or _ts_to_ms(trace_info.get("request_time"))
+        or request_time_uc
+    )
+    dur_ms = (
+        _dur_to_ms(trace_info.get("execution_time_ms"))
+        or _dur_to_ms(trace_info.get("execution_duration"))
+        or duration_uc
+    )
+
     result: Dict[str, Any] = {
         "request_id": request_id,
         "trace_name": tags.get("mlflow.traceName") or trace_info.get("name") or "—",
@@ -759,8 +811,8 @@ def _parse_trace_info_to_detail(
             "mlflow_experiment", {}
         ).get("experiment_id"),
         "state": trace_info.get("state", "—"),
-        "request_time": trace_info.get("request_time") or (str(request_time_uc) if request_time_uc else None),
-        "execution_duration": trace_info.get("execution_duration") or duration_uc,
+        "request_time": str(ts_ms) if ts_ms is not None else None,
+        "execution_duration": dur_ms,
         "user_message": user_message or trace_info.get("request_preview") or None,
         "response": trace_info.get("response", ""),
         "response_preview": trace_info.get("response_preview", ""),
@@ -822,6 +874,17 @@ def _row_to_trace_detail(
         spans = td.get("spans")
     if isinstance(spans, list):
         detail["spans"] = spans
+    # Surface assessments (LLM-judge / human evaluators) — collected by the
+    # Tier 2b discovery into trace_data.assessments_json.
+    if isinstance(td, dict):
+        aj = td.get("assessments_json") or td.get("assessments")
+        if isinstance(aj, str) and aj:
+            try:
+                aj = _json.loads(aj)
+            except Exception:
+                aj = None
+        if isinstance(aj, list):
+            detail["assessments"] = aj
     detail["data_source"] = "cache"
     return detail
 

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -291,6 +291,36 @@ export function useGatewayLogSources() {
   })
 }
 
+export function useGatewayLogTimeseries(
+  windowDays: number,
+  sourceTable?: string | null,
+  bucket: 'hour' | 'day' = 'hour',
+) {
+  return useQuery({
+    queryKey: ['gateway-logs', 'timeseries', windowDays, sourceTable, bucket],
+    queryFn: async () => {
+      const params: Record<string, string> = {
+        window_days: String(windowDays),
+        bucket,
+      }
+      if (sourceTable) params.source_table = sourceTable
+      const { data } = await apiClient.get('/gateway-logs/timeseries', { params })
+      return data as Array<{
+        bucket: string
+        source_table: string
+        requests: number
+        errors: number
+        p50_ms: number | null
+        p95_ms: number | null
+        avg_ms: number | null
+        input_tokens: number
+        output_tokens: number
+        total_tokens: number
+      }>
+    },
+  })
+}
+
 export function useGatewayLogDetail(sourceTable: string | null, requestId: string | null) {
   return useQuery({
     queryKey: ['gateway-logs', 'detail', sourceTable, requestId],

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -218,8 +218,10 @@ export function useMlflowExperiments(workspaceId?: string | null) {
   return useQuery({
     queryKey: ['mlflow', 'experiments', workspaceId],
     queryFn: async () => {
-      const params: Record<string, string> = {}
-      if (workspaceId) params.workspace_id = workspaceId
+      // Default to account-wide cache when no specific workspace is selected,
+      // otherwise the local-MLflow REST path returns 0 rows even though the
+      // Lakebase cache is populated by the discovery workflow.
+      const params: Record<string, string> = { workspace_id: workspaceId || 'all' }
       const { data } = await apiClient.get('/mlflow/experiments', { params })
       return data as any[]
     },
@@ -230,21 +232,21 @@ export function useMlflowRuns(experimentIds?: string, workspaceId?: string | nul
   return useQuery({
     queryKey: ['mlflow', 'runs', experimentIds, workspaceId],
     queryFn: async () => {
-      const params: Record<string, string> = {}
+      const params: Record<string, string> = { workspace_id: workspaceId || 'all' }
       if (experimentIds) params.experiment_ids = experimentIds
-      if (workspaceId) params.workspace_id = workspaceId
       const { data } = await apiClient.get('/mlflow/runs', { params })
       return data as any[]
     },
   })
 }
 
-export function useMlflowTraces(workspaceId?: string | null) {
+export function useMlflowTraces(workspaceId?: string | null, windowDays?: number | null) {
   return useQuery({
-    queryKey: ['mlflow', 'traces', workspaceId],
+    queryKey: ['mlflow', 'traces', workspaceId, windowDays],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (workspaceId) params.workspace_id = workspaceId
+      if (windowDays) params.window_days = String(windowDays)
       const { data } = await apiClient.get('/mlflow/traces', { params })
       return data as any[]
     },
@@ -264,12 +266,49 @@ export function useMlflowTraceDetail(requestId: string | null, workspaceId?: str
   })
 }
 
+// ── Gateway inference logs (Tier 2a) ──────────────────────────────
+
+export function useGatewayLogs(windowDays?: number | null, sourceTable?: string | null) {
+  return useQuery({
+    queryKey: ['gateway-logs', 'list', windowDays, sourceTable],
+    queryFn: async () => {
+      const params: Record<string, string> = {}
+      if (windowDays) params.window_days = String(windowDays)
+      if (sourceTable) params.source_table = sourceTable
+      const { data } = await apiClient.get('/gateway-logs', { params })
+      return data as any[]
+    },
+  })
+}
+
+export function useGatewayLogSources() {
+  return useQuery({
+    queryKey: ['gateway-logs', 'sources'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway-logs/sources')
+      return data as any[]
+    },
+  })
+}
+
+export function useGatewayLogDetail(sourceTable: string | null, requestId: string | null) {
+  return useQuery({
+    queryKey: ['gateway-logs', 'detail', sourceTable, requestId],
+    queryFn: async () => {
+      const { data } = await apiClient.get(
+        `/gateway-logs/${encodeURIComponent(sourceTable!)}/${encodeURIComponent(requestId!)}`
+      )
+      return data
+    },
+    enabled: !!sourceTable && !!requestId,
+  })
+}
+
 export function useMlflowModels(workspaceId?: string | null) {
   return useQuery({
     queryKey: ['mlflow', 'models', workspaceId],
     queryFn: async () => {
-      const params: Record<string, string> = {}
-      if (workspaceId) params.workspace_id = workspaceId
+      const params: Record<string, string> = { workspace_id: workspaceId || 'all' }
       const { data } = await apiClient.get('/mlflow/models', { params })
       return data as any[]
     },
@@ -295,6 +334,20 @@ export function useMlflowObservabilityWorkspaces() {
       return data as Array<{ workspace_id: string; trace_count: number; last_synced: string }>
     },
     staleTime: 60_000,
+  })
+}
+
+/** Map of workspace_id → host URL (e.g., 'https://my-ws.cloud.databricks.com').
+ *  Used to build "Open in MLflow" links that route to each record's owning
+ *  workspace rather than the deploy workspace. */
+export function useWorkspaceHosts() {
+  return useQuery({
+    queryKey: ['mlflow', 'workspace-hosts'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/mlflow/workspace-hosts')
+      return (data || {}) as Record<string, string>
+    },
+    staleTime: 5 * 60_000,
   })
 }
 

--- a/control-plane-app/frontend/src/lib/utils.ts
+++ b/control-plane-app/frontend/src/lib/utils.ts
@@ -25,8 +25,16 @@ export function formatCurrency(amount: number): string {
 }
 
 export function formatDuration(ms: number): string {
-  if (ms < 1000) {
-    return `${ms}ms`
+  if (!ms || isNaN(ms)) return '—'
+  if (ms < 1) return `${ms.toFixed(2)}ms`
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(2)}s`
+  if (ms < 3_600_000) {
+    const m = Math.floor(ms / 60_000)
+    const s = Math.round((ms % 60_000) / 1000)
+    return `${m}m ${s}s`
   }
-  return `${(ms / 1000).toFixed(2)}s`
+  const h = Math.floor(ms / 3_600_000)
+  const m = Math.round((ms % 3_600_000) / 60_000)
+  return `${h}h ${m}m`
 }

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -351,7 +351,7 @@ function TracesPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceU
             <>
             <div className="divide-y divide-gray-100 dark:divide-gray-700">
               {/* Header */}
-              <div className={`grid gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}>
+              <div className={`grid gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_8rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}>
                 <div className={workspaceId ? '' : 'col-span-1'} />
                 <div className={workspaceId ? '' : 'col-span-3'}>Request ID</div>
                 <div className={workspaceId ? '' : 'col-span-2'}>Trace Name</div>
@@ -395,7 +395,7 @@ function TracesPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceU
                 return (
                   <div
                     key={`${traceWsId || 'local'}-${reqId}`}
-                    className={`grid gap-3 py-2.5 items-center hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer rounded transition-colors ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}
+                    className={`grid gap-3 py-2.5 items-center hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer rounded transition-colors ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_8rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}
                     onClick={() => { setSelectedTraceId(reqId); setSelectedTraceWs(traceWsId) }}
                   >
                     <div className={`${workspaceId ? '' : 'col-span-1'} flex justify-center`}>
@@ -406,11 +406,11 @@ function TracesPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceU
                     </div>
                     <div className={`${workspaceId ? '' : 'col-span-2'} text-xs text-gray-500 truncate`}>{traceName}</div>
                     {workspaceId && (
-                      <div className="text-xs flex items-center gap-1">
-                        <Badge variant="default" className="text-[10px] font-mono">
+                      <div className="text-xs flex flex-col items-start gap-0.5 min-w-0">
+                        <Badge variant="default" className="text-[10px] font-mono truncate max-w-full">
                           {traceWsId ? traceWsId.substring(0, 8) + '…' : 'local'}
                         </Badge>
-                        {dataSourceBadge(t.data_source)}
+                        <div className="truncate max-w-full">{dataSourceBadge(t.data_source)}</div>
                       </div>
                     )}
                     <div className={`${workspaceId ? '' : 'col-span-2'} text-xs text-gray-500`}>{tsToDate(ts)}</div>
@@ -418,7 +418,9 @@ function TracesPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceU
                       {msToReadable(dur)}
                     </div>
                     <div className={`${workspaceId ? 'text-right' : 'col-span-1 text-right'} text-xs text-gray-600 dark:text-gray-300`}
-                         title={tu.input_tokens != null ? `in ${tu.input_tokens} / out ${tu.output_tokens || 0}` : ''}>
+                         title={tu.input_tokens != null
+                           ? `in ${tu.input_tokens} / out ${tu.output_tokens || 0}`
+                           : 'No token usage recorded — this trace likely isn’t a direct LLM call'}>
                       {totalTokens ? totalTokens.toLocaleString() : '—'}
                     </div>
                     <div className={`${workspaceId ? 'text-center' : 'col-span-1'} flex justify-center`}>{statusIcon(status)}</div>
@@ -472,9 +474,9 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-function MetricTile({ icon: Icon, label, value, sub }: { icon: any; label: string; value: string | number; sub?: string }) {
+function MetricTile({ icon: Icon, label, value, sub, title }: { icon: any; label: string; value: string | number; sub?: string; title?: string }) {
   return (
-    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 flex items-start gap-3">
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 flex items-start gap-3" title={title}>
       <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
         <Icon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
       </div>
@@ -609,16 +611,19 @@ function TraceDetailView({
           label="Input Tokens"
           value={tokenUsage.input_tokens?.toLocaleString() ?? '—'}
           sub={tokenUsage.cache_read_input_tokens ? `${tokenUsage.cache_read_input_tokens} cached` : undefined}
+          title={tokenUsage.input_tokens == null ? 'No token usage recorded — this trace likely isn’t a direct LLM call' : undefined}
         />
         <MetricTile
           icon={Hash}
           label="Output Tokens"
           value={tokenUsage.output_tokens?.toLocaleString() ?? '—'}
+          title={tokenUsage.output_tokens == null ? 'No token usage recorded — this trace likely isn’t a direct LLM call' : undefined}
         />
         <MetricTile
           icon={Zap}
           label="Total Tokens"
           value={tokenUsage.total_tokens?.toLocaleString() ?? '—'}
+          title={tokenUsage.total_tokens == null ? 'No token usage recorded — this trace likely isn’t a direct LLM call' : undefined}
         />
         <MetricTile
           icon={Layers}

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -9,6 +9,10 @@ import {
   useMlflowModels,
   useMlflowModelVersions,
   useMlflowObservabilityWorkspaces,
+  useWorkspaceHosts,
+  useGatewayLogs,
+  useGatewayLogSources,
+  useGatewayLogDetail,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { RefreshButton } from '@/components/RefreshButton'
@@ -67,9 +71,20 @@ function safePrettyJson(raw: string | undefined | null, maxLen = 1500): string {
 }
 
 function msToReadable(ms: number | undefined | null) {
-  if (ms == null) return '—'
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(2)}s`
+  if (ms == null || isNaN(ms as any)) return '—'
+  const n = Number(ms)
+  if (!n) return '—'
+  if (n < 1) return `${n.toFixed(2)}ms`
+  if (n < 1000) return `${Math.round(n)}ms`
+  if (n < 60_000) return `${(n / 1000).toFixed(2)}s`
+  if (n < 3_600_000) {
+    const m = Math.floor(n / 60_000)
+    const s = Math.round((n % 60_000) / 1000)
+    return `${m}m ${s}s`
+  }
+  const h = Math.floor(n / 3_600_000)
+  const m = Math.round((n % 3_600_000) / 60_000)
+  return `${h}h ${m}m`
 }
 
 function tsToDate(ms: number | string | undefined) {
@@ -77,6 +92,18 @@ function tsToDate(ms: number | string | undefined) {
   const n = typeof ms === 'string' ? Number(ms) : ms
   if (!n || isNaN(n)) return '—'
   return format(new Date(n), 'MMM dd, HH:mm:ss')
+}
+
+/** Resolve the right workspace host for a record. Falls back to the deploy
+ *  workspace URL when the registry doesn't have an entry (local rows or
+ *  workspaces not yet discovered). */
+function resolveWorkspaceUrl(
+  recordWorkspaceId: string | null | undefined,
+  hosts: Record<string, string> | undefined,
+  fallback: string,
+): string {
+  if (recordWorkspaceId && hosts && hosts[recordWorkspaceId]) return hosts[recordWorkspaceId]
+  return fallback
 }
 
 function statusIcon(s: string) {
@@ -121,6 +148,7 @@ function dataSourceBadge(source: string | undefined) {
 /* ── tab definitions ─────────────────────────────────────────── */
 const tabs = [
   { id: 'traces', label: 'Traces', icon: Search },
+  { id: 'gateway', label: 'Gateway Requests', icon: Activity },
   { id: 'experiments', label: 'Experiments', icon: FlaskConical },
   { id: 'runs', label: 'Evaluation Runs', icon: Activity },
   { id: 'models', label: 'Model Registry', icon: Database },
@@ -141,6 +169,7 @@ export default function ObservabilityPage() {
   const mlflowUpdatedAt = queryClient.getQueryState(['mlflow', 'traces'])?.dataUpdatedAt
   const mlflowLastSynced = mlflowUpdatedAt ? new Date(mlflowUpdatedAt).toISOString() : null
   const { data: obsWorkspaces } = useMlflowObservabilityWorkspaces()
+  const { data: workspaceHosts } = useWorkspaceHosts()
 
   // The workspace_id value to pass to hooks: undefined means current workspace (no param sent)
   const wsParam = selectedWs || undefined
@@ -217,42 +246,51 @@ export default function ObservabilityPage() {
       </div>
 
       {/* Tab content */}
-      {activeTab === 'traces' && <TracesPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} />}
-      {activeTab === 'experiments' && <ExperimentsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} />}
-      {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} />}
-      {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} />}
+      {activeTab === 'traces' && <TracesPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
+      {activeTab === 'gateway' && <GatewayRequestsPanel />}
+      {activeTab === 'experiments' && <ExperimentsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
+      {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
+      {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
     </div>
   )
 }
 
 /* ── Traces Panel ────────────────────────────────────────────── */
 
-function TracesPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; workspaceId?: string }) {
-  const { data: traces, isLoading } = useMlflowTraces(workspaceId)
+const TRACE_WINDOW_OPTIONS = [7, 14, 30, 90, 180, 365] as const
+type TraceWindow = (typeof TRACE_WINDOW_OPTIONS)[number]
+
+function TracesPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceUrl: string; workspaceId?: string; workspaceHosts?: Record<string,string> }) {
+  const [windowDays, setWindowDays] = useState<TraceWindow>(30)
+  const { data: traces, isLoading } = useMlflowTraces(workspaceId, windowDays)
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null)
   const [selectedTraceWs, setSelectedTraceWs] = useState<string | undefined>(undefined)
   const [tracePage, setTracePage] = useState(0)
   const [tracePageSize, setTracePageSize] = useState(10)
 
   const traceList = traces || []
-  const okCount = traceList.filter((t: any) => (t.status || t.info?.status) === 'OK').length
-  const errCount = traceList.filter((t: any) => {
-    const s = t.status || t.info?.status
-    return s === 'ERROR'
-  }).length
+  // The Lakebase-cached row uses {state, execution_duration, request_time}.
+  // Live MLflow REST hits (cross-workspace) use info.{status, execution_time_ms, timestamp_ms}.
+  // Read both shapes so KPIs work regardless of which path served the data.
+  const traceState = (t: any) => t.state || t.status || t.info?.status || ''
+  const traceDur = (t: any) => Number(t.execution_duration ?? t.execution_time_ms ?? t.info?.execution_time_ms ?? 0)
+  const traceTs = (t: any) => t.request_time ?? t.timestamp_ms ?? t.info?.timestamp_ms
+  const okCount = traceList.filter((t: any) => traceState(t) === 'OK').length
+  const errCount = traceList.filter((t: any) => traceState(t) === 'ERROR').length
   const avgDur =
     traceList.length > 0
-      ? traceList.reduce((sum: number, t: any) => {
-          return sum + (t.execution_time_ms || t.info?.execution_time_ms || 0)
-        }, 0) / traceList.length
+      ? traceList.reduce((sum: number, t: any) => sum + (traceDur(t) || 0), 0) / traceList.length
       : 0
 
-  // If a trace is selected, show the detail view
+  // If a trace is selected, show the detail view. The "View in MLflow" link
+  // inside the detail must point at the trace's owning workspace, not the
+  // deploy workspace, so resolve through the registry first.
   if (selectedTraceId) {
+    const traceWorkspaceUrl = resolveWorkspaceUrl(selectedTraceWs, workspaceHosts, workspaceUrl)
     return (
       <TraceDetailView
         requestId={selectedTraceId}
-        workspaceUrl={workspaceUrl}
+        workspaceUrl={traceWorkspaceUrl}
         workspaceId={selectedTraceWs}
         onBack={() => { setSelectedTraceId(null); setSelectedTraceWs(undefined) }}
       />
@@ -271,8 +309,24 @@ function TracesPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; work
 
       {/* Trace table */}
       <Card>
-        <CardHeader className="pb-3">
+        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3">
           <CardTitle className="text-base">Agent Traces</CardTitle>
+          <div className="inline-flex items-center gap-1 text-xs">
+            <span className="text-gray-500 dark:text-gray-400 mr-1">Window:</span>
+            {TRACE_WINDOW_OPTIONS.map((d) => (
+              <button
+                key={d}
+                onClick={() => { setWindowDays(d); setTracePage(0) }}
+                className={`px-2 py-1 rounded font-medium transition-colors ${
+                  windowDays === d
+                    ? 'bg-db-red text-white'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -287,15 +341,16 @@ function TracesPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; work
             <>
             <div className="divide-y divide-gray-100 dark:divide-gray-700">
               {/* Header */}
-              <div className={`grid gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_5rem]' : 'grid-cols-12'}`}>
+              <div className={`grid gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}>
                 <div className={workspaceId ? '' : 'col-span-1'} />
                 <div className={workspaceId ? '' : 'col-span-3'}>Request ID</div>
                 <div className={workspaceId ? '' : 'col-span-2'}>Trace Name</div>
                 {workspaceId && <div>Workspace</div>}
                 <div className={workspaceId ? '' : 'col-span-2'}>Timestamp</div>
                 <div className={workspaceId ? 'text-right' : 'col-span-1 text-right'}>Duration</div>
+                <div className={workspaceId ? 'text-right' : 'col-span-1 text-right'}>Tokens</div>
                 <div className={workspaceId ? 'text-center' : 'col-span-1 text-center'}>Status</div>
-                <div className={workspaceId ? 'text-right' : 'col-span-2 text-right'}>Actions</div>
+                <div className={workspaceId ? 'text-right' : 'col-span-1 text-right'}>Actions</div>
               </div>
               {(() => {
                 const totalPages = Math.max(1, Math.ceil(traceList.length / tracePageSize))
@@ -304,17 +359,33 @@ function TracesPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; work
                 return paged
               })().map((t: any) => {
                 const reqId = t.request_id || t.info?.request_id || '—'
-                const status = t.status || t.info?.status || '—'
-                const dur = t.execution_time_ms || t.info?.execution_time_ms
-                const ts = t.timestamp_ms || t.info?.timestamp_ms
-                const traceName = t.tags?.['mlflow.traceName'] || t.info?.tags?.['mlflow.traceName'] || '—'
+                const status = traceState(t) || '—'
+                const dur = traceDur(t)
+                const ts = traceTs(t)
+                // tags arrives as a JSON string from JSONB or an array of {key,value} from REST.
+                const tagsParsed = (() => {
+                  const raw = t.tags ?? t.info?.tags
+                  if (!raw) return {}
+                  if (typeof raw === 'string') { try { return JSON.parse(raw) } catch { return {} } }
+                  if (Array.isArray(raw)) return Object.fromEntries(raw.map((x: any) => [x.key, x.value]))
+                  return raw
+                })()
+                const traceName = t.trace_name || tagsParsed['mlflow.traceName'] || '—'
                 const experimentId = t.experiment_id || t.info?.experiment_id
                 const traceWsId = t.workspace_id
+                // token_usage arrives as parsed JSON from JSONB or as a JSON string.
+                const tu = (() => {
+                  const raw = t.token_usage
+                  if (!raw) return {}
+                  if (typeof raw === 'string') { try { return JSON.parse(raw) } catch { return {} } }
+                  return raw
+                })()
+                const totalTokens = tu.total_tokens ?? ((tu.input_tokens || 0) + (tu.output_tokens || 0))
 
                 return (
                   <div
                     key={`${traceWsId || 'local'}-${reqId}`}
-                    className={`grid gap-3 py-2.5 items-center hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer rounded transition-colors ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_5rem]' : 'grid-cols-12'}`}
+                    className={`grid gap-3 py-2.5 items-center hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer rounded transition-colors ${workspaceId ? 'grid-cols-[2rem_1fr_1fr_5rem_5rem_4rem_4rem_4rem_4rem]' : 'grid-cols-12'}`}
                     onClick={() => { setSelectedTraceId(reqId); setSelectedTraceWs(traceWsId) }}
                   >
                     <div className={`${workspaceId ? '' : 'col-span-1'} flex justify-center`}>
@@ -336,19 +407,27 @@ function TracesPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; work
                     <div className={`${workspaceId ? 'text-right' : 'col-span-1 text-right'} text-xs font-medium`}>
                       {msToReadable(dur)}
                     </div>
+                    <div className={`${workspaceId ? 'text-right' : 'col-span-1 text-right'} text-xs text-gray-600 dark:text-gray-300`}
+                         title={tu.input_tokens != null ? `in ${tu.input_tokens} / out ${tu.output_tokens || 0}` : ''}>
+                      {totalTokens ? totalTokens.toLocaleString() : '—'}
+                    </div>
                     <div className={`${workspaceId ? 'text-center' : 'col-span-1'} flex justify-center`}>{statusIcon(status)}</div>
-                    <div className={`${workspaceId ? 'text-right' : 'col-span-2 text-right'}`}>
-                      {workspaceUrl && experimentId && !traceWsId && (
-                        <a
-                          href={`${workspaceUrl}/ml/experiments/${experimentId}?searchFilter=request_id%3D%27${reqId}%27&compareRunsMode=TRACES`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-600 hover:text-blue-800 text-xs inline-flex items-center gap-1"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          MLflow <ExternalLink className="w-3 h-3" />
-                        </a>
-                      )}
+                    <div className={`${workspaceId ? 'text-right' : 'col-span-1 text-right'}`}>
+                      {experimentId && (() => {
+                        const base = resolveWorkspaceUrl(traceWsId, workspaceHosts, workspaceUrl)
+                        if (!base) return null
+                        return (
+                          <a
+                            href={`${base}/ml/experiments/${experimentId}?searchFilter=request_id%3D%27${reqId}%27&compareRunsMode=TRACES`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-600 hover:text-blue-800 text-xs inline-flex items-center gap-1"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            MLflow <ExternalLink className="w-3 h-3" />
+                          </a>
+                        )
+                      })()}
                     </div>
                   </div>
                 )
@@ -438,7 +517,10 @@ function TraceDetailView({
 
   const tokenUsage = detail.token_usage || {}
   const sizeStats = detail.size_stats || {}
-  const durationStr = detail.execution_duration || '—'
+  const durationMs = typeof detail.execution_duration === 'string'
+    ? Number(detail.execution_duration)
+    : detail.execution_duration
+  const durationStr = msToReadable(typeof durationMs === 'number' && !isNaN(durationMs) ? durationMs : null)
 
   return (
     <div className="space-y-4">
@@ -474,7 +556,7 @@ function TraceDetailView({
               </div>
             </div>
             <div className="text-right text-xs text-gray-500">
-              {detail.request_time ? format(new Date(detail.request_time), 'MMM dd, yyyy HH:mm:ss') : '—'}
+              {tsToDate(detail.request_time)}
             </div>
           </div>
         </CardContent>
@@ -640,6 +722,20 @@ function TraceDetailView({
         </Card>
       </div>
 
+      {/* Span waterfall — hierarchical timeline of all spans in this trace */}
+      {Array.isArray((detail as any).spans) && (detail as any).spans.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base flex items-center gap-2">
+              <Layers className="w-4 h-4" /> Span Waterfall
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SpanWaterfall spans={(detail as any).spans} />
+          </CardContent>
+        </Card>
+      )}
+
       {/* Raw request JSON (collapsible) */}
       <Card>
         <CardHeader className="pb-2">
@@ -712,9 +808,316 @@ function SpanSizeBar({ stats }: { stats: any }) {
   )
 }
 
+/* ── Span waterfall view ─────────────────────────────────────── */
+
+type Span = {
+  span_id?: string
+  parent_id?: string | null
+  parent_span_id?: string | null
+  name?: string
+  span_type?: string
+  kind?: string
+  status?: any
+  status_code?: any
+  start_time_unix_nano?: number | string
+  end_time_unix_nano?: number | string
+  start_time?: number | string
+  end_time?: number | string
+  inputs?: any
+  outputs?: any
+  attributes?: any
+}
+
+/** MLflow trace_logs spans nest these as JSON-encoded string values, e.g.
+ *  attributes["mlflow.spanType"] === '"AGENT"'. Unwrap once. */
+function unwrapAttr(v: any): any {
+  if (typeof v !== 'string') return v
+  try { return JSON.parse(v) } catch { return v }
+}
+
+function spanAttributes(s: Span): Record<string, any> {
+  const a = s.attributes
+  if (!a) return {}
+  if (typeof a === 'string') {
+    try { return JSON.parse(a) } catch { return {} }
+  }
+  return a
+}
+
+function spanIdOf(s: Span): string {
+  return String(s.span_id ?? Math.random())
+}
+
+function spanParentOf(s: Span): string | null {
+  // Prefer top-level fields; trace_logs spans may carry parent in attributes
+  // under various MLflow keys.
+  const a = spanAttributes(s)
+  const p =
+    s.parent_id ??
+    s.parent_span_id ??
+    unwrapAttr(a['mlflow.parentSpanId']) ??
+    unwrapAttr(a['parent_span_id']) ??
+    null
+  return p ? String(p) : null
+}
+
+/** Returns ms since epoch. Handles unix_nano, unix_ms, and ISO strings. */
+function spanStartMs(s: Span): number {
+  if (s.start_time_unix_nano != null) {
+    const n = Number(s.start_time_unix_nano)
+    return Number.isFinite(n) ? n / 1_000_000 : 0
+  }
+  const v = s.start_time
+  if (v == null) return 0
+  if (typeof v === 'number') return v >= 1e15 ? v / 1_000_000 : v // heuristic ns → ms
+  // ISO string
+  const t = Date.parse(v)
+  return Number.isFinite(t) ? t : Number(v) || 0
+}
+
+function spanEndMs(s: Span): number {
+  if (s.end_time_unix_nano != null) {
+    const n = Number(s.end_time_unix_nano)
+    return Number.isFinite(n) ? n / 1_000_000 : 0
+  }
+  const v = s.end_time
+  if (v == null) return 0
+  if (typeof v === 'number') return v >= 1e15 ? v / 1_000_000 : v
+  const t = Date.parse(v)
+  return Number.isFinite(t) ? t : Number(v) || 0
+}
+
+function spanKind(s: Span): string {
+  const a = spanAttributes(s)
+  const raw = (
+    s.span_type ||
+    s.kind ||
+    unwrapAttr(a['mlflow.spanType']) ||
+    unwrapAttr(a['span_type']) ||
+    ''
+  ).toString().toUpperCase()
+  if (raw.includes('LLM') || raw === 'CHAT_MODEL' || raw === 'CHAT' || raw === 'COMPLETION') return 'LLM'
+  if (raw.includes('TOOL')) return 'TOOL'
+  if (raw.includes('AGENT')) return 'AGENT'
+  if (raw.includes('CHAIN')) return 'CHAIN'
+  if (raw.includes('RETRIEVER') || raw.includes('RAG')) return 'RETRIEVER'
+  if (raw.includes('PARSER')) return 'PARSER'
+  if (raw.includes('EMBEDDING')) return 'EMBEDDING'
+  return raw || 'SPAN'
+}
+
+const KIND_COLORS: Record<string, string> = {
+  LLM: '#7c3aed',       // violet
+  TOOL: '#0ea5e9',      // sky
+  AGENT: '#dc2626',     // db-red
+  CHAIN: '#16a34a',     // green
+  RETRIEVER: '#f59e0b', // amber
+  PARSER: '#0891b2',    // cyan
+  EMBEDDING: '#db2777', // pink
+  SPAN: '#6b7280',      // slate
+}
+
+function spanStatusOk(s: Span): 'OK' | 'ERROR' | 'UNKNOWN' {
+  // Top-level status_code (trace_logs format) or nested status (OTel format)
+  const codeRaw = s.status_code ?? (s.status && (s.status.status_code || s.status.code))
+  if (codeRaw != null) {
+    const u = String(codeRaw).toUpperCase()
+    if (u.includes('OK') || u === '1') return 'OK'
+    if (u.includes('ERROR') || u === '2') return 'ERROR'
+  }
+  if (typeof s.status === 'string') {
+    const u = s.status.toUpperCase()
+    return u.includes('OK') ? 'OK' : u.includes('ERROR') ? 'ERROR' : 'UNKNOWN'
+  }
+  return 'UNKNOWN'
+}
+
+/** When spans don't carry parent IDs (e.g. trace_logs format), infer
+ *  hierarchy via temporal containment: a span A is the parent of B if A's
+ *  interval [start, end] contains B's interval. The closest containing span
+ *  (smallest enclosing) is the immediate parent. Stable for properly
+ *  instrumented traces; falls back to flat ordering for ambiguous cases. */
+function inferParentByContainment(
+  spans: Span[],
+  starts: number[],
+  ends: number[],
+): (string | null)[] {
+  const n = spans.length
+  const parents: (string | null)[] = new Array(n).fill(null)
+  for (let i = 0; i < n; i++) {
+    let best = -1
+    let bestSpan = Infinity
+    for (let j = 0; j < n; j++) {
+      if (i === j) continue
+      // j must strictly contain i (allow equal endpoints, but j ≠ i)
+      if (starts[j] <= starts[i] && ends[j] >= ends[i]) {
+        const span = ends[j] - starts[j]
+        // Prefer the smallest span that still contains i
+        if (span < bestSpan) {
+          best = j; bestSpan = span
+        }
+      }
+    }
+    if (best >= 0) parents[i] = spanIdOf(spans[best])
+  }
+  return parents
+}
+
+function SpanWaterfall({ spans }: { spans: Span[] }) {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const flat = spans || []
+  if (!flat.length) return <div className="text-sm text-gray-400 text-center py-6">No spans available.</div>
+
+  // Cache normalized timestamps once (ms since epoch).
+  const startsMs = flat.map(spanStartMs)
+  const endsMs = flat.map(spanEndMs)
+
+  // Build parent map. Use explicit parent_id when present; otherwise infer
+  // by temporal containment so the trace_logs-format spans (which don't
+  // carry parent IDs) still render as a hierarchy.
+  const byId = new Map<string, Span>()
+  for (const s of flat) byId.set(spanIdOf(s), s)
+  const explicitParents = flat.map(spanParentOf)
+  const haveAnyExplicit = explicitParents.some((p) => p && byId.has(p))
+  const parents: (string | null)[] = haveAnyExplicit
+    ? explicitParents.map((p) => (p && byId.has(p) ? p : null))
+    : inferParentByContainment(flat, startsMs, endsMs)
+
+  const childrenOf = new Map<string, Span[]>()
+  for (let i = 0; i < flat.length; i++) {
+    const key = parents[i] ?? '__root__'
+    const list = childrenOf.get(key) || []
+    list.push(flat[i])
+    childrenOf.set(key, list)
+  }
+  // Sort each level by start time (using cached starts via id lookup)
+  const startById = new Map<string, number>()
+  for (let i = 0; i < flat.length; i++) startById.set(spanIdOf(flat[i]), startsMs[i])
+  for (const [k, list] of childrenOf) {
+    list.sort((a, b) => (startById.get(spanIdOf(a)) || 0) - (startById.get(spanIdOf(b)) || 0))
+    childrenOf.set(k, list)
+  }
+
+  const minStart = Math.min(...startsMs.filter((n) => n > 0))
+  const maxEnd = Math.max(...endsMs.filter((n) => n > 0))
+  const totalMs = Math.max(1, maxEnd - minStart)
+
+  // Flatten into render order with a depth counter.
+  const ordered: Array<{ s: Span; depth: number }> = []
+  function walk(parentKey: string, depth: number) {
+    for (const s of (childrenOf.get(parentKey) || [])) {
+      ordered.push({ s, depth })
+      walk(spanIdOf(s), depth + 1)
+    }
+  }
+  walk('__root__', 0)
+
+  const selected = selectedId ? byId.get(selectedId) : null
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs text-gray-500 dark:text-gray-400">
+        {ordered.length} spans · click a row for details
+      </div>
+      <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+        <div className="grid grid-cols-[minmax(0,1fr)_4rem_minmax(0,1.5fr)] gap-2 px-3 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
+          <div>Span</div>
+          <div className="text-right">Duration</div>
+          <div>Timeline</div>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto">
+          {ordered.map(({ s, depth }) => {
+            const sid = spanIdOf(s)
+            const startMs = startById.get(sid) || 0
+            const endMs = spanEndMs(s)
+            const dur = endMs > startMs ? Math.round(endMs - startMs) : 0
+            const offsetPct = totalMs > 0 ? Math.max(0, ((startMs - minStart) / totalMs) * 100) : 0
+            const widthPct = totalMs > 0 ? Math.max(0.5, ((endMs - startMs) / totalMs) * 100) : 0
+            const k = spanKind(s)
+            const color = KIND_COLORS[k] || KIND_COLORS.SPAN
+            const status = spanStatusOk(s)
+            const isSel = selectedId === sid
+            return (
+              <button
+                key={sid}
+                onClick={() => setSelectedId(isSel ? null : sid)}
+                className={`grid grid-cols-[minmax(0,1fr)_4rem_minmax(0,1.5fr)] gap-2 px-3 py-1.5 w-full text-left text-xs items-center border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/40 ${isSel ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`}
+              >
+                <div className="flex items-center gap-2 min-w-0" style={{ paddingLeft: depth * 16 }}>
+                  <span
+                    className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: color }}
+                  />
+                  <span className="text-[10px] font-mono text-gray-500 dark:text-gray-400 flex-shrink-0">{k}</span>
+                  <span className="truncate font-medium text-gray-700 dark:text-gray-200" title={s.name || ''}>
+                    {s.name || sid.slice(0, 8)}
+                  </span>
+                  {status === 'ERROR' && <XCircle className="w-3 h-3 text-red-500 flex-shrink-0" />}
+                </div>
+                <div className="text-right font-medium text-gray-600 dark:text-gray-300">
+                  {dur > 0 ? msToReadable(dur) : '—'}
+                </div>
+                <div className="relative h-3 bg-gray-100 dark:bg-gray-700 rounded">
+                  <div
+                    className="absolute inset-y-0 rounded"
+                    style={{ left: `${offsetPct}%`, width: `${widthPct}%`, backgroundColor: color, opacity: 0.85 }}
+                  />
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {selected && (() => {
+        const attrs = spanAttributes(selected)
+        const rawIn = selected.inputs ?? attrs['mlflow.spanInputs'] ?? attrs['inputs']
+        const rawOut = selected.outputs ?? attrs['mlflow.spanOutputs'] ?? attrs['outputs']
+        const inJson = typeof rawIn === 'string' ? rawIn : (rawIn != null ? JSON.stringify(rawIn) : '')
+        const outJson = typeof rawOut === 'string' ? rawOut : (rawOut != null ? JSON.stringify(rawOut) : '')
+        const sStart = startById.get(spanIdOf(selected)) || 0
+        const sEnd = spanEndMs(selected)
+        const sDur = sEnd > sStart ? Math.round(sEnd - sStart) : 0
+        return (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm flex items-center gap-2 flex-wrap">
+                <span className="font-mono">{selected.name || spanIdOf(selected)}</span>
+                <Badge variant="default" className="text-[10px]">{spanKind(selected)}</Badge>
+                {spanStatusOk(selected) === 'ERROR' && <Badge variant="error" className="text-[10px]">error</Badge>}
+                <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal">
+                  {sDur > 0 ? msToReadable(sDur) : '—'}
+                </span>
+                <span className="text-[11px] text-gray-400 dark:text-gray-500 font-mono font-normal">{spanIdOf(selected)}</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 text-xs">
+                <div>
+                  <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Inputs</div>
+                  <pre className="bg-gray-50 dark:bg-gray-800 rounded p-2 overflow-auto max-h-72 whitespace-pre-wrap">
+                    {safePrettyJson(inJson, 4000) || '—'}
+                  </pre>
+                </div>
+                <div>
+                  <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Outputs</div>
+                  <pre className="bg-gray-50 dark:bg-gray-800 rounded p-2 overflow-auto max-h-72 whitespace-pre-wrap">
+                    {safePrettyJson(outJson, 4000) || '—'}
+                  </pre>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })()}
+    </div>
+  )
+}
+
 /* ── Experiments Panel ───────────────────────────────────────── */
 
-function ExperimentsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; workspaceId?: string }) {
+function ExperimentsPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceUrl: string; workspaceId?: string; workspaceHosts?: Record<string,string> }) {
   const { data: experiments, isLoading } = useMlflowExperiments(workspaceId)
   const [selectedExpId, setSelectedExpId] = useState<string | null>(null)
   const [expPage, setExpPage] = useState(0)
@@ -723,11 +1126,14 @@ function ExperimentsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string;
 
   if (selectedExpId) {
     const exp = expList.find((e: any) => e.experiment_id === selectedExpId)
+    // Route the "Open in MLflow" link to the experiment's owning workspace.
+    const expWorkspaceUrl = resolveWorkspaceUrl(exp?.workspace_id, workspaceHosts, workspaceUrl)
     return (
       <ExperimentDetailView
         experiment={exp}
         experimentId={selectedExpId}
-        workspaceUrl={workspaceUrl}
+        workspaceUrl={expWorkspaceUrl}
+        workspaceHosts={workspaceHosts}
         onBack={() => setSelectedExpId(null)}
       />
     )
@@ -836,11 +1242,13 @@ function ExperimentDetailView({
   experiment,
   experimentId,
   workspaceUrl,
+  workspaceHosts,
   onBack,
 }: {
   experiment: any
   experimentId: string
   workspaceUrl: string
+  workspaceHosts?: Record<string,string>
   onBack: () => void
 }) {
   const { data: runs, isLoading: runsLoading } = useMlflowRuns(experimentId)
@@ -858,7 +1266,9 @@ function ExperimentDetailView({
   const finishedRuns = runList.filter((r: any) => r.info?.status === 'FINISHED').length
   const failedRuns = runList.filter((r: any) => r.info?.status === 'FAILED').length
 
-  // If a run is selected, show run detail
+  // If a run is selected, show run detail. workspaceUrl was already resolved
+  // to the experiment's workspace in the parent panel, and runs in an
+  // experiment share that workspace, so reuse it here.
   if (selectedRunId) {
     const run = runList.find((r: any) => r.info?.run_id === selectedRunId)
     return (
@@ -1072,7 +1482,7 @@ function normalizeRun(r: any) {
   }
 }
 
-function RunsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; workspaceId?: string }) {
+function RunsPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceUrl: string; workspaceId?: string; workspaceHosts?: Record<string,string> }) {
   const { data: runs, isLoading } = useMlflowRuns(undefined, workspaceId)
   const runList = (runs || []).map(normalizeRun)
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
@@ -1092,10 +1502,12 @@ function RunsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; worksp
 
   if (selectedRunId) {
     const run = (runs || []).find((r: any) => (r.info?.run_id || r.run_id) === selectedRunId)
+    // Resolve link base URL using the run's owning workspace.
+    const runWorkspaceUrl = resolveWorkspaceUrl(run?.workspace_id, workspaceHosts, workspaceUrl)
     return (
       <RunDetailView
         run={run}
-        workspaceUrl={workspaceUrl}
+        workspaceUrl={runWorkspaceUrl}
         onBack={() => setSelectedRunId(null)}
       />
     )
@@ -1427,7 +1839,7 @@ function RunDetailView({
 
 /* ── Models Panel ────────────────────────────────────────────── */
 
-function ModelsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; workspaceId?: string }) {
+function ModelsPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceUrl: string; workspaceId?: string; workspaceHosts?: Record<string,string> }) {
   const { data: models, isLoading } = useMlflowModels(workspaceId)
   const modelList = models || []
   const [selectedModel, setSelectedModel] = useState<string | null>(null)
@@ -1436,11 +1848,15 @@ function ModelsPanel({ workspaceUrl, workspaceId }: { workspaceUrl: string; work
 
   if (selectedModel) {
     const model = modelList.find((m: any) => m.name === selectedModel)
+    // UC registered models are account-wide objects (catalog.schema.name);
+    // any workspace with grants can browse them. Use the deploy workspace
+    // URL by default; if the model row carries a workspace_id, prefer that.
+    const modelWorkspaceUrl = resolveWorkspaceUrl(model?.workspace_id, workspaceHosts, workspaceUrl)
     return (
       <ModelDetailView
         model={model}
         modelName={selectedModel}
-        workspaceUrl={workspaceUrl}
+        workspaceUrl={modelWorkspaceUrl}
         onBack={() => setSelectedModel(null)}
       />
     )
@@ -1778,6 +2194,242 @@ function ModelVersionCard({
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+/* ── Gateway Requests Panel (Tier 2a) ─────────────────────────── */
+
+const GATEWAY_WINDOW_OPTIONS = [1, 7, 30, 90, 180, 365] as const
+type GatewayWindow = (typeof GATEWAY_WINDOW_OPTIONS)[number]
+
+function GatewayRequestsPanel() {
+  const [windowDays, setWindowDays] = useState<GatewayWindow>(7)
+  const [sourceFilter, setSourceFilter] = useState<string | null>(null)
+  const [selected, setSelected] = useState<{ source_table: string; request_id: string } | null>(null)
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+
+  const { data: rows, isLoading } = useGatewayLogs(windowDays, sourceFilter)
+  const { data: sources } = useGatewayLogSources()
+
+  const list = rows || []
+  const okCount = list.filter((r: any) => r.status_code != null && r.status_code < 400).length
+  const errCount = list.filter((r: any) => r.status_code != null && r.status_code >= 400).length
+  const avgLatency =
+    list.length > 0
+      ? list.reduce((sum: number, r: any) => sum + (Number(r.execution_ms) || 0), 0) / list.length
+      : 0
+
+  if (selected) {
+    return (
+      <GatewayRequestDetailView
+        sourceTable={selected.source_table}
+        requestId={selected.request_id}
+        onBack={() => setSelected(null)}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+        <KpiCard title="Total Requests" value={list.length} format="number" />
+        <KpiCard title="Successful" value={okCount} format="number" />
+        <KpiCard title="Errors" value={errCount} format="number" />
+        <KpiCard title="Avg Latency" value={avgLatency} format="duration" />
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3 flex-wrap">
+          <CardTitle className="text-base">AI Gateway / Inference Requests</CardTitle>
+          <div className="flex items-center gap-3">
+            <select
+              value={sourceFilter || ''}
+              onChange={(e) => { setSourceFilter(e.target.value || null); setPage(0) }}
+              className="text-xs px-2 py-1 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+            >
+              <option value="">All endpoints ({(sources || []).length})</option>
+              {(sources || []).map((s: any) => (
+                <option key={s.source_table} value={s.source_table}>
+                  {s.source_table.split('.').pop()} ({s.row_count})
+                </option>
+              ))}
+            </select>
+            <div className="inline-flex items-center gap-1 text-xs">
+              <span className="text-gray-500 dark:text-gray-400 mr-1">Window:</span>
+              {GATEWAY_WINDOW_OPTIONS.map((d) => (
+                <button
+                  key={d}
+                  onClick={() => { setWindowDays(d); setPage(0) }}
+                  className={`px-2 py-1 rounded font-medium transition-colors ${
+                    windowDays === d
+                      ? 'bg-db-red text-white'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  {d}d
+                </button>
+              ))}
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12 text-gray-400">
+              <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading inference logs…
+            </div>
+          ) : list.length === 0 ? (
+            <div className="text-sm text-gray-400 text-center py-12">
+              No gateway/inference logs found. Enable AI Gateway request logging on your endpoints, or pick a wider window.
+            </div>
+          ) : (
+            <>
+              <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                <div className="grid grid-cols-12 gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  <div className="col-span-2">Endpoint</div>
+                  <div className="col-span-2">Request ID</div>
+                  <div className="col-span-2">Time</div>
+                  <div className="col-span-2">Model</div>
+                  <div>Status</div>
+                  <div className="text-right">Latency</div>
+                  <div className="text-right">Tokens</div>
+                  <div>Requester</div>
+                </div>
+                {(() => {
+                  const totalPages = Math.max(1, Math.ceil(list.length / pageSize))
+                  const safePage = Math.min(page, totalPages - 1)
+                  const paged = list.slice(safePage * pageSize, (safePage + 1) * pageSize)
+                  return paged.map((r: any) => {
+                    const rid = r.request_id || ''
+                    const endpoint = (r.source_table || '').split('.').pop() || ''
+                    const status = r.status_code
+                    const isErr = status != null && status >= 400
+                    const modelShort = r.model ? (r.model.length > 22 ? r.model.slice(0, 22) + '…' : r.model) : '—'
+                    return (
+                      <div
+                        key={`${r.source_table}::${rid}`}
+                        className="grid grid-cols-12 gap-3 py-3 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/40"
+                        onClick={() => setSelected({ source_table: r.source_table, request_id: rid })}
+                      >
+                        <div className="col-span-2 truncate font-mono text-xs" title={r.source_table}>{endpoint}</div>
+                        <div className="col-span-2 truncate font-mono text-xs">{rid.slice(0, 36)}</div>
+                        <div className="col-span-2 text-xs text-gray-500">
+                          {r.request_time ? format(new Date(r.request_time), 'yyyy-MM-dd HH:mm:ss') : '—'}
+                        </div>
+                        <div className="col-span-2 truncate text-xs text-gray-600 dark:text-gray-300" title={r.model || ''}>{modelShort}</div>
+                        <div>
+                          <Badge variant={isErr ? 'error' : status != null ? 'success' : 'default'} className="text-[10px]">
+                            {status ?? '—'}
+                          </Badge>
+                        </div>
+                        <div className="text-xs text-right">{r.execution_ms != null ? msToReadable(Number(r.execution_ms)) : '—'}</div>
+                        <div className="text-xs text-right text-gray-600 dark:text-gray-300"
+                             title={r.input_tokens != null ? `in ${r.input_tokens} / out ${r.output_tokens || 0}` : ''}>
+                          {r.total_tokens != null ? Number(r.total_tokens).toLocaleString() : '—'}
+                        </div>
+                        <div className="truncate text-xs text-gray-500" title={r.requester || ''}>
+                          {r.requester || '—'}
+                        </div>
+                      </div>
+                    )
+                  })
+                })()}
+              </div>
+              <TablePagination page={page} totalItems={list.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function GatewayRequestDetailView({
+  sourceTable, requestId, onBack,
+}: { sourceTable: string; requestId: string; onBack: () => void }) {
+  const { data: detail, isLoading } = useGatewayLogDetail(sourceTable, requestId)
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-gray-400">
+        <Loader2 className="w-6 h-6 animate-spin mr-3" /> Loading request detail…
+      </div>
+    )
+  }
+  if (!detail) {
+    return (
+      <div className="space-y-4">
+        <button onClick={onBack} className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+          <ArrowLeft className="w-4 h-4" /> Back to gateway requests
+        </button>
+        <Card><CardContent className="py-12 text-center text-gray-400">
+          Request detail not found.
+        </CardContent></Card>
+      </div>
+    )
+  }
+
+  const statusCode = (detail as any).status_code
+  const isErr = statusCode != null && statusCode >= 400
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onBack} className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+        <ArrowLeft className="w-4 h-4" /> Back to gateway requests
+      </button>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <span className="font-mono text-sm">{(detail as any).request_id}</span>
+            <Badge variant={isErr ? 'error' : 'success'} className="text-[10px]">
+              {statusCode ?? '—'}
+            </Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-xs">
+            <MetadataRow label="Endpoint" value={(detail as any).source_table} />
+            <MetadataRow label="Model" value={(detail as any).model || '—'} />
+            <MetadataRow label="Latency" value={(detail as any).execution_ms != null ? msToReadable(Number((detail as any).execution_ms)) : '—'} />
+            <MetadataRow label="Time" value={(detail as any).request_time ? format(new Date((detail as any).request_time), 'yyyy-MM-dd HH:mm:ss') : '—'} />
+            <MetadataRow label="Total Tokens" value={(detail as any).total_tokens != null ? Number((detail as any).total_tokens).toLocaleString() : '—'} />
+            <MetadataRow label="Input / Output" value={(detail as any).input_tokens != null ? `${(detail as any).input_tokens} / ${(detail as any).output_tokens || 0}` : '—'} />
+            <MetadataRow label="Finish Reason" value={(detail as any).finish_reason || '—'} />
+            <MetadataRow label="Tool Calls" value={(detail as any).tool_call_count != null ? String((detail as any).tool_call_count) : '—'} />
+            <MetadataRow label="Requester" value={(detail as any).requester || '—'} />
+            <MetadataRow label="Served Entity" value={(detail as any).served_entity_id || '—'} />
+            <MetadataRow label="Client Request ID" value={(detail as any).client_request_id || '—'} />
+            <MetadataRow label="Request Size" value={(detail as any).request_size_bytes != null ? `${(detail as any).request_size_bytes} B` : '—'} />
+            <MetadataRow label="Response Size" value={(detail as any).response_size_bytes != null ? `${(detail as any).response_size_bytes} B` : '—'} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">Request payload</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="text-xs font-mono overflow-auto max-h-96 bg-gray-50 dark:bg-gray-800 p-3 rounded">
+            {(() => {
+              const v = (detail as any).request_payload || ''
+              try { return JSON.stringify(JSON.parse(v), null, 2) } catch { return v || '(empty)' }
+            })()}
+          </pre>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">Response payload</CardTitle></CardHeader>
+        <CardContent>
+          <pre className="text-xs font-mono overflow-auto max-h-96 bg-gray-50 dark:bg-gray-800 p-3 rounded">
+            {(() => {
+              const v = (detail as any).response_payload || ''
+              try { return JSON.stringify(JSON.parse(v), null, 2) } catch { return v || '(empty)' }
+            })()}
+          </pre>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -13,6 +13,7 @@ import {
   useGatewayLogs,
   useGatewayLogSources,
   useGatewayLogDetail,
+  useGatewayLogTimeseries,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { RefreshButton } from '@/components/RefreshButton'
@@ -21,6 +22,14 @@ import { Badge } from '@/components/ui/badge'
 import { KpiCard } from '@/components/KpiCard'
 import { TablePagination } from '@/components/TablePagination'
 import { format } from 'date-fns'
+import {
+  LineChart as RcLineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
 import {
   Search,
   FlaskConical,
@@ -1576,6 +1585,9 @@ function ExperimentDetailView({
         <KpiCard title="Failed" value={failedRuns} format="number" />
       </div>
 
+      {/* Metric trends across runs in this experiment */}
+      <RunMetricTrends runs={runList} />
+
       {/* Runs table */}
       <Card>
         <CardHeader className="pb-3">
@@ -1799,11 +1811,15 @@ function RunsPanel({ workspaceUrl, workspaceId, workspaceHosts }: { workspaceUrl
                     <div className="col-span-2 flex gap-1 flex-wrap items-center">
                       {r.metrics.length > 0 ? (
                         <>
-                          {r.metrics.slice(0, 2).map((m: any) => (
-                            <Badge key={m.key} variant="default" className="text-[10px]">
-                              {m.key.split('.').pop()}: {Number(m.value).toFixed(3)}
-                            </Badge>
-                          ))}
+                          {r.metrics.slice(0, 2).map((m: any, idx: number) => {
+                            const norm = normalizeMetric(m)
+                            if (!norm) return null
+                            return (
+                              <Badge key={`${norm.name}-${idx}`} variant="default" className="text-[10px]">
+                                {norm.name.split('.').pop()}: {norm.value.toFixed(3)}
+                              </Badge>
+                            )
+                          })}
                           {r.metrics.length > 2 && (
                             <Badge variant="default" className="text-[10px]">+{r.metrics.length - 2}</Badge>
                           )}
@@ -2421,6 +2437,210 @@ function ModelVersionCard({
   )
 }
 
+/* ── Run-metric trends ────────────────────────────────────────── */
+
+const TREND_COLORS = ['#dc2626', '#7c3aed', '#0ea5e9', '#16a34a', '#f59e0b', '#0891b2', '#db2777', '#6b7280']
+
+/** Normalize metric items across the two shapes we see in the cache:
+ *    - {key, value}                                     (older / REST direct)
+ *    - {metric_name, latest_value, min_value, max_value} (system-table cache)
+ */
+function normalizeMetric(m: any): { name: string; value: number } | null {
+  const name = m?.metric_name || m?.key || ''
+  const raw = m?.latest_value ?? m?.value
+  const v = typeof raw === 'number' ? raw : Number(raw)
+  if (!name || !Number.isFinite(v)) return null
+  return { name, value: v }
+}
+
+function RunMetricTrends({ runs }: { runs: any[] }) {
+  // Build {metricName → [{time, value, run_id}]} sorted by time.
+  const byMetric = new Map<string, Array<{ time: number; value: number; run_id: string; bucket_label: string }>>()
+  for (const r of runs || []) {
+    let metrics = r?.data?.metrics ?? r?.metrics ?? []
+    if (typeof metrics === 'string') {
+      try { metrics = JSON.parse(metrics) } catch { metrics = [] }
+    }
+    if (!Array.isArray(metrics)) continue
+    const start = Number(r?.info?.start_time ?? r?.start_time ?? 0)
+    if (!start) continue
+    const runId = r?.info?.run_id ?? r?.run_id ?? ''
+    for (const m of metrics) {
+      const norm = normalizeMetric(m)
+      if (!norm) continue
+      const list = byMetric.get(norm.name) || []
+      list.push({ time: start, value: norm.value, run_id: runId, bucket_label: format(new Date(start), 'MM-dd HH:mm') })
+      byMetric.set(norm.name, list)
+    }
+  }
+  for (const [k, list] of byMetric) {
+    list.sort((a, b) => a.time - b.time)
+    byMetric.set(k, list)
+  }
+
+  if (byMetric.size === 0) return null
+
+  // Cap rendered metrics to avoid grid blow-up on experiments with hundreds of metric keys.
+  const MAX = 12
+  const entries = Array.from(byMetric.entries())
+  // Sort by descending number of points first — most-tracked metrics are usually the most interesting.
+  entries.sort((a, b) => b[1].length - a[1].length)
+  const visible = entries.slice(0, MAX)
+  const truncated = entries.length - visible.length
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <BarChart3 className="w-4 h-4" /> Metric trends
+          <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal ml-2">
+            {byMetric.size} metric{byMetric.size === 1 ? '' : 's'} across {runs.length} runs
+            {truncated > 0 && <span className="ml-2">· showing top {MAX} (+{truncated} more)</span>}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {visible.map(([name, series], i) => (
+            <div key={name}>
+              <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1 truncate" title={name}>
+                {name}  <span className="text-gray-400 normal-case">({series.length} pts)</span>
+              </div>
+              <MiniLineChart
+                data={series}
+                dataKey="value"
+                name={name}
+                color={TREND_COLORS[i % TREND_COLORS.length]}
+                height={120}
+                valueFormatter={(v) => v == null ? '—' : (Math.abs(Number(v)) >= 100 ? Number(v).toFixed(1) : Number(v).toFixed(3))}
+              />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── Gateway Requests time-series ─────────────────────────────── */
+
+/** A small line chart for one metric over time. Used in a 4-up grid above
+ *  the Gateway Requests list (request rate / P95 latency / errors / tokens).
+ *  Inline-recharts because the shared LineChart wrapper only supports a
+ *  single 'value' field. */
+function MiniLineChart({
+  data, dataKey, name, color, height = 110, valueFormatter,
+}: {
+  data: any[]
+  dataKey: string
+  name: string
+  color: string
+  height?: number
+  valueFormatter?: (v: any) => string
+}) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <RcLineChart data={data} margin={{ top: 4, right: 6, left: -10, bottom: 0 }}>
+        <XAxis dataKey="bucket_label" tick={{ fontSize: 10 }} interval="preserveStartEnd" />
+        <YAxis tick={{ fontSize: 10 }} width={40}
+               tickFormatter={(v: any) => valueFormatter ? valueFormatter(v) : String(v)} />
+        <Tooltip
+          contentStyle={{ borderRadius: 6, fontSize: 11, padding: '4px 8px',
+                          backgroundColor: 'var(--tooltip-bg, #fff)', color: 'var(--tooltip-text, #1f2937)' }}
+          formatter={(v: any) => valueFormatter ? valueFormatter(v) : String(v)}
+        />
+        <Line type="monotone" dataKey={dataKey} stroke={color} strokeWidth={2}
+              dot={false} name={name} isAnimationActive={false} />
+      </RcLineChart>
+    </ResponsiveContainer>
+  )
+}
+
+function GatewayTimeSeries({ windowDays, sourceTable }: { windowDays: number; sourceTable: string | null }) {
+  // Choose bucket size: hourly for 1d, daily for >7d, hourly otherwise.
+  const bucket: 'hour' | 'day' = windowDays >= 14 ? 'day' : 'hour'
+  const { data: rows, isLoading } = useGatewayLogTimeseries(windowDays, sourceTable, bucket)
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-xs text-gray-400 text-center flex items-center justify-center gap-2">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading trend data…
+        </CardContent>
+      </Card>
+    )
+  }
+  const list = rows || []
+  if (!list.length) return null
+
+  // Aggregate across endpoints when no specific filter; preserve per-endpoint
+  // when one source_table is selected. Group by bucket.
+  const byBucket = new Map<string, any>()
+  for (const r of list) {
+    const key = r.bucket
+    const cur = byBucket.get(key) || { bucket: key, requests: 0, errors: 0, total_tokens: 0, p95_acc: [], avg_acc: [] }
+    cur.requests += Number(r.requests || 0)
+    cur.errors += Number(r.errors || 0)
+    cur.total_tokens += Number(r.total_tokens || 0)
+    if (r.p95_ms != null) cur.p95_acc.push(Number(r.p95_ms))
+    if (r.avg_ms != null) cur.avg_acc.push(Number(r.avg_ms))
+    byBucket.set(key, cur)
+  }
+  const merged = Array.from(byBucket.values()).sort((a, b) => a.bucket.localeCompare(b.bucket))
+  // Take the max p95 across endpoints for that bucket — that's the worst-
+  // case latency anyone saw in that window. Avg is a simple mean.
+  for (const m of merged) {
+    m.p95_ms = m.p95_acc.length ? Math.round(Math.max(...m.p95_acc)) : null
+    m.avg_ms = m.avg_acc.length ? Math.round(m.avg_acc.reduce((s: number, n: number) => s + n, 0) / m.avg_acc.length) : null
+    m.error_rate = m.requests > 0 ? (m.errors / m.requests) * 100 : 0
+    m.bucket_label = (() => {
+      const t = Date.parse(m.bucket)
+      if (!Number.isFinite(t)) return m.bucket
+      return bucket === 'hour' ? format(new Date(t), 'MM-dd HH:mm') : format(new Date(t), 'MM-dd')
+    })()
+  }
+
+  const totalRequests = merged.reduce((s, m) => s + m.requests, 0)
+  const totalErrors = merged.reduce((s, m) => s + m.errors, 0)
+  const totalTokens = merged.reduce((s, m) => s + m.total_tokens, 0)
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <BarChart3 className="w-4 h-4" /> Trends
+          <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal ml-2">
+            {sourceTable ? sourceTable.split('.').pop() : 'all endpoints'} · last {windowDays}d · per {bucket}
+            <span className="ml-2">· {totalRequests.toLocaleString()} requests · {totalErrors.toLocaleString()} errors · {totalTokens.toLocaleString()} tokens</span>
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Requests</div>
+            <MiniLineChart data={merged} dataKey="requests" name="Requests" color="#dc2626" />
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">P95 Latency</div>
+            <MiniLineChart data={merged} dataKey="p95_ms" name="P95 ms" color="#7c3aed"
+                           valueFormatter={(v) => v == null ? '—' : (Number(v) >= 1000 ? `${(Number(v)/1000).toFixed(1)}s` : `${v}ms`)} />
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Error Rate</div>
+            <MiniLineChart data={merged} dataKey="error_rate" name="Error %" color="#f59e0b"
+                           valueFormatter={(v) => v == null ? '—' : `${Number(v).toFixed(1)}%`} />
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Tokens</div>
+            <MiniLineChart data={merged} dataKey="total_tokens" name="Tokens" color="#0ea5e9"
+                           valueFormatter={(v) => Number(v).toLocaleString()} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 /* ── Gateway Requests Panel (Tier 2a) ─────────────────────────── */
 
 const GATEWAY_WINDOW_OPTIONS = [1, 7, 30, 90, 180, 365] as const
@@ -2462,6 +2682,8 @@ function GatewayRequestsPanel() {
         <KpiCard title="Errors" value={errCount} format="number" />
         <KpiCard title="Avg Latency" value={avgLatency} format="duration" />
       </div>
+
+      <GatewayTimeSeries windowDays={windowDays} sourceTable={sourceFilter} />
 
       <Card>
         <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3 flex-wrap">

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -52,6 +52,7 @@ import {
   Server,
   Calendar,
   Info,
+  Wrench,
 } from 'lucide-react'
 import { DB_RED_SHADES } from '@/lib/brand'
 
@@ -529,16 +530,41 @@ function TraceDetailView({
         <button onClick={onBack} className="inline-flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 transition-colors">
           <ArrowLeft className="w-4 h-4" /> Back to traces
         </button>
-        {workspaceUrl && detail.experiment_id && (
-          <a
-            href={`${workspaceUrl}/ml/experiments/${detail.experiment_id}?searchFilter=request_id%3D%27${requestId}%27&compareRunsMode=TRACES`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800"
-          >
-            View in MLflow <ExternalLink className="w-3 h-3" />
-          </a>
-        )}
+        <div className="flex items-center gap-3">
+          {/* Source notebook link — uses metadata.mlflow.databricks.webappURL
+              (a direct host URL) if present, else builds from the registry.
+              Renders only when notebook id + workspace are known. */}
+          {(() => {
+            const meta = (detail as any).metadata || {}
+            const nbId = meta['mlflow.databricks.notebookID']
+            const sourceWsId = meta['mlflow.databricks.workspaceID'] || (detail as any).workspace_id
+            const direct = meta['mlflow.databricks.webappURL']
+            const base = direct || workspaceUrl
+            if (!nbId || !base) return null
+            const wsParam = sourceWsId ? `?o=${sourceWsId}` : ''
+            return (
+              <a
+                href={`${String(base).replace(/\/$/, '')}${wsParam}#notebook/${nbId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800"
+                title={meta['mlflow.source.name'] || ''}
+              >
+                View source notebook <ExternalLink className="w-3 h-3" />
+              </a>
+            )
+          })()}
+          {workspaceUrl && detail.experiment_id && (
+            <a
+              href={`${workspaceUrl}/ml/experiments/${detail.experiment_id}?searchFilter=request_id%3D%27${requestId}%27&compareRunsMode=TRACES`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-blue-600 hover:text-blue-800"
+            >
+              View in MLflow <ExternalLink className="w-3 h-3" />
+            </a>
+          )}
+        </div>
       </div>
 
       {/* Header card */}
@@ -721,6 +747,16 @@ function TraceDetailView({
           </CardContent>
         </Card>
       </div>
+
+      {/* Assessments — only renders when the trace has eval/quality data */}
+      {Array.isArray((detail as any).assessments) && (detail as any).assessments.length > 0 && (
+        <AssessmentsCard assessments={(detail as any).assessments} />
+      )}
+
+      {/* Tool-call breakdown — only renders when the trace has TOOL spans */}
+      {Array.isArray((detail as any).spans) && (detail as any).spans.length > 0 && (
+        <ToolCallBreakdown spans={(detail as any).spans} />
+      )}
 
       {/* Span waterfall — hierarchical timeline of all spans in this trace */}
       {Array.isArray((detail as any).spans) && (detail as any).spans.length > 0 && (
@@ -1112,6 +1148,193 @@ function SpanWaterfall({ spans }: { spans: Span[] }) {
         )
       })()}
     </div>
+  )
+}
+
+/* ── Tool-call breakdown ─────────────────────────────────────── */
+
+/** Aggregate spans where kind=TOOL by name and render a sortable summary
+ *  table. Renders nothing when the trace has no tool spans (so we don't
+ *  reserve an empty card for retrieval-only or LLM-only traces).
+ *
+ *  The "% of trace" bar is the tool's total wall-clock time divided by the
+ *  trace's wall-clock duration (max end - min start across all spans).
+ *  Tool spans can run in parallel so per-row bars may sum past 100% — that's
+ *  meaningful and we show it without clamping. */
+function ToolCallBreakdown({ spans }: { spans: Span[] }) {
+  const toolSpans = (spans || []).filter((s) => spanKind(s) === 'TOOL')
+  if (!toolSpans.length) return null
+
+  // Trace wall-clock from all spans (not just tools) so the % reflects the
+  // tool's share of the user-visible latency.
+  const allStarts = (spans || []).map(spanStartMs).filter((n) => n > 0)
+  const allEnds = (spans || []).map(spanEndMs).filter((n) => n > 0)
+  const traceMs = allStarts.length && allEnds.length ? Math.max(...allEnds) - Math.min(...allStarts) : 0
+
+  type Row = { name: string; count: number; totalMs: number; errors: number }
+  const groups = new Map<string, Row>()
+  let totalErrs = 0
+  for (const s of toolSpans) {
+    const name = (s.name && String(s.name)) || 'unknown'
+    const start = spanStartMs(s)
+    const end = spanEndMs(s)
+    const dur = end > start ? end - start : 0
+    const isErr = spanStatusOk(s) === 'ERROR'
+    if (isErr) totalErrs += 1
+    const g = groups.get(name) || { name, count: 0, totalMs: 0, errors: 0 }
+    g.count += 1
+    g.totalMs += dur
+    if (isErr) g.errors += 1
+    groups.set(name, g)
+  }
+  const rows = Array.from(groups.values()).sort((a, b) => b.totalMs - a.totalMs)
+  const totalToolMs = rows.reduce((s, r) => s + r.totalMs, 0)
+  const color = KIND_COLORS.TOOL
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Wrench className="w-4 h-4" /> Tool Calls ({toolSpans.length})
+          <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal ml-2">
+            {rows.length} unique · {msToReadable(totalToolMs)} total
+            {totalErrs > 0 && <span className="ml-2 text-red-500">· {totalErrs} error{totalErrs===1?'':'s'}</span>}
+            {traceMs > 0 && <span className="ml-2">· {((totalToolMs / traceMs) * 100).toFixed(0)}% of trace wall time</span>}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-[minmax(0,1.5fr)_3rem_4.5rem_4.5rem_3rem_minmax(0,2fr)] gap-2 px-1 py-1.5 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+          <div>Tool</div>
+          <div className="text-right">Count</div>
+          <div className="text-right">Total</div>
+          <div className="text-right">Avg</div>
+          <div className="text-right">Err</div>
+          <div>% of trace</div>
+        </div>
+        {rows.map((r) => {
+          const avg = r.count > 0 ? r.totalMs / r.count : 0
+          const pct = traceMs > 0 ? (r.totalMs / traceMs) * 100 : 0
+          // Cap visual bar at 100% but keep numeric label exact.
+          const barPct = Math.min(100, pct)
+          return (
+            <div
+              key={r.name}
+              className="grid grid-cols-[minmax(0,1.5fr)_3rem_4.5rem_4.5rem_3rem_minmax(0,2fr)] gap-2 px-1 py-1.5 text-xs border-b border-gray-100 dark:border-gray-800 last:border-0 items-center"
+            >
+              <div className="truncate font-medium text-gray-800 dark:text-gray-200" title={r.name}>{r.name}</div>
+              <div className="text-right">{r.count}</div>
+              <div className="text-right font-medium">{msToReadable(r.totalMs)}</div>
+              <div className="text-right text-gray-500 dark:text-gray-400">{msToReadable(Math.round(avg))}</div>
+              <div className="text-right">
+                {r.errors > 0 ? <span className="text-red-500 font-medium">{r.errors}</span> : <span className="text-gray-400">—</span>}
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="relative h-2 bg-gray-100 dark:bg-gray-700 rounded flex-1">
+                  <div className="absolute inset-y-0 left-0 rounded" style={{ width: `${barPct}%`, backgroundColor: color, opacity: 0.85 }} />
+                </div>
+                <span className="text-[10px] text-gray-500 dark:text-gray-400 tabular-nums w-9 text-right">{pct.toFixed(0)}%</span>
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── Assessments / eval-quality card ─────────────────────────── */
+
+type Assessment = {
+  assessment_id?: string
+  name?: string
+  source?: { source_id?: string; source_type?: string }
+  feedback?: { value?: any; numeric_value?: any }
+  expectation?: any
+  rationale?: string
+  create_time?: string
+  last_update_time?: string
+  metadata?: any
+  error?: any
+}
+
+/** Render quality / eval data attached to a trace. MLflow stores assessments
+ *  as an array per trace — each entry is a name + score (numeric or
+ *  categorical) + rationale + source (LLM judge, human, etc.). */
+function AssessmentsCard({ assessments }: { assessments: Assessment[] }) {
+  const list = (assessments || []).filter((a) => a && a.name)
+  if (!list.length) return null
+
+  // Group by source type for at-a-glance summary
+  const bySource: Record<string, number> = {}
+  for (const a of list) {
+    const st = a.source?.source_type || 'UNKNOWN'
+    bySource[st] = (bySource[st] || 0) + 1
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <CheckCircle2 className="w-4 h-4" /> Assessments ({list.length})
+          <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal ml-2">
+            {Object.entries(bySource).map(([k, v]) => `${v} ${k}`).join(' · ')}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {list.map((a, i) => {
+            // Feedback can be string ("yes"/"no"), number, or JSON-encoded.
+            let scoreText: string = '—'
+            const fbVal = a.feedback?.value
+            const fbNum = a.feedback?.numeric_value
+            if (fbNum != null) scoreText = String(fbNum)
+            else if (fbVal != null) {
+              if (typeof fbVal === 'string') {
+                // MLflow sometimes wraps strings in extra quotes.
+                try { const p = JSON.parse(fbVal); scoreText = String(p) } catch { scoreText = fbVal }
+              } else {
+                scoreText = JSON.stringify(fbVal)
+              }
+            } else if (a.expectation != null) {
+              scoreText = typeof a.expectation === 'string' ? a.expectation : JSON.stringify(a.expectation).slice(0, 60)
+            }
+            const isErr = a.error || (typeof scoreText === 'string' && /^"?(no|fail|failed|error)"?$/i.test(scoreText.trim()))
+            const isPass = !isErr && (typeof scoreText === 'string' && /^"?(yes|pass|true|ok)"?$/i.test(scoreText.trim()))
+            const badgeVariant: any = isErr ? 'error' : isPass ? 'success' : 'default'
+            return (
+              <div key={a.assessment_id || i} className="border border-gray-200 dark:border-gray-700 rounded-md p-2.5">
+                <div className="flex items-center justify-between gap-2 mb-1.5">
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <span className="font-medium text-sm text-gray-900 dark:text-gray-200 truncate" title={a.name}>{a.name}</span>
+                    <Badge variant={badgeVariant} className="text-[10px] flex-shrink-0">{scoreText}</Badge>
+                    {a.source?.source_type && (
+                      <span className="text-[10px] text-gray-400 uppercase tracking-wide flex-shrink-0">
+                        {a.source.source_type}
+                      </span>
+                    )}
+                  </div>
+                  {a.create_time && (
+                    <span className="text-[10px] text-gray-400 flex-shrink-0">
+                      {(() => {
+                        const t = Date.parse(a.create_time)
+                        return Number.isFinite(t) ? format(new Date(t), 'MMM dd HH:mm') : ''
+                      })()}
+                    </span>
+                  )}
+                </div>
+                {a.rationale && (
+                  <div className="text-xs text-gray-600 dark:text-gray-300 whitespace-pre-wrap leading-relaxed">
+                    {a.rationale.length > 400 ? a.rationale.slice(0, 400) + '…' : a.rationale}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/docs/decisions/2026-04-29-cross-workspace-observability-pivot.md
+++ b/docs/decisions/2026-04-29-cross-workspace-observability-pivot.md
@@ -1,0 +1,103 @@
+# ADR: Cross-workspace observability via Unity Catalog, not MLflow trace fan-out
+
+**Status:** Accepted (2026-04-29)
+**Defers (does not abandon):** the cross-workspace MLflow REST API fan-out approach. The prototype is parked; whether to revive it as a future direction will be re-evaluated as Databricks platform constraints evolve and as we see how Tier 2 adoption plays out (see *Trigger conditions* below).
+**Related:** [RCA: Cross-workspace trace discovery silently returning empty](../rca/2026-04-28-cross-workspace-trace-discovery.md)
+
+## Context
+
+The Observability page needs to surface agent activity across all workspaces in a Databricks account. The original design fanned out MLflow REST API calls (`/api/2.0/mlflow/traces`) per workspace from the discovery workflow.
+
+Investigation (full detail in the RCA) showed this is structurally blocked by Databricks platform constraints:
+
+1. **Cross-workspace REST API calls from Databricks Serverless and Databricks Apps Compute are rejected** at the destination workspace's gateway with `403 Cert validation failed. Both workspace comparison and snp system trusted checks did not pass.` This applies whenever the destination workspace has any Network Policy attached, even an allow-all one. Confirmed via direct probes from both runtimes.
+2. **Classic compute is a viable alternative** in principle but requires the destination region/account to provision classic worker environments — not available in our test workspaces, and provisioning was further constrained by an industry-wide supply-chain security incident affecting Python dependency provisioning during the investigation window.
+3. **An external runner works** (proven via direct HTTPS calls from outside Databricks compute, returning trace data using the same service-principal credentials), but is operationally heavyweight: requires external scheduling, cross-system secret management, and per-deployment service-principal provisioning across all target workspaces.
+4. **A native self-serve platform control for cross-workspace API access is on the Databricks roadmap.** No public GA confirmation as of this ADR's date.
+
+## Decision
+
+**For the near term, source cross-workspace observability data from Unity Catalog (AI Gateway inference tables and UC-stored MLflow traces), not from per-workspace MLflow REST API fan-out.**
+
+The architectural reframe: anything in Unity Catalog is queryable cross-workspace via a SQL warehouse — no per-workspace fan-out, no service principal on each target workspace, no platform-level isolation to fight at the destination. Both AI Gateway inference logs and UC-bound MLflow trace tables live in UC. The MLflow REST API fan-out path is deferred to a future iteration as platform constraints lift; this is a pragmatic choice to ship now, not a long-term architectural commitment against MLflow REST traces.
+
+The product's surface area becomes:
+
+A note on terminology used below: MLflow traces have **two storage backends** — the original control-plane backend (referred to as the *default backend* below; this is what `@mlflow.trace`-decorated code writes to unless an experiment is explicitly bound to a UC trace location) and the newer **Unity Catalog OTel backend** (`<prefix>_otel_spans` Delta tables, MLflow 3.11+). These are *storage* concepts, separate from the compute that does the discovery (Serverless, Apps, classic clusters, or external runners).
+
+- **Tier 1 (today):** Local-workspace MLflow traces stored in the default backend. Fetched via `/api/2.0/mlflow/traces` REST against the local workspace — the existing Serverless workflow path. Captures `@mlflow.trace`-decorated agent code that uses the default backend. Spans, tool calls, payloads.
+- **Tier 2 (today):** Any agent observability data that lives in Unity Catalog. Because UC governance is account-level, an account admin (or any principal with the right UC grants) can discover and read these tables via a SQL warehouse from any workspace — there's no per-workspace boundary at the data layer, no per-workspace API to fan out across, no platform isolation to fight. Three sub-sources, one SQL-warehouse implementation:
+  - **2a. AI Gateway inference tables** — `<catalog>.<schema>.<endpoint_name>_payload`. One row per gateway-served request: input, output, status, latency, model, tokens. Request-level. **The default first-touch source** for cross-workspace observability today.
+  - **2b. UC-stored MLflow OTel traces, account-wide** — discovered via `SELECT FROM system.information_schema.tables WHERE table_name LIKE '%_otel_spans'` across the metastore. Each matching table is queried directly. Verified empirically: a single SQL warehouse query lists every OTel spans table in the account regardless of which workspace's experiment created it; SELECT against the discovered tables succeeds whenever UC grants permit. Span-level, full agent execution detail. Covers both local-workspace UC-bound experiments *and* UC-bound experiments from every other workspace in the account, in a single uniform query path.
+  - The legacy MLflow REST API does *not* return UC-stored traces (verified empirically — `/api/2.0/mlflow/traces` responds with `experiment does not exist` for UC-bound experiments), which is why even the local-workspace UC slice is served by SQL rather than by the existing Tier 1 REST path.
+- **Tier 3 (deferred):** Cross-workspace coverage for MLflow traces in the **default backend** — the residual gap that Tier 2 doesn't reach (because UC SQL only sees UC-stored data; default-backend traces in other workspaces aren't in UC at all). Reaching them would require per-workspace MLflow REST calls, which the destination workspace's gateway blocks today. A working prototype of that fan-out exists internally and may be useful if Tier 2 adoption signals a meaningful gap *and* the platform changes in *Trigger conditions* below make this path operationally tractable. Whether to promote it from "parked" to a shipped feature is a future decision, not a current commitment.
+
+Framing for the README and operator-facing docs: *"MLflow traces from the local workspace work today via the existing workflow when those traces use MLflow's default storage backend. Anything in Unity Catalog — AI Gateway request logs and UC-stored MLflow traces — works account-wide via SQL warehouse, with no per-workspace setup beyond the UC grants. The remaining gap is default-backend MLflow traces from other workspaces; how we close it will depend on adoption signals and how the Databricks platform evolves."*
+
+## Alternatives considered (and current status)
+
+| Option | Status today | What would change it |
+|---|---|---|
+| Cross-workspace MLflow REST fan-out from Serverless workflow | Deferred — blocked at destination workspace (HTTP 403 cert validation) | Native self-serve cross-workspace API control ships in the Databricks platform |
+| Cross-workspace MLflow REST fan-out from Databricks Apps Compute | Deferred — same 403, Apps Compute is also subject to the same destination filter | Same as above |
+| Cross-workspace MLflow REST fan-out from classic compute job | Deferred — classic compute was not available in our test workspaces; provisioning issues during investigation prevented validation | Reliable classic-compute provisioning across customer workspaces, AND classic egress confirmed not subject to the same filter at destination |
+| External runner (cron / scheduler outside Databricks) | Proven working but deferred — operationally heavy: external scheduler, cross-system secret management, operator-side setup burden too high for a deployable app | Demand pulls us into shipping it as an opt-in Tier-2.5 anyway |
+| One-off platform-level allowlist exceptions | Not viable as a product path — bespoke per-customer engagement, not a feature customers can self-enable | Won't change. Useful only for specific internal scenarios. |
+| Wait for the platform-level self-serve control | Tracking | When it ships, opens a path to revisit Tier 3 (native cross-workspace MLflow REST) |
+
+**These alternatives are deferred, not abandoned.** MLflow REST cross-workspace fan-out may eventually unlock trace coverage that the Unity Catalog approach doesn't reach — agents that don't route through AI Gateway and don't use UC-bound experiments. But it carries its own complexity: operational overhead, per-deployment service-principal provisioning across all target workspaces, and dependence on Databricks platform changes that aren't yet generally available. Whether it becomes a long-term direction will depend on how Tier 2 adoption plays out and how the platform evolves; for now it's not prioritized at this stage.
+
+## Consequences
+
+**Positive:**
+- Ships today without an external scheduler.
+- Customer setup is a documented Databricks-native step (enable AI Gateway request logging on relevant endpoints; optionally bind MLflow experiments to a UC trace location for richer span-level data) — not a multi-workspace service-principal provisioning project.
+- No reliance on platform-level exceptions or out-of-band approvals.
+- Aligns the app with Unity Catalog as the canonical cross-workspace observability surface — both AI Gateway data and UC MLflow traces flow through the same architectural pattern (UC SQL warehouse query, no fan-out).
+- The MLflow REST fan-out prototype is parked, not deleted — if it becomes the right direction in the future, we resume that work without starting over.
+
+**Negative:**
+- Span-level coverage of *other* workspaces requires those workspaces' MLflow experiments to be UC-bound. MLflow 3.11+ with explicit UC trace binding is still Beta and region-limited. Default-backend traces in other workspaces fall into the deferred Tier 3 gap until either an operator opts into an external runner or the platform evolves.
+- AI Gateway coverage gap: direct foundation-model calls that bypass the gateway aren't captured by Tier 2a. Tier 2b's UC OTel traces cover those calls if the deployment has bound its experiments to UC.
+- The OTel spans table doesn't carry a `workspace_id` column; trace data is conceptually account-level once it lands in UC. If the UI needs to attribute traces to originating workspaces, that mapping has to come from the experiment-to-workspace association (e.g., `system.mlflow.experiments_latest`) rather than from the OTel rows themselves.
+- Documentation must clearly explain: (i) local-workspace default-backend traces work via the existing workflow, (ii) anything in UC (gateway logs, UC-bound traces) is covered account-wide via SQL with the right UC grants, (iii) default-backend traces from other workspaces are a known coverage gap with no committed roadmap timing.
+- Two ingestion paths into the shared cache schema: (a) MLflow REST for the local workspace's default-backend experiments, (b) UC SQL for everything in UC (gateway logs and UC-bound traces). The UC SQL path is one warehouse-query implementation with two normalizers — gateway-payload and OTel-spans.
+
+**Code-level impact:**
+
+Keep (still useful, no rework):
+- `observability_trace_details` Lakebase cache table + DDL — works for both Tier 1 local default-backend traces *and* Tier 2b UC OTel traces (same shape).
+- `_parse_trace_info_to_detail` shared helper in `mlflow_service.py`.
+- Cache-first read in `get_trace_detail_for_workspace`.
+- Frontend 7/14/30/90-day window filter.
+- Per-trace detail caching in `04_discover_observability.py` for the local workspace.
+
+Park behind a feature flag (Tier 3 prototype, deferred not deleted):
+- The service-principal token-exchange path in `04_discover_observability.py`.
+- `discovery_sp_secret_scope` and `narrow_test_workspace_id` bundle variables (default empty/off).
+- Accounts API and `system.access.workspaces_latest` fallback for cross-workspace host resolution.
+- The fan-out parallelism that targets remote workspaces.
+
+Rationale for "park, don't delete": if we revisit this direction later, this is the closest starting point we have. Re-enabling behind a flag is cheaper than rebuilding from scratch.
+
+Add:
+- **UC MLflow OTel trace discovery** — pure SQL implementation, account-wide. Step 1: discover OTel tables via `SELECT FROM system.information_schema.tables WHERE table_name LIKE '%_otel_spans'`. Step 2: for each discovered table, query it over the retention window and normalize into the existing `observability_trace_details` schema. No per-workspace MLflow API calls, no experiment enumeration, no SP-on-each-workspace setup — UC governance is the only auth boundary. The same query path covers local and remote UC-bound traces uniformly. Optionally join with `system.mlflow.experiments_latest` if experiment-name context is needed in the UI.
+- **`gateway_inference_logs` Lakebase cache table** — for AI Gateway request logs (Tier 2a).
+- **AI Gateway inference table discovery** in `06_discover_gateway_usage.py` (or split into a new `07_discover_gateway_inference_logs.py`) — enumerates endpoints with logging enabled, queries `<catalog>.<schema>.<endpoint_name>_payload` over the retention window, upserts to Lakebase.
+- **New "Gateway requests" panel** in the Observability page, alongside the existing "Traces" panel. Gateway-request rows and trace rows can be visually distinguished but share the same cross-workspace querying primitives.
+- **README section**: "Enabling cross-workspace observability" — covers AI Gateway request-logging setup and UC MLflow trace binding (with link to the public docs page on storing traces in Unity Catalog), and the UC grants the operator's principal needs (USE_CATALOG, USE_SCHEMA, SELECT on the OTel tables and gateway payload tables).
+
+## Trigger conditions for revisiting this decision
+
+Re-open this ADR if any of the following change. The first three would make MLflow REST cross-workspace fan-out more operationally tractable than it is today; the fourth would put pressure on us to close coverage gaps regardless of the operational cost.
+
+1. **A native Databricks self-serve control for cross-workspace API access ships.** At that point, the parked Tier 3 code could be re-evaluated as a viable path directly from the Databricks workflow, without external infrastructure.
+2. **Classic compute workspace provisioning becomes reliable** *and* classic egress is confirmed not subject to the same destination filter as Serverless. Could open a Databricks-native path for the deferred prototype.
+3. **A `system.mlflow.traces` (or equivalent) Unity Catalog system table ships**, making default-backend MLflow traces queryable cross-workspace via SQL the same way AI Gateway logs and UC OTel traces already are. This would close the Tier 3 gap entirely without needing fan-out at all — everything would route through UC SQL.
+4. **AI Gateway + UC MLflow trace adoption is too narrow** in operator feedback. If most deployments use direct model calls outside the gateway *and* haven't adopted UC-bound experiments, Tier 2 misses too much, and Tier 3's gap (default-backend traces in other workspaces) is the dominant unmet need. At that point, we'd reconsider the trade-off and may decide that the operational cost of an external runner (or a then-newly-tractable native option) is worth shipping despite the complexity.
+
+## References
+
+- RCA: [`docs/rca/2026-04-28-cross-workspace-trace-discovery.md`](../rca/2026-04-28-cross-workspace-trace-discovery.md) (full investigation and diagnostic matrix).
+- Storing MLflow traces in Unity Catalog (Databricks public documentation): https://learn.microsoft.com/en-us/azure/databricks/mlflow3/genai/tracing/trace-unity-catalog
+- AI Gateway inference table / request logging — see Databricks Mosaic AI Gateway documentation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -159,6 +159,37 @@ targets:
 
 For Provisioned Lakebase, leave `lakebase_endpoint_path` empty and set `lakebase_instance` to the instance name.
 
+#### Choose the discovery run-as principal
+
+Trace and gateway-log discovery (Tiers 2a and 2b) use Unity Catalog as the auth boundary. The workflow only sees catalogs, schemas, and tables that its **run-as principal** has been granted on, and `system.information_schema.tables` is principal-filtered — tables in catalogs without any grant are invisible.
+
+| Run-as principal | What it sees | When to use |
+|------------------|--------------|-------------|
+| **Metastore admin user / service principal** | All catalogs and tables in the metastore (metadata) + any tables the principal has `SELECT` on | Recommended. New catalogs auto-covered without per-catalog grants. |
+| **Regular user / service principal** | Only catalogs and schemas the principal has been explicitly granted on | Use when metastore-admin is not appropriate. Requires per-catalog `USE CATALOG + USE SCHEMA + SELECT` grants. |
+
+By default, the bundle runs the workflow as the deploying user. To run as a service principal instead, add a `run_as` block at the job level in `databricks.yml`:
+
+```yaml
+resources:
+  jobs:
+    agent_discovery:
+      run_as:
+        service_principal_name: <application-id-of-your-discovery-sp>
+```
+
+Then make sure that service principal is either:
+
+1. **A member of the metastore admin group** (recommended — covers new catalogs automatically). Add via the Account Console → Unity Catalog → Metastore → Admin group, or via SCIM/Terraform.
+2. **OR** explicitly granted on each catalog you want covered:
+   ```sql
+   GRANT USE CATALOG ON CATALOG <c> TO `<sp-application-id>`;
+   GRANT USE SCHEMA ON CATALOG <c> TO `<sp-application-id>`;
+   GRANT SELECT ON CATALOG <c> TO `<sp-application-id>`;
+   ```
+
+> **Important**: Metastore admin grants metadata visibility (you can see every catalog) and the ability to grant yourself privileges, but it does **not** auto-confer `SELECT` on data. To actually read traces, the principal still needs `SELECT` along the chain — the simplest path is for the metastore admin group to own the catalogs that should be covered, or to grant the group `SELECT ON CATALOG` for each.
+
 Then deploy and run:
 
 ```bash
@@ -214,6 +245,14 @@ After redeploy, add scopes in the UI and refresh — they should persist.
 
 ### Empty Observability page
 The workflow hasn't run yet, or `system.mlflow` access hasn't been granted. Check the workflow run output and Step 8 above.
+
+### Fewer traces than expected
+Trace coverage is bounded by two things: (a) which trace-producing features are enabled on the agents themselves, and (b) what the discovery run-as principal can see and read in Unity Catalog (see Step 7 → "Choose the discovery run-as principal"). Common causes:
+
+- **The agent isn't producing the kind of trace you expect.** Check the README's *"What your agents need to do for traces to exist"* table — Tier 1 needs MLflow tracing in code, Tier 2a needs inference-table or AI Gateway request logging on the endpoint, Tier 2b needs the experiment bound to a UC trace location. If none are enabled for an agent, no trace data exists for the workflow to find.
+- The run-as principal is not a metastore admin and has no grants on the catalog where the missing traces live. Either add it to the metastore admin group or grant explicit `USE CATALOG + USE SCHEMA + SELECT`.
+- Traces fall outside the retention window (`trace_retention_days`, default 90). Bump it via the bundle variable.
+- Traces live in a different workspace's default MLflow backend (not in Unity Catalog). Cross-workspace REST fan-out (Tier 3) is on the roadmap; until then, those traces are only visible from within their owning workspace.
 
 ### Lakebase connection errors
 Verify your `LAKEBASE_DNS` is correct and that you set exactly one of `LAKEBASE_ENDPOINT_PATH` (Autoscaling) or `LAKEBASE_INSTANCE` (Provisioned). The instance must be in the `AVAILABLE` state.

--- a/docs/rca/2026-04-28-cross-workspace-trace-discovery.md
+++ b/docs/rca/2026-04-28-cross-workspace-trace-discovery.md
@@ -1,0 +1,78 @@
+# RCA: Cross-workspace trace discovery silently returning empty
+
+**Date:** 2026-04-28 (updated 2026-04-29)
+**Status:** Diagnosed; root cause is a Databricks platform-level limitation. Cross-workspace data is sourced via Unity Catalog instead. See [related ADR](../decisions/2026-04-29-cross-workspace-observability-pivot.md).
+**Severity:** Feature failure, no data loss
+
+## Summary
+
+The discovery workflow's cross-workspace MLflow trace fan-out has been silently returning zero traces from every workspace except the runner's local one. The Observability page's cross-workspace traces never actually surfaced data from any other workspace. Local workspace caching succeeded, masking the cross-workspace failure from casual inspection.
+
+## Symptom
+
+The cached `observability_traces` table contained rows from a single workspace only — the workspace where the discovery workflow ran. System tables showed many more workspaces with MLflow experiments (~80) but none of those translated into cached traces.
+
+## Investigation
+
+The discovery workflow logs showed:
+- The Lakebase `workspace_registry` host-mapping table was empty (it had only ever been populated by an admin endpoint that was never invoked).
+- Adding a fallback that resolves hosts via `system.access.workspaces_latest` recovered ~13 reachable workspaces.
+- Even after host resolution worked, fan-out returned `error_breakdown: {}` (no errors) and `total_traces: 0` from every remote workspace.
+- Auditing the few cached traces that did exist confirmed every row traced back to an experiment owned by the workflow runner in the runner's local workspace.
+
+Initial hypothesis: an MLflow permission-filtering issue (other users' experiments not visible to the runner principal). Provisioning a service principal with workspace admin on each target workspace and re-running the fan-out tested this hypothesis directly.
+
+## Root cause
+
+The MLflow API call from one workspace's compute to another workspace's API is rejected at the destination workspace with:
+
+```
+HTTP 403  {"error_code":403,"message":"Cert validation failed.
+Both workspace comparison and snp system trusted checks did not pass."}
+```
+
+This is **not** an authentication or authorization issue. The OIDC token exchange succeeds. The service principal grant is valid. The destination workspace's API gateway rejects the request based on its origin — Databricks' platform isolation between workspaces blocks cross-workspace REST API calls from inside another workspace's compute.
+
+The block applies whenever the destination workspace has any Network Policy attached — even one that allows everything. This is documented Databricks platform behavior.
+
+## Diagnostic matrix
+
+We tested every viable runtime to confirm the constraint. Same caller identity, same target, same endpoint — only the runtime differs:
+
+| Caller runtime | Token exchange | Cross-workspace MLflow API call |
+|---|---|---|
+| Databricks Serverless workflow | ✅ | ❌ 403 cert validation |
+| Databricks Apps Compute | ✅ | ❌ 403 cert validation |
+| Databricks Classic compute | not available in our test environment | not testable |
+| External runner (HTTP from outside Databricks) | ✅ | ✅ 200 + trace data |
+
+The destination filter is enforced at the receiving workspace's gateway, not by egress controls at the source. External callers — those not originating from a Databricks workspace's compute layer — pass through.
+
+## Why this wasn't caught earlier
+
+- The local workspace path always worked (the workflow runner could read their own experiments), so the cache always had data. The page rendered, masking the cross-workspace failure.
+- Fan-out errors were caught and logged as "0 traces" — indistinguishable from "succeeded but no data".
+- No alerting compared `workspaces_queried` against `workspaces_with_traces`. A 14:1 ratio in production would have been an obvious signal.
+- Account admin permissions in Databricks ≠ implicit MLflow read access to every workspace's experiments — a subtle distinction.
+
+## Workarounds we evaluated
+
+| Approach | Status |
+|---|---|
+| Use Classic compute instead of Serverless (different egress path) | Could not test in our environment — workspaces were provisioned serverless-only and didn't have classic worker environments associated, partly due to a recent industry-wide supply-chain security incident affecting Python dependency provisioning |
+| Run the discovery from outside any Databricks workspace (laptop / external scheduler) | **Proven working** — the same service principal credentials, hitting the same MLflow API, return real trace data when the request originates outside Databricks compute. Operationally heavier (external scheduler, secret management). |
+| Engineering-only platform exception | Per-workspace-pair allowlist managed by the Databricks platform team. Bespoke per-customer engagement, not a feature customers can self-enable. Useful for one-off internal scenarios only. |
+| Wait for native platform-level customer control | A user-facing control for cross-workspace API access is on the Databricks platform roadmap. No public GA confirmation as of this RCA's update date. |
+
+## Decision
+
+Documented separately in the [companion ADR](../decisions/2026-04-29-cross-workspace-observability-pivot.md). Briefly: source cross-workspace observability data from Unity Catalog (AI Gateway request-logging tables and UC-stored MLflow OTel traces) instead of fanning out per-workspace REST API calls. UC is account-level and naturally cross-workspace queryable via SQL warehouse — no platform isolation to fight. The MLflow REST fan-out path is preserved on a feature branch to be re-enabled when the platform-level control ships.
+
+## Action items
+
+- [x] Confirm the root cause via direct probes from each runtime.
+- [x] Document the diagnostic matrix and the decision in the companion ADR.
+- [ ] Implement Tier 2 (Unity Catalog–sourced cross-workspace observability) — see ADR for scope.
+- [ ] Add an observability metric: alert when `workspaces_queried > workspaces_with_traces × N` to catch silent regressions of the same shape (cross-workspace fan-out reporting success but returning empty).
+- [ ] Document the deployment requirements for cross-workspace observability in the install guide.
+- [ ] Track the platform-level self-serve control on the Databricks roadmap; revisit the deferred MLflow REST fan-out path when it ships.

--- a/runners/README.md
+++ b/runners/README.md
@@ -1,0 +1,93 @@
+# External runners
+
+Scripts that run **outside** Databricks compute (laptop, GitHub Actions,
+self-hosted runner) to fill discovery gaps that the in-cloud workflow can't
+cover from Serverless / Apps Compute.
+
+## tier3_local.py — cross-workspace MLflow trace fan-out
+
+The default-backend MLflow trace path (Tier 3 in the architecture doc) calls
+each workspace's MLflow REST API directly. From Databricks Serverless it's
+blocked by the destination workspace's SNP filter; an external runner is not.
+
+### Prerequisites
+
+1. **Account membership/access on the workspaces you want to cover.** The
+   runner authenticates as the user; the user needs at least workspace USER
+   (and resource ACLs to read experiments) on each target workspace.
+2. **Account-level OAuth profile.** The script uses the user's account
+   profile. Set up once:
+   ```
+   databricks auth login --host https://accounts.cloud.databricks.com
+   ```
+   This creates a CLI profile (often named for your email) — pass it via
+   `--account-profile` or set `DATABRICKS_CONFIG_PROFILE`.
+3. **Lakebase config in env.** The runner writes to the same Lakebase
+   instance the in-cloud workflow uses. Source the app's `.env` first:
+   ```
+   source control-plane-app/.env
+   ```
+4. **Python deps.**
+   ```
+   pip install psycopg2-binary databricks-sdk requests
+   ```
+
+### Usage
+
+```bash
+# Smoke test: dry-run against 5 workspaces, no DB writes
+python runners/tier3_local.py --dry-run --max-workspaces 5
+
+# Single-workspace targeted run
+python runners/tier3_local.py --workspace-id 7474649325766269
+
+# Real run, all workspaces in the account, last 90 days
+python runners/tier3_local.py --retention-days 90
+
+# Larger workspace cap, lower concurrency for shaky networks
+python runners/tier3_local.py --concurrency 3 --max-traces-per-exp 500
+```
+
+Flags:
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--dry-run` | off | Don't write to Lakebase; print counts only. |
+| `--max-workspaces N` | 0 (no cap) | Limit fan-out to first N workspaces (testing). |
+| `--workspace-id ID` | — | Run against a single workspace_id only. |
+| `--retention-days N` | 90 | Trace recency window. |
+| `--max-experiments-per-ws N` | 50 | Cap per workspace. |
+| `--max-traces-per-exp N` | 200 | Cap per experiment. |
+| `--account-profile P` | env or `kaan...` | CLI profile to authenticate with. |
+| `--concurrency N` | 6 | Parallel workers. Lower for 429s. |
+
+### What lands in Lakebase
+
+Rows are upserted into `observability_traces` and
+`observability_trace_details` with `data_source = 'rest_fanout'` (so they're
+distinguishable from Tier 1's `rest_api`, Tier 2a's `gateway`, and Tier 2b's
+`uc_otel` / `uc_trace_logs`). The app's existing endpoints surface them
+without any code change.
+
+### Scheduling
+
+For a real Tier-3 setup you'd want this to run periodically. Two clean paths:
+
+- **GitHub Actions** — cron schedule, account-OAuth client credentials of
+  a service principal stored as repo secrets, runs on Actions runners which
+  are not Databricks Serverless and so aren't subject to the SNP filter.
+- **A self-hosted runner / launchd / systemd timer** on a host that has a
+  routable path to `*.cloud.databricks.com`.
+
+Both keep the data flow uniform (Lakebase upsert) so the rest of the app
+doesn't need to know whether traces came from in-cloud or external.
+
+### Caveats
+
+- **429s.** The MLflow REST API rate-limits aggressively at the account
+  level; default concurrency of 6 with backoff is conservative but you
+  may still see retries on big runs.
+- **Permissions.** A workspace where the user has no membership returns 403
+  silently; the runner counts it as an error and continues.
+- **Default-backend only.** This path doesn't add anything for UC-stored
+  traces — those are already covered by Tier 2b (UC SQL).

--- a/runners/README.md
+++ b/runners/README.md
@@ -29,8 +29,11 @@ blocked by the destination workspace's SNP filter; an external runner is not.
    ```
 4. **Python deps.**
    ```
-   pip install psycopg2-binary databricks-sdk requests
+   pip install psycopg2-binary databricks-sdk requests mlflow
    ```
+   The `mlflow` Python client is used to fetch full span data per trace —
+   the basic MLflow REST endpoint only returns trace_info, while spans
+   live in artifact storage and only the client knows how to assemble them.
 
 ### Usage
 

--- a/runners/tier3_local.py
+++ b/runners/tier3_local.py
@@ -253,6 +253,70 @@ def get_trace_detail(ws_host, token, request_id):
     return None, (code, str(body)[:200])
 
 
+# Span fetching uses the MLflow Python client because the basic REST trace
+# endpoint only returns trace_info; spans live in artifact storage and only
+# the client knows how to assemble them. The client reads auth from env
+# vars (DATABRICKS_HOST / DATABRICKS_TOKEN), which is global state — guard
+# with a lock so concurrent workspace workers don't clobber each other.
+_mlflow_lock = threading.Lock()
+
+
+def fetch_span_data(ws_host: str, token: str, request_id: str):
+    """Return (spans_list, request_str, response_str, error_str) for a trace.
+
+    Uses mlflow.MlflowClient.get_trace which transparently handles MLflow's
+    artifact-store fetch. Returns ([], "", "", err) on missing data — that
+    case is normal (failed agents may not persist spans)."""
+    try:
+        from mlflow.tracking import MlflowClient
+    except ImportError:
+        return [], "", "", "mlflow not installed"
+    with _mlflow_lock:
+        prev_host = os.environ.get("DATABRICKS_HOST")
+        prev_tok = os.environ.get("DATABRICKS_TOKEN")
+        prev_uri = os.environ.get("MLFLOW_TRACKING_URI")
+        os.environ["DATABRICKS_HOST"] = ws_host
+        os.environ["DATABRICKS_TOKEN"] = token
+        os.environ["MLFLOW_TRACKING_URI"] = "databricks"
+        try:
+            client = MlflowClient(tracking_uri="databricks")
+            try:
+                trace = client.get_trace(request_id)
+            except Exception as e:
+                return [], "", "", str(e)[:120]
+            if not trace or not getattr(trace, "data", None):
+                return [], "", "", "empty"
+            data = trace.data
+            spans = []
+            for s in (getattr(data, "spans", None) or []):
+                # Span objects expose to_dict() in MLflow 3.x; fall back to
+                # a hand-rolled projection of the public attributes.
+                if hasattr(s, "to_dict"):
+                    try:
+                        spans.append(s.to_dict()); continue
+                    except Exception: pass
+                spans.append({
+                    "name": getattr(s, "name", None),
+                    "span_id": getattr(s, "span_id", None),
+                    "parent_id": getattr(s, "parent_id", None),
+                    "start_time_ns": getattr(s, "start_time_ns", None),
+                    "end_time_ns": getattr(s, "end_time_ns", None),
+                    "span_type": getattr(s, "span_type", None),
+                    "status": str(getattr(s, "status", None)),
+                    "inputs": getattr(s, "inputs", None),
+                    "outputs": getattr(s, "outputs", None),
+                    "attributes": getattr(s, "attributes", None),
+                })
+            req = getattr(data, "request", "") or ""
+            resp = getattr(data, "response", "") or ""
+            return spans, req, resp, None
+        finally:
+            # Restore env vars so other (non-MLflow) code paths aren't poisoned.
+            for k, v in (("DATABRICKS_HOST", prev_host), ("DATABRICKS_TOKEN", prev_tok), ("MLFLOW_TRACKING_URI", prev_uri)):
+                if v is None: os.environ.pop(k, None)
+                else: os.environ[k] = v
+
+
 # ── Lakebase write ────────────────────────────────────────────────
 
 def get_lakebase_creds(profile=None):
@@ -364,10 +428,14 @@ def trace_to_rows(workspace_id, ws_name, exp_id, trace_obj, detail_obj):
     response_raw = ""
     response_preview = ""
     user_message = ""
+    # MLflow detail response is one of two shapes — `{trace_info, trace_data}`
+    # at top level (3.x) or `{trace: {trace_info, trace_data}}` (older). Try
+    # both so we don't drop spans for no good reason.
+    td_outer = {}
     if detail_obj:
-        td = detail_obj.get("trace_data") or {}
-        request_raw = info.get("request") or td.get("request") or ""
-        response_raw = info.get("response") or td.get("response") or ""
+        td_outer = detail_obj.get("trace_data") or (detail_obj.get("trace") or {}).get("trace_data") or {}
+        request_raw = info.get("request") or td_outer.get("request") or ""
+        response_raw = info.get("response") or td_outer.get("response") or ""
         response_preview = info.get("response_preview") or ""
 
     # MLflow REST exposes request/response as values inside request_metadata
@@ -410,7 +478,7 @@ def trace_to_rows(workspace_id, ws_name, exp_id, trace_obj, detail_obj):
     detail_row = None
     if detail_obj:
         ti_json = json.dumps(info)
-        td_json = json.dumps(detail_obj.get("trace_data") or {})
+        td_json = json.dumps(td_outer or {})
         size_bytes = len(ti_json) + len(td_json)
         detail_row = {
             "workspace_id": str(workspace_id),
@@ -538,12 +606,32 @@ def process_workspace(w, args, progress, sp_client_id, sp_client_secret):
             continue
         # Fetch detail (best-effort; on error we still include the slim row)
         detail, derr = get_trace_detail(ws_host, token, rid)
-        tr, dr = trace_to_rows(ws_id, ws_name, exp_id, t, detail or {})
+        # Fetch full span data via the MLflow Python client. Failures here
+        # are expected for traces whose agent crashed before persisting
+        # spans — emit a slim row anyway.
+        spans, req_full, resp_full, span_err = fetch_span_data(ws_host, token, rid)
+        # Splice the spans into the detail's trace_data so trace_to_rows /
+        # the existing detail-row builder picks them up uniformly.
+        if detail is None:
+            detail = {}
+        # Both shapes — top-level trace_data and nested under 'trace':
+        td_top = detail.get("trace_data") or {}
+        if not isinstance(td_top, dict): td_top = {}
+        if spans:
+            td_top["spans"] = spans
+        if req_full and not td_top.get("request"): td_top["request"] = req_full
+        if resp_full and not td_top.get("response"): td_top["response"] = resp_full
+        detail["trace_data"] = td_top
+        tr, dr = trace_to_rows(ws_id, ws_name, exp_id, t, detail)
         trace_rows.append(tr)
         if dr:
             detail_rows.append(dr)
         if derr:
             errors.append((ws_name, f"detail {derr[0]} for {rid[:24]}"))
+        if span_err and span_err not in ("empty",):
+            # Don't flood logs with the routine "missing span data" message.
+            if "missing span data" not in span_err:
+                errors.append((ws_name, f"spans: {span_err[:80]}"))
 
     written_t, written_d = (0, 0)
     if not args.dry_run and trace_rows:

--- a/runners/tier3_local.py
+++ b/runners/tier3_local.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""Tier-3 cross-workspace MLflow trace runner — runs locally to bypass the
+serverless cross-workspace SNP block.
+
+Authenticates with the user's account-OAuth credentials, fans out to each
+workspace's MLflow REST API to search experiments + traces, and writes the
+result into the same Lakebase observability tables that the in-cloud
+discovery workflow uses (with data_source = 'rest_fanout' to distinguish
+them from the Tier 1 / 2a / 2b paths).
+
+Why local: the SNP filter at each destination workspace rejects calls
+originating from Databricks Serverless / Apps Compute. An external runner
+(laptop, GH Actions) doesn't trigger the filter — auth still flows through
+account OAuth, so coverage matches the operator's permissions.
+
+Quick start:
+    pip install psycopg2-binary databricks-sdk requests
+    cd /path/to/agent-control-plane
+    source control-plane-app/.env                # for Lakebase config
+    export DATABRICKS_CONFIG_PROFILE=kaan.kuguoglu@databricks.com
+    python runners/tier3_local.py --dry-run --max-workspaces 5
+
+Real run:
+    python runners/tier3_local.py --retention-days 90
+
+Flags:
+    --dry-run               Don't write to Lakebase. Print counts only.
+    --max-workspaces N      Limit fan-out to first N workspaces (for testing).
+    --retention-days N      Trace recency window (default: 90).
+    --max-traces-per-exp N  Cap traces fetched per experiment (default: 200).
+    --account-profile P     Account-OAuth profile (default: env-or-DEFAULT).
+    --workspace-id WS_ID    Run against a single workspace_id only.
+    --concurrency N         Parallel workers (default: 6 — keep low for 429).
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import threading
+import urllib.error
+import urllib.request as ur
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone, timedelta
+
+# ── Config ────────────────────────────────────────────────────────
+
+DEFAULT_PROFILE = os.environ.get("DATABRICKS_CONFIG_PROFILE") or "kaan.kuguoglu@databricks.com"
+ACCOUNT_HOST = "https://accounts.cloud.databricks.com"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--max-workspaces", type=int, default=0, help="0 = no cap")
+    p.add_argument("--retention-days", type=int, default=90)
+    p.add_argument("--max-traces-per-exp", type=int, default=200)
+    p.add_argument("--max-experiments-per-ws", type=int, default=50)
+    p.add_argument("--account-profile", default=DEFAULT_PROFILE)
+    p.add_argument("--workspace-id", default=None)
+    p.add_argument("--concurrency", type=int, default=6)
+    # SP M2M auth (used for cross-workspace REST). Either pass via flags, env
+    # vars (ACP_SP_CLIENT_ID, ACP_SP_CLIENT_SECRET), or a Databricks secret
+    # scope where the runner reads them.
+    p.add_argument("--sp-client-id", default=os.environ.get("ACP_SP_CLIENT_ID"))
+    p.add_argument("--sp-client-secret", default=os.environ.get("ACP_SP_CLIENT_SECRET"))
+    p.add_argument("--sp-secret-profile", default="acp-sandbox",
+                   help="Databricks profile to read the SP creds from a secret scope.")
+    p.add_argument("--sp-secret-scope", default="acp-discovery")
+    return p.parse_args()
+
+
+def load_sp_creds(args):
+    """Resolve client_id + client_secret from flags / env / secret scope."""
+    cid = args.sp_client_id
+    csec = args.sp_client_secret
+    if cid and csec:
+        return cid, csec
+    # Fall back to a Databricks secret scope (default: 'acp-discovery' on sandbox).
+    # Secret values come back base64-encoded — decode before use.
+    import base64 as _b64
+    try:
+        for key, target in (("client_id", "cid"), ("client_secret", "csec")):
+            rc, out, err = cli(args.sp_secret_profile, ["secrets", "get-secret", args.sp_secret_scope, key, "--output", "json"])
+            if rc != 0:
+                continue
+            v = json.loads(out).get("value", "")
+            if not v:
+                continue
+            try:
+                decoded = _b64.b64decode(v).decode().strip()
+            except Exception:
+                decoded = v.strip()
+            if target == "cid": cid = decoded
+            else: csec = decoded
+    except Exception as e:
+        print(f"  (couldn't read secret scope: {e})")
+    if not cid or not csec:
+        sys.exit(
+            "Missing SP credentials. Either:\n"
+            "  - export ACP_SP_CLIENT_ID and ACP_SP_CLIENT_SECRET, or\n"
+            "  - keep them in a Databricks secret scope (default scope 'acp-discovery'\n"
+            "    on the 'acp-sandbox' profile, with keys client_id and client_secret).\n"
+        )
+    return cid, csec
+
+
+# ── Auth helpers ──────────────────────────────────────────────────
+
+def cli(profile, args):
+    p = subprocess.run(["databricks", "--profile", profile] + args,
+                       capture_output=True, text=True, timeout=30)
+    return p.returncode, p.stdout.strip(), p.stderr.strip()
+
+
+def get_account_token(profile):
+    """Returns the account-OAuth access token. Used for the account API
+    (workspace listing). NOT valid for workspace REST APIs — those need
+    token-exchange via the SDK's per-workspace client (see ws_token)."""
+    rc, out, err = cli(profile, ["auth", "token", "--output", "json"])
+    if rc != 0:
+        sys.exit(f"auth token fetch failed: {err}")
+    return json.loads(out)["access_token"]
+
+
+# Per-workspace token cache — minting a workspace-scoped token is non-trivial
+# (the SDK does it via OIDC token-exchange against the account host). Cache
+# tokens for ~30 min so we don't pay the cost on every API call.
+_ws_token_cache: dict = {}
+_ws_token_lock = threading.Lock()
+
+
+def ws_token(ws_host, sp_client_id, sp_client_secret):
+    """Mint a workspace-scoped token via SP M2M client_credentials flow.
+
+    POST {ws_host}/oidc/v1/token with HTTP Basic auth (client_id:client_secret)
+    yields an access_token accepted by that workspace's REST API. Tokens are
+    short-lived (~1h); cache for 30 min.
+    """
+    with _ws_token_lock:
+        cached = _ws_token_cache.get(ws_host)
+        if cached and cached[1] > time.time():
+            return cached[0], None
+    import base64
+    cred = base64.b64encode(f"{sp_client_id}:{sp_client_secret}".encode()).decode()
+    body = "grant_type=client_credentials&scope=all-apis"
+    req = ur.Request(
+        f"{ws_host}/oidc/v1/token",
+        data=body.encode(),
+        method="POST",
+        headers={
+            "Authorization": f"Basic {cred}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    try:
+        with ur.urlopen(req, timeout=15) as r:
+            d = json.loads(r.read().decode())
+            token = d.get("access_token")
+    except urllib.error.HTTPError as e:
+        try: msg = e.read().decode()[:200]
+        except Exception: msg = str(e.reason)
+        return None, f"{e.code} {msg}"
+    except Exception as e:
+        return None, str(e)[:120]
+    if not token:
+        return None, "empty token"
+    with _ws_token_lock:
+        _ws_token_cache[ws_host] = (token, time.time() + 1800)
+    return token, None
+
+
+def list_account_workspaces(profile):
+    rc, out, err = cli(profile, ["account", "workspaces", "list", "--output", "json"])
+    if rc != 0:
+        sys.exit(f"workspaces list failed: {err}")
+    return json.loads(out)
+
+
+# ── HTTP with backoff ─────────────────────────────────────────────
+
+def _do_request(method, url, token, body=None, max_retries=5, timeout=30):
+    delay = 1.0
+    for _ in range(max_retries):
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {"Authorization": f"Bearer {token}"}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        req = ur.Request(url, data=data, method=method, headers=headers)
+        try:
+            with ur.urlopen(req, timeout=timeout) as r:
+                txt = r.read().decode()
+                return r.status, (json.loads(txt) if txt else {})
+        except urllib.error.HTTPError as e:
+            if e.code in (429,) or e.code >= 500:
+                time.sleep(delay); delay = min(delay * 2, 30); continue
+            try: msg = e.read().decode()[:300]
+            except Exception: msg = str(e.reason)
+            return e.code, msg
+        except Exception:
+            time.sleep(delay); delay = min(delay * 2, 30); continue
+    return -1, "retries_exhausted"
+
+
+# ── MLflow API per workspace ──────────────────────────────────────
+
+def search_experiments(ws_host, token, max_results=50):
+    code, body = _do_request(
+        "POST", f"{ws_host}/api/2.0/mlflow/experiments/search", token,
+        body={"max_results": max_results, "order_by": ["last_update_time DESC"]},
+    )
+    if code == 200 and isinstance(body, dict):
+        return body.get("experiments", []), None
+    return [], (code, str(body)[:200])
+
+
+def search_traces(ws_host, token, experiment_ids, retention_days, max_results=200):
+    """`GET /api/2.0/mlflow/traces?experiment_ids=...&max_results=...` —
+    matches the endpoint the in-cloud workflow (04_discover_observability.py)
+    uses. The MLflow REST trace API takes one experiment_id at a time, so we
+    iterate and apply the retention filter client-side."""
+    cutoff_ms = int((datetime.now(timezone.utc) - timedelta(days=retention_days)).timestamp() * 1000)
+    import urllib.parse as up
+    out = []
+    for eid in experiment_ids:
+        qs = up.urlencode({"experiment_ids": eid, "max_results": max_results})
+        code, body = _do_request("GET", f"{ws_host}/api/2.0/mlflow/traces?{qs}", token)
+        if code != 200 or not isinstance(body, dict):
+            return out, (code, str(body)[:200])
+        for t in body.get("traces", []):
+            info = t.get("info") or t
+            ts = info.get("timestamp_ms") or t.get("timestamp_ms") or 0
+            try: ts = int(ts)
+            except Exception: ts = 0
+            if ts and ts < cutoff_ms:
+                continue
+            out.append(t)
+    return out, None
+
+
+def get_trace_detail(ws_host, token, request_id):
+    """MLflow 3.x trace fetch by request_id."""
+    # URL-encode the request_id since it may contain ':' / '/' (UC traces).
+    import urllib.parse as up
+    rid = up.quote(request_id, safe="")
+    code, body = _do_request(
+        "GET", f"{ws_host}/api/2.0/mlflow/traces/{rid}", token,
+    )
+    if code == 200 and isinstance(body, dict):
+        return body, None
+    return None, (code, str(body)[:200])
+
+
+# ── Lakebase write ────────────────────────────────────────────────
+
+def get_lakebase_creds(profile=None):
+    """Mint a Lakebase Postgres password using the same flow as
+    setup_lakebase_tables.py — works for both Autoscaling and Provisioned.
+
+    `profile` selects which Databricks workspace's API to call for
+    credential minting (must match the workspace that hosts the Lakebase
+    instance). Defaults to LAKEBASE_PROFILE env or 'acp-sandbox'."""
+    import requests
+    from databricks.sdk import WorkspaceClient
+    profile = profile or os.environ.get("LAKEBASE_PROFILE") or "acp-sandbox"
+    w = WorkspaceClient(profile=profile)
+    me = w.current_user.me()
+    pg_user = me.user_name
+    headers = w.config.authenticate()
+    token = headers["Authorization"].replace("Bearer ", "")
+    host = w.config.host.rstrip("/")
+    endpoint = os.environ.get("LAKEBASE_ENDPOINT_PATH", "")
+    instance = os.environ.get("LAKEBASE_INSTANCE", "")
+    if endpoint:
+        r = requests.post(f"{host}/api/2.0/postgres/credentials",
+                          headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                          json={"endpoint": endpoint})
+        r.raise_for_status()
+        return pg_user, r.json()["token"]
+    if instance:
+        r = requests.post(f"{host}/api/2.0/database/credentials",
+                          headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                          json={"instance_names": [instance], "request_id": str(uuid.uuid4())})
+        r.raise_for_status()
+        return pg_user, r.json()["token"]
+    sys.exit("Set LAKEBASE_ENDPOINT_PATH (Autoscaling) or LAKEBASE_INSTANCE (Provisioned).")
+
+
+def lakebase_connection():
+    import psycopg2
+    user, password = get_lakebase_creds()
+    conn = psycopg2.connect(
+        host=os.environ["LAKEBASE_DNS"],
+        port=5432,
+        database=os.environ.get("LAKEBASE_DATABASE", "control_plane"),
+        user=user,
+        password=password,
+        sslmode="require",
+    )
+    return conn
+
+
+# ── Per-trace projection into Lakebase rows ───────────────────────
+
+def trace_to_rows(workspace_id, ws_name, exp_id, trace_obj, detail_obj):
+    """Project an MLflow trace (search hit + detail) into the
+    (observability_traces, observability_trace_details) row shapes used by
+    02_sync_to_lakebase.py — but with data_source='rest_fanout'.
+
+    The MLflow REST `/api/2.0/mlflow/traces` response uses flat top-level
+    keys (no `info` wrapper); the detail call's response uses
+    `{trace: {trace_info: {...}, trace_data: {...}}}`. We accept both.
+    """
+    # Flat fallbacks: a search hit IS the info dict.
+    info = trace_obj.get("info") or trace_obj or {}
+    if detail_obj:
+        # Prefer detail's trace_info when richer (it carries trace_metadata),
+        # but the search hit's primitive numeric fields are more reliable —
+        # detail sometimes returns execution_time as "0s"-style duration
+        # strings from MLflow 3.x. Merge but let the search hit win for keys
+        # that already had a value.
+        di = (detail_obj.get("trace") or {}).get("trace_info") or detail_obj.get("trace_info") or {}
+        if di:
+            merged = dict(di)
+            merged.update({k: v for k, v in info.items() if v not in (None, "", 0)})
+            info = merged
+    request_id = info.get("request_id") or ""
+
+    def _to_int(v):
+        if v is None or v == "": return None
+        try: return int(v)
+        except (TypeError, ValueError):
+            # MLflow 3.x sometimes returns durations like "0s" or "5.7s"
+            if isinstance(v, str) and v.endswith("s"):
+                try: return int(float(v[:-1]) * 1000)
+                except Exception: return None
+            return None
+
+    ts = _to_int(info.get("timestamp_ms")) or _to_int(info.get("request_time"))
+    duration = _to_int(info.get("execution_time_ms")) or _to_int(info.get("execution_duration"))
+    state = info.get("status") or info.get("state") or ""
+    # tags / request_metadata can be list of {key,value} (REST) or dict (cache)
+    tags = info.get("tags") or {}
+    if isinstance(tags, list):
+        tags = {t.get("key", ""): t.get("value", "") for t in tags if isinstance(t, dict)}
+    trace_name = (tags.get("mlflow.traceName") if isinstance(tags, dict) else "") or ""
+    # Token usage / model id from request_metadata (MLflow 3.x list-of-pairs)
+    meta = info.get("request_metadata") or info.get("trace_metadata") or info.get("metadata") or {}
+    if isinstance(meta, list):
+        meta = {m.get("key", ""): m.get("value", "") for m in meta if isinstance(m, dict)}
+    tu_str = meta.get("mlflow.trace.tokenUsage") if isinstance(meta, dict) else None
+    try:
+        tu_obj = json.loads(tu_str) if isinstance(tu_str, str) else (tu_str or {})
+    except Exception:
+        tu_obj = {}
+    model_id = meta.get("mlflow.modelId") if isinstance(meta, dict) else None
+    user = meta.get("mlflow.user") if isinstance(meta, dict) else None
+    source = meta.get("mlflow.source.name") if isinstance(meta, dict) else None
+
+    # Best-effort user_message/response_preview from the detail object.
+    request_raw = ""
+    response_raw = ""
+    response_preview = ""
+    user_message = ""
+    if detail_obj:
+        td = detail_obj.get("trace_data") or {}
+        request_raw = info.get("request") or td.get("request") or ""
+        response_raw = info.get("response") or td.get("response") or ""
+        response_preview = info.get("response_preview") or ""
+
+    # MLflow REST exposes request/response as values inside request_metadata
+    # rather than as top-level fields. Pull them out so the dedicated columns
+    # (`user_message`, `response_preview`, `request_raw`, `response_raw`) get
+    # populated for Tier-3 rows the same way Tier-1/2 rows do.
+    if isinstance(meta, dict):
+        meta_req = meta.get("mlflow.trace.request") or ""
+        meta_resp = meta.get("mlflow.trace.response") or ""
+        if not user_message and meta_req:
+            user_message = meta_req
+        if not request_raw and meta_req:
+            request_raw = meta_req
+        if not response_raw and meta_resp:
+            response_raw = meta_resp
+        # Build a readable response preview if we don't have one yet —
+        # capped so the slim list row stays small.
+        if not response_preview and meta_resp:
+            response_preview = meta_resp[:1000]
+
+    trace_row = {
+        "request_id": request_id,
+        "workspace_id": str(workspace_id),
+        "experiment_id": str(exp_id),
+        "trace_name": trace_name,
+        "state": state,
+        "request_time": str(ts) if ts is not None else "",
+        "execution_duration": duration,
+        "user_message": user_message,
+        "response_preview": response_preview,
+        "token_usage": json.dumps(tu_obj),
+        "model_id": model_id or "",
+        "session_id": (meta.get("mlflow.trace.session") if isinstance(meta, dict) else "") or "",
+        "trace_user": user or "",
+        "source": source or "",
+        "tags": json.dumps(tags) if isinstance(tags, dict) else "{}",
+        "data_source": "rest_fanout",
+    }
+
+    detail_row = None
+    if detail_obj:
+        ti_json = json.dumps(info)
+        td_json = json.dumps(detail_obj.get("trace_data") or {})
+        size_bytes = len(ti_json) + len(td_json)
+        detail_row = {
+            "workspace_id": str(workspace_id),
+            "request_id": request_id,
+            "experiment_id": str(exp_id),
+            "trace_info": ti_json,
+            "trace_data": td_json,
+            "request_raw": request_raw,
+            "response_raw": response_raw,
+            "size_bytes": size_bytes,
+            "source_type": "rest_fanout",
+        }
+
+    return trace_row, detail_row
+
+
+def upsert_lakebase(trace_rows, detail_rows):
+    if not trace_rows and not detail_rows:
+        return 0, 0
+    import psycopg2.extras
+    conn = lakebase_connection()
+    now = datetime.now(timezone.utc)
+    n_traces = 0
+    n_details = 0
+    try:
+        with conn.cursor() as cur:
+            if trace_rows:
+                vals = [
+                    (
+                        r["request_id"], r["workspace_id"], r["experiment_id"],
+                        r["trace_name"], r["state"], r["request_time"],
+                        r["execution_duration"], r["user_message"], r["response_preview"],
+                        r["token_usage"], r["model_id"], r["session_id"],
+                        r["trace_user"], r["source"], r["tags"], r["data_source"], now,
+                    )
+                    for r in trace_rows if r["request_id"]
+                ]
+                psycopg2.extras.execute_values(cur, """
+                    INSERT INTO observability_traces
+                       (request_id, workspace_id, experiment_id, trace_name, state,
+                        request_time, execution_duration, user_message, response_preview,
+                        token_usage, model_id, session_id, trace_user, source, tags,
+                        data_source, last_synced)
+                    VALUES %s
+                    ON CONFLICT (workspace_id, request_id) DO UPDATE SET
+                        trace_name = EXCLUDED.trace_name, state = EXCLUDED.state,
+                        request_time = EXCLUDED.request_time,
+                        execution_duration = EXCLUDED.execution_duration,
+                        user_message = EXCLUDED.user_message,
+                        response_preview = EXCLUDED.response_preview,
+                        token_usage = EXCLUDED.token_usage,
+                        model_id = EXCLUDED.model_id, session_id = EXCLUDED.session_id,
+                        trace_user = EXCLUDED.trace_user, source = EXCLUDED.source,
+                        tags = EXCLUDED.tags, data_source = EXCLUDED.data_source,
+                        last_synced = EXCLUDED.last_synced
+                """, vals, page_size=100)
+                n_traces = len(vals)
+            if detail_rows:
+                vals = [
+                    (
+                        r["workspace_id"], r["request_id"], r["experiment_id"],
+                        r["trace_info"], r["trace_data"], r["request_raw"],
+                        r["response_raw"], r["size_bytes"], r["source_type"], now,
+                    )
+                    for r in detail_rows if r["request_id"]
+                ]
+                psycopg2.extras.execute_values(cur, """
+                    INSERT INTO observability_trace_details
+                       (workspace_id, request_id, experiment_id, trace_info, trace_data,
+                        request_raw, response_raw, size_bytes, source_type, cached_at)
+                    VALUES %s
+                    ON CONFLICT (workspace_id, request_id) DO UPDATE SET
+                        experiment_id = EXCLUDED.experiment_id,
+                        trace_info = EXCLUDED.trace_info,
+                        trace_data = EXCLUDED.trace_data,
+                        request_raw = EXCLUDED.request_raw,
+                        response_raw = EXCLUDED.response_raw,
+                        size_bytes = EXCLUDED.size_bytes,
+                        source_type = EXCLUDED.source_type,
+                        cached_at = EXCLUDED.cached_at
+                """, vals, page_size=50)
+                n_details = len(vals)
+            conn.commit()
+    finally:
+        conn.close()
+    return n_traces, n_details
+
+
+# ── Per-workspace processing ──────────────────────────────────────
+
+def process_workspace(w, args, progress, sp_client_id, sp_client_secret):
+    """Returns (workspace_id, n_experiments, n_traces, errors)."""
+    ws_id = str(w.get("workspace_id") or "")
+    deployment = w.get("deployment_name") or ""
+    ws_name = w.get("workspace_name") or ws_id
+    if not deployment:
+        return ws_id, 0, 0, [(ws_name, "no deployment_name")]
+    ws_host = f"https://{deployment}.cloud.databricks.com"
+    errors = []
+
+    # Mint a workspace-scoped token via the SP's M2M client_credentials flow.
+    token, err = ws_token(ws_host, sp_client_id, sp_client_secret)
+    if not token:
+        return ws_id, 0, 0, [(ws_name, f"token-exchange: {err}")]
+
+    exps, err = search_experiments(ws_host, token, max_results=args.max_experiments_per_ws)
+    if err:
+        return ws_id, 0, 0, [(ws_name, f"search_experiments {err[0]}: {err[1]}")]
+    if not exps:
+        return ws_id, 0, 0, []
+
+    # Search traces across all this workspace's experiments in one call
+    exp_ids = [str(e.get("experiment_id")) for e in exps if e.get("experiment_id")]
+    traces, err = search_traces(ws_host, token, exp_ids,
+                                args.retention_days, max_results=args.max_traces_per_exp)
+    if err:
+        return ws_id, len(exps), 0, [(ws_name, f"search_traces {err[0]}: {err[1]}")]
+
+    trace_rows, detail_rows = [], []
+    for t in traces:
+        info = t.get("info") or t
+        rid = info.get("request_id") or t.get("request_id")
+        exp_id = info.get("experiment_id") or t.get("experiment_id") or ""
+        if not rid:
+            continue
+        # Fetch detail (best-effort; on error we still include the slim row)
+        detail, derr = get_trace_detail(ws_host, token, rid)
+        tr, dr = trace_to_rows(ws_id, ws_name, exp_id, t, detail or {})
+        trace_rows.append(tr)
+        if dr:
+            detail_rows.append(dr)
+        if derr:
+            errors.append((ws_name, f"detail {derr[0]} for {rid[:24]}"))
+
+    written_t, written_d = (0, 0)
+    if not args.dry_run and trace_rows:
+        written_t, written_d = upsert_lakebase(trace_rows, detail_rows)
+
+    progress.tick(ws_name, len(exps), len(trace_rows), written_t, written_d)
+    return ws_id, len(exps), len(trace_rows), errors
+
+
+class Progress:
+    def __init__(self, total):
+        self.total = total
+        self.done = 0
+        self.lock = threading.Lock()
+    def tick(self, ws_name, n_exps, n_traces, w_t, w_d):
+        with self.lock:
+            self.done += 1
+            tag = f"[{self.done:>3d}/{self.total}]"
+            mark = "·" if n_traces == 0 else "✓"
+            print(f"  {tag} {mark} {ws_name[:48]:<48s}  exps={n_exps:>3d}  traces={n_traces:>4d}  wrote={w_t}/{w_d}")
+
+
+def main():
+    args = parse_args()
+    # Account API (workspaces list) uses the user's account-OAuth profile.
+    # Workspace REST APIs use SP M2M tokens minted per-workspace.
+    sp_cid, sp_csec = load_sp_creds(args)
+    print(f"sp      : {sp_cid[:8]}…  (M2M client_credentials)")
+
+    if args.workspace_id:
+        # Targeted run — just one workspace
+        all_ws = list_account_workspaces(args.account_profile)
+        workspaces = [w for w in all_ws if str(w.get("workspace_id")) == str(args.workspace_id)]
+        if not workspaces:
+            sys.exit(f"workspace_id {args.workspace_id} not found in account")
+    else:
+        workspaces = list_account_workspaces(args.account_profile)
+        if args.max_workspaces:
+            workspaces = workspaces[:args.max_workspaces]
+
+    print(f"profile : {args.account_profile}")
+    print(f"target  : {len(workspaces)} workspaces")
+    print(f"window  : {args.retention_days}d  cap/exp: {args.max_traces_per_exp}  exps/ws: {args.max_experiments_per_ws}")
+    print(f"dry-run : {args.dry_run}\n")
+
+    progress = Progress(len(workspaces))
+    total_exps = 0; total_traces = 0; all_errors = []
+    t0 = time.time()
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = [pool.submit(process_workspace, w, args, progress, sp_cid, sp_csec) for w in workspaces]
+        for fut in as_completed(futures):
+            try:
+                ws_id, n_exps, n_traces, errors = fut.result()
+                total_exps += n_exps
+                total_traces += n_traces
+                all_errors.extend(errors)
+            except Exception as e:
+                import traceback as _tb
+                all_errors.append(("?", f"unexpected: {e}\n{_tb.format_exc()[:1500]}"))
+    print(f"\ndone in {time.time()-t0:.1f}s")
+    print(f"experiments scanned : {total_exps}")
+    print(f"traces collected    : {total_traces}")
+    print(f"errors              : {len(all_errors)}")
+    if all_errors[:8]:
+        from collections import Counter
+        c = Counter(msg.split(" ")[0] for _, msg in all_errors)
+        print(f"  by status: {dict(c.most_common(8))}")
+        for ws, msg in all_errors[:5]:
+            print(f"  - {ws[:40]}  {msg}")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -935,6 +935,10 @@ with obs_conn.cursor() as cur:
     """)
     # Extracted-payload columns — populated at sync time by parsing the JSON
     # payload bodies. Best-effort across vendor shapes (OpenAI/Anthropic/etc.).
+    # Each ALTER runs in its own savepoint so a single column failure
+    # doesn't poison the surrounding transaction (psycopg2 does not auto-
+    # rollback on caught exceptions, and any subsequent statement on the
+    # same cursor would otherwise hit InFailedSqlTransaction).
     for col_ddl in (
         "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS model TEXT",
         "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS input_tokens BIGINT",
@@ -943,8 +947,14 @@ with obs_conn.cursor() as cur:
         "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS finish_reason TEXT",
         "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS tool_call_count INTEGER",
     ):
-        try: cur.execute(col_ddl)
-        except Exception as e: print(f"  gw col DDL warn: {e}")
+        try:
+            cur.execute("SAVEPOINT gw_col_sp")
+            cur.execute(col_ddl)
+            cur.execute("RELEASE SAVEPOINT gw_col_sp")
+        except Exception as e:
+            try: cur.execute("ROLLBACK TO SAVEPOINT gw_col_sp")
+            except Exception: pass
+            print(f"  gw col DDL warn: {e}")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_time   ON gateway_inference_logs (request_time DESC)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_source ON gateway_inference_logs (source_table)")
     cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_status ON gateway_inference_logs (status_code)")

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -508,18 +508,61 @@ except Exception as exc:
 # COMMAND ----------
 
 TRACES_DELTA = f"{CATALOG}.{SCHEMA}.observability_traces"
+TRACE_DETAILS_DELTA = f"{CATALOG}.{SCHEMA}.observability_trace_details"
+TRACES_UC_OTEL_DELTA = f"{CATALOG}.{SCHEMA}.observability_traces_uc_otel"
+TRACE_DETAILS_UC_OTEL_DELTA = f"{CATALOG}.{SCHEMA}.observability_trace_details_uc_otel"
 trace_count = 0
+trace_detail_count = 0
 
 print(f"▸ Reading traces from Delta: {TRACES_DELTA} ...")
 try:
     traces_df = spark.read.table(TRACES_DELTA)
     delta_trace_count = traces_df.count()
-    print(f"  ✅ {delta_trace_count} traces in Delta table")
+    print(f"  ✅ {delta_trace_count} traces in Delta table (default-backend, REST)")
     delta_traces = traces_df.collect()
 except Exception as exc:
     print(f"  ⚠️  Could not read traces Delta table: {exc}")
     delta_traces = []
     delta_trace_count = 0
+
+print(f"▸ Reading UC-OTel traces from Delta: {TRACES_UC_OTEL_DELTA} ...")
+try:
+    uc_traces_df = spark.read.table(TRACES_UC_OTEL_DELTA)
+    delta_uc_trace_count = uc_traces_df.count()
+    print(f"  ✅ {delta_uc_trace_count} traces in Delta table (Tier 2b: UC OTel)")
+    delta_uc_traces = uc_traces_df.collect()
+except Exception as exc:
+    print(f"  ⚠️  Could not read UC OTel traces Delta table: {exc}")
+    delta_uc_traces = []
+    delta_uc_trace_count = 0
+
+print(f"▸ Reading trace details from Delta: {TRACE_DETAILS_DELTA} ...")
+try:
+    details_df = spark.read.table(TRACE_DETAILS_DELTA)
+    delta_detail_count = details_df.count()
+    print(f"  ✅ {delta_detail_count} trace details in Delta table (default-backend, REST)")
+    delta_trace_details = details_df.collect()
+except Exception as exc:
+    print(f"  ⚠️  Could not read trace details Delta table: {exc}")
+    delta_trace_details = []
+    delta_detail_count = 0
+
+print(f"▸ Reading UC-OTel trace details from Delta: {TRACE_DETAILS_UC_OTEL_DELTA} ...")
+try:
+    uc_details_df = spark.read.table(TRACE_DETAILS_UC_OTEL_DELTA)
+    delta_uc_detail_count = uc_details_df.count()
+    print(f"  ✅ {delta_uc_detail_count} trace details in Delta table (Tier 2b: UC OTel)")
+    delta_uc_trace_details = uc_details_df.collect()
+except Exception as exc:
+    print(f"  ⚠️  Could not read UC OTel trace details Delta table: {exc}")
+    delta_uc_trace_details = []
+    delta_uc_detail_count = 0
+
+# Combine REST and UC OTel rows for the upsert path below — both go to the
+# same Lakebase tables, with `data_source`/`source_type` distinguishing them.
+delta_traces = list(delta_traces) + list(delta_uc_traces)
+delta_trace_details = list(delta_trace_details) + list(delta_uc_trace_details)
+print(f"▸ Combined: {len(delta_traces)} trace rows, {len(delta_trace_details)} detail rows for Lakebase upsert")
 
 # COMMAND ----------
 
@@ -572,6 +615,15 @@ with obs_conn.cursor() as cur:
         "CREATE INDEX IF NOT EXISTS idx_ot_ws ON observability_traces (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_ot_time ON observability_traces (request_time DESC)",
         "ALTER TABLE observability_traces ADD COLUMN IF NOT EXISTS data_source TEXT DEFAULT 'rest_api'",
+        """CREATE TABLE IF NOT EXISTS observability_trace_details (
+            workspace_id TEXT NOT NULL, request_id TEXT NOT NULL,
+            experiment_id TEXT, trace_info JSONB, trace_data JSONB,
+            request_raw TEXT, response_raw TEXT,
+            size_bytes INTEGER, source_type TEXT,
+            cached_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (workspace_id, request_id))""",
+        "CREATE INDEX IF NOT EXISTS idx_otd_ws     ON observability_trace_details (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_otd_cached ON observability_trace_details (cached_at DESC)",
     ]:
         try:
             cur.execute(ddl)
@@ -688,13 +740,68 @@ print(f"✅ Upserted {run_count} runs (system_table)")
 # COMMAND ----------
 
 # Upsert traces (from Delta table populated by discover_observability task)
+# We enrich each slim trace row with fields parsed from the matching detail
+# row's trace_info JSON — token_usage, user_message, response_preview — so the
+# list endpoint surfaces them without an extra JSONB read per row.
 trace_count = 0
+
+# Build a lookup of detail rows by request_id (UC traces have empty workspace_id,
+# default-backend traces are scoped — request_id is unique enough either way).
+details_by_rid: dict = {}
+for d in delta_trace_details:
+    if d.request_id:
+        details_by_rid[d.request_id] = d
+
+
+def _enrich_from_trace_info(rid: str) -> tuple:
+    """Return (token_usage_json, user_message, response_preview) for a trace."""
+    d = details_by_rid.get(rid)
+    if not d:
+        return ("{}", "", "")
+    ti_raw = d.trace_info or "{}"
+    try:
+        ti = json.loads(ti_raw) if isinstance(ti_raw, str) else (ti_raw or {})
+    except Exception:
+        ti = {}
+    meta = ti.get("trace_metadata") or {}
+    # token_usage lives under trace_metadata as a JSON-string value
+    tu_str = meta.get("mlflow.trace.tokenUsage") or "{}"
+    try:
+        tu_obj = json.loads(tu_str) if isinstance(tu_str, str) else (tu_str or {})
+    except Exception:
+        tu_obj = {}
+    tu_json = json.dumps(tu_obj) if isinstance(tu_obj, dict) else "{}"
+    # Best-effort user message + response preview — populated by the parser for
+    # default-backend traces (request_preview tag) and explicitly for UC traces.
+    user_msg = ti.get("request_preview") or ""
+    if not user_msg:
+        # Fallback: pull first user-role text from the parsed request payload
+        req_raw = d.request_raw or ""
+        try:
+            req_parsed = json.loads(req_raw) if req_raw else {}
+            for inp in (req_parsed.get("input") or []):
+                if isinstance(inp, dict) and inp.get("role") == "user":
+                    c = inp.get("content")
+                    if isinstance(c, str):
+                        user_msg = c; break
+                    if isinstance(c, list):
+                        for piece in c:
+                            if isinstance(piece, dict) and piece.get("text"):
+                                user_msg = piece["text"]; break
+                        if user_msg: break
+        except Exception:
+            pass
+    resp_preview = ti.get("response_preview") or ""
+    return (tu_json, user_msg or "", resp_preview or "")
+
+
 if delta_traces:
     trace_values = []
     for r in delta_traces:
         rid = r.request_id
         if not rid:
             continue
+        token_usage_json, user_msg, resp_preview = _enrich_from_trace_info(rid)
         trace_values.append((
             rid,
             r.workspace_id or "",
@@ -703,7 +810,9 @@ if delta_traces:
             r.state or "",
             r.request_time or "",
             r.execution_duration,
-            json.dumps({}),  # token_usage
+            user_msg,
+            resp_preview,
+            token_usage_json,
             r.model_id or "",
             r.session_id or "",
             r.trace_user or "",
@@ -717,12 +826,14 @@ if delta_traces:
             cur,
             """INSERT INTO observability_traces
                (request_id, workspace_id, experiment_id, trace_name, state,
-                request_time, execution_duration, token_usage, model_id,
-                session_id, trace_user, source, tags, data_source, last_synced)
+                request_time, execution_duration, user_message, response_preview,
+                token_usage, model_id, session_id, trace_user, source, tags,
+                data_source, last_synced)
                VALUES %s
                ON CONFLICT (workspace_id, request_id) DO UPDATE SET
                    trace_name = EXCLUDED.trace_name, state = EXCLUDED.state,
                    request_time = EXCLUDED.request_time, execution_duration = EXCLUDED.execution_duration,
+                   user_message = EXCLUDED.user_message, response_preview = EXCLUDED.response_preview,
                    token_usage = EXCLUDED.token_usage, model_id = EXCLUDED.model_id,
                    session_id = EXCLUDED.session_id, trace_user = EXCLUDED.trace_user,
                    source = EXCLUDED.source, tags = EXCLUDED.tags,
@@ -731,7 +842,217 @@ if delta_traces:
         )
         obs_conn.commit()
         trace_count = len(trace_values)
-print(f"✅ Upserted {trace_count} traces (from Delta)")
+print(f"✅ Upserted {trace_count} traces (from Delta, enriched from trace_info)")
+
+# COMMAND ----------
+
+# Upsert trace details (full spans + payloads) for cross-workspace cache.
+# Note: UC-OTel traces have empty workspace_id (UC data is account-level, not
+# workspace-scoped); we accept empty workspace_id here since the URI-form
+# request_id is globally unique on its own.
+if delta_trace_details:
+    detail_values = []
+    for r in delta_trace_details:
+        rid = r.request_id
+        if not rid:
+            continue
+        ws_id = r.workspace_id or ""
+        detail_values.append((
+            ws_id,
+            rid,
+            r.experiment_id or "",
+            r.trace_info or "{}",
+            r.trace_data or "{}",
+            r.request_raw or "",
+            r.response_raw or "",
+            int(r.size_bytes or 0),
+            r.source_type or "mlflow_rest",
+            now,
+        ))
+    if detail_values:
+        with obs_conn.cursor() as cur:
+            execute_values(
+                cur,
+                """INSERT INTO observability_trace_details
+                   (workspace_id, request_id, experiment_id, trace_info, trace_data,
+                    request_raw, response_raw, size_bytes, source_type, cached_at)
+                   VALUES %s
+                   ON CONFLICT (workspace_id, request_id) DO UPDATE SET
+                       experiment_id = EXCLUDED.experiment_id,
+                       trace_info = EXCLUDED.trace_info,
+                       trace_data = EXCLUDED.trace_data,
+                       request_raw = EXCLUDED.request_raw,
+                       response_raw = EXCLUDED.response_raw,
+                       size_bytes = EXCLUDED.size_bytes,
+                       source_type = EXCLUDED.source_type,
+                       cached_at = EXCLUDED.cached_at""",
+                detail_values, page_size=50,
+            )
+            obs_conn.commit()
+            trace_detail_count = len(detail_values)
+print(f"✅ Upserted {trace_detail_count} trace details (from Delta)")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Phase 2c: Sync AI Gateway / Inference Logs (Tier 2a, Delta → Lakebase)
+
+# COMMAND ----------
+
+GATEWAY_LOGS_DELTA = f"{CATALOG}.{SCHEMA}.gateway_inference_logs"
+gw_log_count = 0
+
+print(f"▸ Reading inference logs from Delta: {GATEWAY_LOGS_DELTA} ...")
+try:
+    gw_logs_df = spark.read.table(GATEWAY_LOGS_DELTA)
+    gw_log_delta_count = gw_logs_df.count()
+    print(f"  ✅ {gw_log_delta_count} inference-log rows in Delta")
+    gw_log_rows = gw_logs_df.collect()
+except Exception as exc:
+    print(f"  ⚠️  Could not read inference logs Delta: {exc}")
+    gw_log_rows = []
+    gw_log_delta_count = 0
+
+# Ensure Lakebase target table
+with obs_conn.cursor() as cur:
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS gateway_inference_logs (
+            request_id          TEXT NOT NULL,
+            source_table        TEXT NOT NULL,
+            client_request_id   TEXT,
+            request_time        TIMESTAMP WITH TIME ZONE,
+            status_code         INTEGER,
+            execution_ms        BIGINT,
+            request_payload     TEXT,
+            response_payload    TEXT,
+            request_size_bytes  BIGINT,
+            response_size_bytes BIGINT,
+            served_entity_id    TEXT,
+            requester           TEXT,
+            last_synced         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (source_table, request_id)
+        )
+    """)
+    # Extracted-payload columns — populated at sync time by parsing the JSON
+    # payload bodies. Best-effort across vendor shapes (OpenAI/Anthropic/etc.).
+    for col_ddl in (
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS model TEXT",
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS input_tokens BIGINT",
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS output_tokens BIGINT",
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS total_tokens BIGINT",
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS finish_reason TEXT",
+        "ALTER TABLE gateway_inference_logs ADD COLUMN IF NOT EXISTS tool_call_count INTEGER",
+    ):
+        try: cur.execute(col_ddl)
+        except Exception as e: print(f"  gw col DDL warn: {e}")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_time   ON gateway_inference_logs (request_time DESC)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_source ON gateway_inference_logs (source_table)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_status ON gateway_inference_logs (status_code)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_gil_model  ON gateway_inference_logs (model)")
+    obs_conn.commit()
+
+
+def _parse_gateway_payload(req_raw: str, resp_raw: str) -> dict:
+    """Best-effort extraction of model + token usage + finish reason.
+
+    Handles OpenAI-style (`response.model`, `response.usage.{prompt,completion,total}_tokens`)
+    and Anthropic-passthrough variants (`completion_tokens` ↔ `output_tokens`).
+    Returns dict with keys: model, input_tokens, output_tokens, total_tokens,
+    finish_reason, tool_call_count. Any field missing is None.
+    """
+    out = {"model": None, "input_tokens": None, "output_tokens": None,
+           "total_tokens": None, "finish_reason": None, "tool_call_count": None}
+    try:
+        rj = json.loads(req_raw) if req_raw else {}
+    except Exception:
+        rj = {}
+    try:
+        sj = json.loads(resp_raw) if resp_raw else {}
+    except Exception:
+        sj = {}
+    # Model: response.model > request.model
+    out["model"] = sj.get("model") or rj.get("model")
+    # Usage: support both OpenAI shape and Anthropic-passthrough shape
+    usage = sj.get("usage") or {}
+    if isinstance(usage, dict):
+        out["input_tokens"]  = usage.get("prompt_tokens") or usage.get("input_tokens")
+        out["output_tokens"] = usage.get("completion_tokens") or usage.get("output_tokens")
+        out["total_tokens"]  = usage.get("total_tokens")
+        if out["total_tokens"] is None and (out["input_tokens"] or out["output_tokens"]):
+            out["total_tokens"] = (out["input_tokens"] or 0) + (out["output_tokens"] or 0)
+    # Finish reason + tool call count from first choice
+    choices = sj.get("choices")
+    if isinstance(choices, list) and choices:
+        c0 = choices[0] or {}
+        out["finish_reason"] = c0.get("finish_reason")
+        msg = c0.get("message") or {}
+        tcs = msg.get("tool_calls") or []
+        if isinstance(tcs, list):
+            out["tool_call_count"] = len(tcs)
+    return out
+
+if gw_log_rows:
+    values = []
+    for r in gw_log_rows:
+        rid = r.request_id
+        src = r.source_table
+        if not rid or not src:
+            continue
+        parsed = _parse_gateway_payload(r.request_payload or "", r.response_payload or "")
+        values.append((
+            rid, src,
+            r.client_request_id,
+            r.request_time,
+            int(r.status_code) if r.status_code is not None else None,
+            int(r.execution_ms) if r.execution_ms is not None else None,
+            r.request_payload,
+            r.response_payload,
+            int(r.request_size_bytes) if r.request_size_bytes is not None else None,
+            int(r.response_size_bytes) if r.response_size_bytes is not None else None,
+            r.served_entity_id,
+            r.requester,
+            parsed["model"],
+            parsed["input_tokens"],
+            parsed["output_tokens"],
+            parsed["total_tokens"],
+            parsed["finish_reason"],
+            parsed["tool_call_count"],
+            now,
+        ))
+    if values:
+        with obs_conn.cursor() as cur:
+            execute_values(
+                cur,
+                """INSERT INTO gateway_inference_logs
+                   (request_id, source_table, client_request_id, request_time,
+                    status_code, execution_ms, request_payload, response_payload,
+                    request_size_bytes, response_size_bytes, served_entity_id,
+                    requester, model, input_tokens, output_tokens, total_tokens,
+                    finish_reason, tool_call_count, last_synced)
+                   VALUES %s
+                   ON CONFLICT (source_table, request_id) DO UPDATE SET
+                       client_request_id = EXCLUDED.client_request_id,
+                       request_time = EXCLUDED.request_time,
+                       status_code = EXCLUDED.status_code,
+                       execution_ms = EXCLUDED.execution_ms,
+                       request_payload = EXCLUDED.request_payload,
+                       response_payload = EXCLUDED.response_payload,
+                       request_size_bytes = EXCLUDED.request_size_bytes,
+                       response_size_bytes = EXCLUDED.response_size_bytes,
+                       served_entity_id = EXCLUDED.served_entity_id,
+                       requester = EXCLUDED.requester,
+                       model = EXCLUDED.model,
+                       input_tokens = EXCLUDED.input_tokens,
+                       output_tokens = EXCLUDED.output_tokens,
+                       total_tokens = EXCLUDED.total_tokens,
+                       finish_reason = EXCLUDED.finish_reason,
+                       tool_call_count = EXCLUDED.tool_call_count,
+                       last_synced = EXCLUDED.last_synced""",
+                values, page_size=200,
+            )
+            obs_conn.commit()
+            gw_log_count = len(values)
+print(f"✅ Upserted {gw_log_count} gateway inference-log rows (from Delta, payload-enriched)")
 
 # COMMAND ----------
 
@@ -1158,7 +1479,13 @@ result = {
     "observability_experiments": exp_count,
     "observability_runs": run_count,
     "observability_traces": trace_count,
-    "traces_from_delta": delta_trace_count,
+    "observability_trace_details": trace_detail_count,
+    "traces_from_delta_default": delta_trace_count,
+    "traces_from_delta_uc_otel": delta_uc_trace_count,
+    "trace_details_from_delta_default": delta_detail_count,
+    "trace_details_from_delta_uc_otel": delta_uc_detail_count,
+    "gateway_inference_logs": gw_log_count,
+    "gateway_inference_logs_from_delta": gw_log_delta_count,
     "vs_endpoints": vs_ep_count,
     "vs_indexes": vs_idx_count,
     "lakebase_instances": lb_inst_count,

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -21,7 +21,7 @@ import json
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from databricks.sdk import WorkspaceClient
@@ -47,6 +47,18 @@ dbutils.widgets.text("lakebase_dns", "", "Lakebase host (DNS)")
 dbutils.widgets.text("lakebase_database", "control_plane", "Lakebase database name")
 dbutils.widgets.text("lakebase_instance", "", "Lakebase instance name (Provisioned only)")
 dbutils.widgets.text("lakebase_endpoint_path", "", "Lakebase endpoint path (Autoscaling only)")
+dbutils.widgets.text("trace_retention_days", "90", "Trace cache retention window (days)")
+# ── Tier 3 (parked) controls ─────────────────────────────────
+# Cross-workspace MLflow REST fan-out is parked; default-off. The destination
+# workspace's gateway rejects cross-workspace REST calls from Databricks
+# Serverless / Apps Compute (HTTP 403 cert validation). Cross-workspace
+# observability is served by the UC SQL paths in the sibling tasks
+# (07_discover_uc_otel_traces, 08_discover_gateway_inference_logs) instead.
+# Set this to "true" only for experimentation when platform constraints lift.
+dbutils.widgets.text("enable_cross_workspace_rest_fanout", "false",
+                     "Tier 3 prototype — default false. See module docstring.")
+dbutils.widgets.text("discovery_sp_secret_scope", "", "Tier 3 only: secret scope with SP creds.")
+dbutils.widgets.text("narrow_test_workspace_id", "", "Tier 3 only: limit fan-out to this workspace_id.")
 
 CATALOG = dbutils.widgets.get("catalog")
 SCHEMA = dbutils.widgets.get("schema")
@@ -60,13 +72,45 @@ LAKEBASE_ENDPOINT_PATH = dbutils.widgets.get("lakebase_endpoint_path")
 if ACCOUNT_ID:
     os.environ["DATABRICKS_ACCOUNT_ID"] = ACCOUNT_ID
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces"
+TRACE_DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details"
+
+try:
+    RETENTION_DAYS = max(1, int(dbutils.widgets.get("trace_retention_days") or "90"))
+except ValueError:
+    RETENTION_DAYS = 90
+RETENTION_CUTOFF_MS = int((datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)).timestamp() * 1000)
+
+CROSS_WS_FANOUT_ENABLED = (
+    (dbutils.widgets.get("enable_cross_workspace_rest_fanout") or "false").strip().lower()
+    in ("true", "1", "yes", "on")
+)
+SP_SECRET_SCOPE = dbutils.widgets.get("discovery_sp_secret_scope") or ""
+NARROW_TEST_WS = (dbutils.widgets.get("narrow_test_workspace_id") or "").strip()
+
+# Tier 3 SP creds are only relevant when cross-workspace fan-out is explicitly
+# enabled. Skip the secret-scope read otherwise to keep the run output clean.
+SP_CLIENT_ID = ""
+SP_CLIENT_SECRET = ""
+if CROSS_WS_FANOUT_ENABLED and SP_SECRET_SCOPE:
+    try:
+        SP_CLIENT_ID = dbutils.secrets.get(scope=SP_SECRET_SCOPE, key="client_id")
+        SP_CLIENT_SECRET = dbutils.secrets.get(scope=SP_SECRET_SCOPE, key="client_secret")
+        print(f"  Loaded discovery SP creds from secret scope '{SP_SECRET_SCOPE}'")
+    except Exception as exc:
+        print(f"  WARNING: could not load SP creds from '{SP_SECRET_SCOPE}': {exc}")
 
 if not CATALOG or not SCHEMA:
     raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
 
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
 print(f"Target: {TRACES_TABLE}")
+print(f"Detail target: {TRACE_DETAILS_TABLE}")
+print(f"Retention: {RETENTION_DAYS} days (cutoff_ms={RETENTION_CUTOFF_MS})")
 print(f"Warehouse: {WAREHOUSE_ID}")
+print(f"Cross-workspace REST fan-out (Tier 3): {'ENABLED (experimental)' if CROSS_WS_FANOUT_ENABLED else 'disabled (default — local workspace only)'}")
+if CROSS_WS_FANOUT_ENABLED:
+    print(f"  SP auth: {'enabled' if SP_CLIENT_ID else 'disabled'}")
+    print(f"  Narrow test workspace: {NARROW_TEST_WS or '(none, full fan-out)'}")
 
 # COMMAND ----------
 
@@ -90,6 +134,19 @@ TRACES_SCHEMA = StructType([
     StructField("tags", StringType(), True),
     StructField("data_source", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
+])
+
+TRACE_DETAILS_SCHEMA = StructType([
+    StructField("workspace_id",  StringType(), False),
+    StructField("request_id",    StringType(), False),
+    StructField("experiment_id", StringType(), True),
+    StructField("trace_info",    StringType(), True),
+    StructField("trace_data",    StringType(), True),
+    StructField("request_raw",   StringType(), True),
+    StructField("response_raw",  StringType(), True),
+    StructField("size_bytes",    LongType(),   True),
+    StructField("source_type",   StringType(), True),
+    StructField("cached_at",     TimestampType(), False),
 ])
 
 # COMMAND ----------
@@ -214,20 +271,86 @@ def _get_lakebase_conn():
     return psycopg2.connect(host=LAKEBASE_DNS, port=5432, database=LAKEBASE_DATABASE,
         user=pg_user, password=pg_password, sslmode="require", connect_timeout=15)
 
-try:
-    lb_conn = _get_lakebase_conn()
-    with lb_conn.cursor() as cur:
-        cur.execute("SELECT workspace_id, workspace_host FROM workspace_registry WHERE workspace_host IS NOT NULL")
-        for row in cur.fetchall():
-            ws_id = str(row[0])
-            if ws_id in experiment_workspace_ids:
-                workspace_hosts[ws_id] = row[1]
-    lb_conn.close()
-    _host_resolution_log.append(f"lakebase: {len(workspace_hosts)} hosts matched")
-    print(f"  ✅ Lakebase workspace_registry: {len(workspace_hosts)} hosts matched (of {len(experiment_workspace_ids)} with experiments)")
-except Exception as exc:
-    _host_resolution_log.append(f"lakebase: {type(exc).__name__}: {str(exc)[:200]}")
-    print(f"  ⚠️  Lakebase workspace_registry read failed: {exc}")
+# Cross-workspace host resolution (Tier 3) only runs when explicitly enabled.
+# When disabled (default), the workflow processes only the local workspace —
+# the Tier 1 path. Cross-workspace observability is served by the UC SQL
+# discovery tasks (07, 08), not by this REST fan-out.
+_lb_conn_for_refresh = None
+if CROSS_WS_FANOUT_ENABLED:
+    try:
+        _lb_conn_for_refresh = _get_lakebase_conn()
+        with _lb_conn_for_refresh.cursor() as cur:
+            cur.execute("SELECT workspace_id, workspace_host FROM workspace_registry WHERE workspace_host IS NOT NULL")
+            for row in cur.fetchall():
+                ws_id = str(row[0])
+                if ws_id in experiment_workspace_ids:
+                    workspace_hosts[ws_id] = row[1]
+        _host_resolution_log.append(f"lakebase: {len(workspace_hosts)} hosts matched")
+        print(f"  ✅ Lakebase workspace_registry: {len(workspace_hosts)} hosts matched (of {len(experiment_workspace_ids)} with experiments)")
+    except Exception as exc:
+        _host_resolution_log.append(f"lakebase: {type(exc).__name__}: {str(exc)[:200]}")
+        print(f"  ⚠️  Lakebase workspace_registry read failed: {exc}")
+
+    # Fallback: enumerate workspaces via system.access.workspaces_latest (no
+    # Accounts API auth scopes needed — queryable from any workspace with the SQL
+    # warehouse). Fills in any workspace that has experiments but isn't in the
+    # registry yet.
+    _unresolved = experiment_workspace_ids - set(workspace_hosts.keys())
+    _ws_to_upsert = []
+    if _unresolved:
+        print(f"▸ Resolving {len(_unresolved)} remaining workspace(s) via system.access.workspaces_latest ...")
+        try:
+            rows = _execute_sql(
+                "SELECT CAST(workspace_id AS STRING) AS workspace_id, "
+                "       workspace_url, workspace_name "
+                "FROM system.access.workspaces_latest "
+                "WHERE status = 'RUNNING' AND workspace_url IS NOT NULL"
+            )
+            added = 0
+            for r in rows:
+                ws_id = str(r.get("workspace_id") or "")
+                host = (r.get("workspace_url") or "").rstrip("/")
+                name = r.get("workspace_name") or ""
+                if not ws_id or not host:
+                    continue
+                dep = host.replace("https://", "").split(".")[0]
+                _ws_to_upsert.append((ws_id, host, name, dep))
+                if ws_id in experiment_workspace_ids and ws_id not in workspace_hosts:
+                    workspace_hosts[ws_id] = host
+                    added += 1
+            _host_resolution_log.append(f"system.access.workspaces_latest: +{added} hosts (of {len(_unresolved)} unresolved)")
+            print(f"  ✅ system.access.workspaces_latest: added {added} hosts (of {len(_unresolved)} unresolved)")
+        except Exception as exc:
+            _host_resolution_log.append(f"system.access.workspaces_latest: {type(exc).__name__}: {str(exc)[:200]}")
+            print(f"  ⚠️  system.access.workspaces_latest failed: {exc}")
+
+        if _ws_to_upsert and _lb_conn_for_refresh is not None:
+            try:
+                with _lb_conn_for_refresh.cursor() as cur:
+                    for ws_id, host, name, dep in _ws_to_upsert:
+                        cur.execute(
+                            """INSERT INTO workspace_registry (workspace_id, workspace_host, workspace_name, deployment_name, last_updated)
+                               VALUES (%s, %s, %s, %s, NOW())
+                               ON CONFLICT (workspace_id) DO UPDATE SET
+                                   workspace_host = EXCLUDED.workspace_host,
+                                   workspace_name = EXCLUDED.workspace_name,
+                                   deployment_name = EXCLUDED.deployment_name,
+                                   last_updated = NOW()""",
+                            (ws_id, host, name, dep),
+                        )
+                    _lb_conn_for_refresh.commit()
+                print(f"  ✅ Persisted {len(_ws_to_upsert)} workspaces to workspace_registry")
+            except Exception as exc:
+                print(f"  ⚠️  workspace_registry upsert failed: {exc}")
+
+    if _lb_conn_for_refresh is not None:
+        try:
+            _lb_conn_for_refresh.close()
+        except Exception:
+            pass
+else:
+    _host_resolution_log.append("cross-workspace fan-out disabled (Tier 1 only)")
+    print("  ℹ️  Cross-workspace fan-out disabled — local workspace only")
 
 # Always include the current workspace — the workflow runs as the user
 # who has full access to their own MLflow experiments and traces
@@ -259,39 +382,102 @@ except Exception as exc:
 
 # COMMAND ----------
 
-def fetch_traces_for_workspace(ws_id, host, max_traces=100):
-    """Use SDK WorkspaceClient(host=...) to fetch traces from a remote workspace.
-
-    The SDK authenticates using the notebook runner's OAuth credentials.
-    As an account admin, this works across any workspace in the account.
-    """
-    diag = {"ws_id": ws_id, "host": host, "status": "?", "exp_count": 0, "trace_count": 0, "error": None}
+def _get_sp_workspace_token(host: str) -> Optional[str]:
+    """Mint a workspace-scoped SP token via M2M client_credentials. Returns None
+    if SP creds aren't configured or exchange fails."""
+    if not SP_CLIENT_ID or not SP_CLIENT_SECRET:
+        return None
     try:
-        # Mask env vars so SDK uses the explicit host, not the local workspace
+        r = _http.post(
+            f"{host.rstrip('/')}/oidc/v1/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": SP_CLIENT_ID,
+                "client_secret": SP_CLIENT_SECRET,
+                "scope": "all-apis",
+            },
+            timeout=30,
+        )
+        if r.status_code == 200:
+            return r.json().get("access_token") or None
+    except Exception:
+        pass
+    return None
+
+
+def fetch_traces_for_workspace(ws_id, host, max_traces=100):
+    """Fetch traces + details from a remote workspace.
+
+    Auth strategy: prefer an SP-minted workspace token (when SP creds + workspace
+    grant are configured). Fall back to the runner's OAuth via WorkspaceClient(host=...).
+    SP path returns data the runner can't see (other users' MLflow data); OAuth
+    fallback only works for the local workspace.
+
+    Uses raw `requests` (via `_http`) for remote MLflow calls because Databricks
+    Serverless Compute's egress filter rejects cross-workspace SDK HTTP calls
+    with "Cert validation failed". The /oidc/v1/token exchange and raw HTTP both
+    bypass that filter.
+
+    Returns (summaries, details, diag). Both filtered by RETENTION_CUTOFF_MS.
+    """
+    diag = {"ws_id": ws_id, "host": host, "status": "?", "exp_count": 0,
+            "trace_count": 0, "detail_count": 0, "detail_errors": 0,
+            "auth": "?", "error": None}
+    try:
+        sp_token = _get_sp_workspace_token(host)
+        # Mask env vars so SDK uses the explicit host (not the local workspace)
         saved_env = {}
         for key in ["DATABRICKS_HOST", "DATABRICKS_ACCOUNT_ID"]:
             if key in os.environ:
                 saved_env[key] = os.environ.pop(key)
         try:
-            w = WorkspaceClient(host=host)
+            if sp_token:
+                # Raw HTTP path with SP workspace token
+                token = sp_token
+                diag["auth"] = "sp"
+                def _api_post(path, body):
+                    r = _http.post(f"{host.rstrip('/')}{path}",
+                        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                        json=body, timeout=30)
+                    if r.status_code >= 400:
+                        raise RuntimeError(f"HTTP {r.status_code} {path}: {r.text[:300]}")
+                    return r.json()
+                def _api_get(path, params):
+                    r = _http.get(f"{host.rstrip('/')}{path}",
+                        headers={"Authorization": f"Bearer {token}"},
+                        params=params, timeout=30)
+                    if r.status_code >= 400:
+                        raise RuntimeError(f"HTTP {r.status_code} {path}: {r.text[:300]}")
+                    return r.json()
+            else:
+                # SDK path (works for local workspace; remote calls fail under
+                # serverless cert validation, but that's the runner-OAuth case
+                # we hit when no SP creds are configured)
+                w = WorkspaceClient(host=host)
+                diag["auth"] = "runner_oauth"
+                def _api_post(path, body):
+                    return w.api_client.do("POST", path, body=body)
+                def _api_get(path, params):
+                    return w.api_client.do("GET", path, query=params)
 
             # Get experiments
-            exp_resp = w.api_client.do("POST", "/api/2.0/mlflow/experiments/search",
-                body={"max_results": 50, "order_by": ["last_update_time DESC"]})
+            exp_resp = _api_post("/api/2.0/mlflow/experiments/search",
+                {"max_results": 50, "order_by": ["last_update_time DESC"]})
             experiments = exp_resp.get("experiments", [])
             diag["exp_count"] = len(experiments)
 
             exp_ids = [e["experiment_id"] for e in experiments if e.get("experiment_id")]
             if not exp_ids:
                 diag["status"] = "ok_no_experiments"
-                return [], diag
+                return [], [], diag
 
-            # Get traces per experiment
-            all_traces = []
+            # Get traces per experiment (summaries first, details after)
+            all_traces: List[Dict[str, Any]] = []
+            all_details: List[Dict[str, Any]] = []
             for eid in exp_ids:
                 try:
-                    trace_resp = w.api_client.do("GET", "/api/2.0/mlflow/traces",
-                        query={"experiment_ids": eid, "max_results": max_traces})
+                    trace_resp = _api_get("/api/2.0/mlflow/traces",
+                        {"experiment_ids": eid, "max_results": max_traces})
                     for t in trace_resp.get("traces", []):
                         info = t.get("info", {})
                         meta = info.get("trace_metadata", {})
@@ -299,13 +485,21 @@ def fetch_traces_for_workspace(ws_id, host, max_traces=100):
                         rid = t.get("request_id") or info.get("request_id", "")
                         if not rid:
                             continue
+                        ts_ms = t.get("timestamp_ms") or info.get("timestamp_ms") or 0
+                        try:
+                            ts_ms = int(ts_ms)
+                        except (TypeError, ValueError):
+                            ts_ms = 0
+                        # Time-window filter: skip traces older than retention cutoff
+                        if ts_ms and ts_ms < RETENTION_CUTOFF_MS:
+                            continue
                         all_traces.append({
                             "request_id": rid,
                             "workspace_id": ws_id,
                             "experiment_id": eid,
                             "trace_name": tags.get("mlflow.traceName", ""),
                             "state": info.get("state", t.get("state", "")),
-                            "request_time": str(t.get("timestamp_ms") or info.get("timestamp_ms", "")),
+                            "request_time": str(ts_ms or ""),
                             "execution_duration": info.get("execution_duration"),
                             "model_id": meta.get("mlflow.modelId", ""),
                             "session_id": meta.get("mlflow.trace.session", ""),
@@ -314,18 +508,43 @@ def fetch_traces_for_workspace(ws_id, host, max_traces=100):
                             "tags": json.dumps(tags),
                             "data_source": "rest_api",
                         })
+
+                        # Fetch full detail (spans + payloads) for the cache.
+                        try:
+                            detail_resp = _api_get(f"/api/2.0/mlflow/traces/{rid}", {})
+                            trace_obj = detail_resp.get("trace", {}) or detail_resp
+                            trace_info_obj = trace_obj.get("trace_info", {}) or {}
+                            trace_data = trace_obj.get("trace_data", {}) or {}
+                            ti_json = json.dumps(trace_info_obj)
+                            td_json = json.dumps(trace_data)
+                            all_details.append({
+                                "workspace_id": ws_id,
+                                "request_id": rid,
+                                "experiment_id": eid,
+                                "trace_info": ti_json,
+                                "trace_data": td_json,
+                                "request_raw": trace_info_obj.get("request") or trace_data.get("request") or "",
+                                "response_raw": trace_info_obj.get("response") or trace_data.get("response") or "",
+                                "size_bytes": len(ti_json) + len(td_json),
+                                "source_type": "mlflow_rest",
+                            })
+                        except Exception as detail_exc:
+                            diag["detail_errors"] += 1
+                            if not diag["error"]:
+                                diag["error"] = f"detail rid={rid}: {str(detail_exc)[:120]}"
                 except Exception as exc:
                     diag["error"] = f"trace query exp={eid}: {exc}"
 
             diag["trace_count"] = len(all_traces)
+            diag["detail_count"] = len(all_details)
             diag["status"] = "ok"
-            return all_traces, diag
+            return all_traces, all_details, diag
         finally:
             os.environ.update(saved_env)
     except Exception as exc:
         diag["status"] = "error"
         diag["error"] = str(exc)[:200]
-        return [], diag
+        return [], [], diag
 
 # COMMAND ----------
 
@@ -335,10 +554,17 @@ def fetch_traces_for_workspace(ws_id, host, max_traces=100):
 # COMMAND ----------
 
 all_traces = []
+all_details = []
 all_diagnostics = []
 now = datetime.now(timezone.utc)
 
-print(f"▸ Fetching traces from {len(workspace_hosts)} workspaces via SDK ...")
+# Narrow-scope filter (rollout testing): keep only the target workspace if set.
+if NARROW_TEST_WS:
+    workspace_hosts = {k: v for k, v in workspace_hosts.items() if str(k) == NARROW_TEST_WS}
+    _host_resolution_log.append(f"narrow filter: {len(workspace_hosts)} host(s) match {NARROW_TEST_WS}")
+    print(f"  ▸ Narrow filter active — fanning out to {len(workspace_hosts)} workspace(s) only")
+
+print(f"▸ Fetching traces (+ details) from {len(workspace_hosts)} workspaces via SDK ...")
 
 if workspace_hosts:
     with ThreadPoolExecutor(max_workers=min(len(workspace_hosts), 5)) as pool:
@@ -346,23 +572,28 @@ if workspace_hosts:
             pool.submit(fetch_traces_for_workspace, ws_id, host): ws_id
             for ws_id, host in workspace_hosts.items()
         }
-        for fut in as_completed(futures, timeout=120):
+        for fut in as_completed(futures, timeout=300):
             ws_id = futures[fut]
             try:
-                traces, diag = fut.result()
+                traces, details, diag = fut.result()
                 all_traces.extend(traces)
+                all_details.extend(details)
                 all_diagnostics.append(diag)
+                msg = (f"ws={ws_id} auth={diag.get('auth','?')}: {diag['exp_count']} exps, "
+                       f"{diag['trace_count']} traces, {diag['detail_count']} details "
+                       f"({diag['detail_errors']} detail errors)")
                 if diag.get("error"):
-                    print(f"  ⚠️  ws={ws_id}: {diag['exp_count']} exps, {diag['trace_count']} traces, error: {diag['error'][:100]}")
+                    print(f"  ⚠️  {msg} — {diag['error'][:100]}")
                 else:
-                    print(f"  ✅ ws={ws_id}: {diag['exp_count']} exps, {diag['trace_count']} traces")
+                    print(f"  ✅ {msg}")
             except Exception as exc:
                 print(f"  ⚠️  ws={ws_id} failed: {exc}")
                 all_diagnostics.append({"ws_id": ws_id, "status": "exception", "error": str(exc)[:200]})
 
 ws_with_traces = sum(1 for d in all_diagnostics if d.get("trace_count", 0) > 0)
 ws_with_errors = sum(1 for d in all_diagnostics if d.get("status") == "error")
-print(f"\n✅ Total: {len(all_traces)} traces from {ws_with_traces} workspaces ({ws_with_errors} errors)")
+print(f"\n✅ Total: {len(all_traces)} traces, {len(all_details)} details "
+      f"from {ws_with_traces} workspaces ({ws_with_errors} errors)")
 
 # COMMAND ----------
 
@@ -391,14 +622,39 @@ if all_traces:
             now,
         ))
     traces_df = spark.createDataFrame(trace_rows, TRACES_SCHEMA)
-    traces_df.write.mode("overwrite").saveAsTable(TRACES_TABLE)
+    traces_df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACES_TABLE)
     count = spark.read.table(TRACES_TABLE).count()
     print(f"✅ Wrote {count} traces to Delta: {TRACES_TABLE}")
 else:
     # Write empty table to ensure it exists
     empty_df = spark.createDataFrame([], TRACES_SCHEMA)
-    empty_df.write.mode("overwrite").saveAsTable(TRACES_TABLE)
+    empty_df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACES_TABLE)
     print("ℹ️  No traces found — empty Delta table written")
+
+# COMMAND ----------
+
+# Write trace detail snapshot (full spans + payloads) for the cross-workspace cache.
+if all_details:
+    detail_rows = [(
+        d["workspace_id"],
+        d["request_id"],
+        d.get("experiment_id", ""),
+        d.get("trace_info", "{}"),
+        d.get("trace_data", "{}"),
+        d.get("request_raw", "") or "",
+        d.get("response_raw", "") or "",
+        int(d.get("size_bytes") or 0),
+        d.get("source_type", "mlflow_rest"),
+        now,
+    ) for d in all_details]
+    details_df = spark.createDataFrame(detail_rows, TRACE_DETAILS_SCHEMA)
+    details_df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACE_DETAILS_TABLE)
+    detail_count = spark.read.table(TRACE_DETAILS_TABLE).count()
+    print(f"✅ Wrote {detail_count} trace details to Delta: {TRACE_DETAILS_TABLE}")
+else:
+    empty_df = spark.createDataFrame([], TRACE_DETAILS_SCHEMA)
+    empty_df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACE_DETAILS_TABLE)
+    print("ℹ️  No trace details to write — empty Delta table written")
 
 # COMMAND ----------
 
@@ -419,6 +675,10 @@ for d in all_diagnostics:
         elif "error" in d.get("status", ""):
             error_types["other"] = error_types.get("other", 0) + 1
 
+total_detail_errors = sum(d.get("detail_errors", 0) for d in all_diagnostics)
+auth_breakdown = {"sp": 0, "runner_oauth": 0, "?": 0}
+for d in all_diagnostics:
+    auth_breakdown[d.get("auth", "?")] = auth_breakdown.get(d.get("auth", "?"), 0) + 1
 result = {
     "status": "success",
     "workspaces_with_experiments": len(experiment_workspace_ids),
@@ -426,6 +686,12 @@ result = {
     "workspaces_queried": len(all_diagnostics),
     "workspaces_with_traces": ws_with_traces,
     "total_traces": len(all_traces),
+    "total_trace_details": len(all_details),
+    "total_detail_errors": total_detail_errors,
+    "retention_days": RETENTION_DAYS,
+    "sp_auth_enabled": bool(SP_CLIENT_ID),
+    "narrow_test_ws": NARROW_TEST_WS or None,
+    "auth_breakdown": auth_breakdown,
     "error_breakdown": error_types,
     "sample_errors": [d["error"][:150] for d in all_diagnostics if d.get("error")][:5],
     "account_id_set": bool(ACCOUNT_ID),

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -1,0 +1,512 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Discover UC-stored MLflow Traces (Tier 2b)
+# MAGIC
+# MAGIC Discovery routes by table-name suffix over `system.information_schema.tables`.
+# MAGIC The two MLflow trace storage formats produce distinctive table-name
+# MAGIC patterns (`*_otel_spans` and `trace_logs_*`), so suffix routing is
+# MAGIC reliable. Pure schema-based scanning over `information_schema.columns`
+# MAGIC is exhaustive in theory but too slow at metastore scale, and per-table
+# MAGIC `DESCRIBE` calls also blow up the run time. The data-query paths are
+# MAGIC tolerant of column variations, so a name-matching table with an unexpected
+# MAGIC schema is reported as an error and skipped, not a crash.
+# MAGIC
+# MAGIC Two shapes recognized today:
+# MAGIC
+# MAGIC   - **OTel spans (row per span)** — `<prefix>_otel_spans` Delta tables
+# MAGIC     produced by MLflow 3.11+ with `trace_location=UnityCatalog(...)`.
+# MAGIC     Columns include `trace_id`, `span_id`, `start_time_unix_nano`.
+# MAGIC
+# MAGIC   - **Row per trace** — `trace_logs_<experiment_id>` Delta tables
+# MAGIC     produced by Databricks-native MLflow UC trace storage. Columns
+# MAGIC     include `trace_id`, `spans` (ARRAY), `request_time`, `request`,
+# MAGIC     `response`, `assessments`, etc.
+# MAGIC
+# MAGIC Adding a new format = add one name pattern + extend the shape verifier.
+# MAGIC UC governance is the only auth boundary — no per-workspace API calls,
+# MAGIC no SP-on-each-workspace setup. Writes to Delta tables
+# MAGIC `observability_traces_uc_otel` (summary) and
+# MAGIC `observability_trace_details_uc_otel` (full span data) which the sync
+# MAGIC workflow upserts into the shared Lakebase cache.
+
+# COMMAND ----------
+
+# MAGIC %pip install databricks-sdk --upgrade --quiet
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructType, StructField, StringType, LongType, TimestampType,
+)
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name (Delta target)")
+dbutils.widgets.text("schema", "", "Schema name (Delta target)")
+dbutils.widgets.text("trace_retention_days", "90", "Trace retention window (days)")
+dbutils.widgets.text("max_traces_per_table", "1000",
+                     "Cap on traces pulled per source table per run (prevents runaway).")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+
+try:
+    RETENTION_DAYS = max(1, int(dbutils.widgets.get("trace_retention_days") or "90"))
+except ValueError:
+    RETENTION_DAYS = 90
+
+try:
+    MAX_TRACES_PER_TABLE = max(10, int(dbutils.widgets.get("max_traces_per_table") or "1000"))
+except ValueError:
+    MAX_TRACES_PER_TABLE = 1000
+
+NOW = datetime.now(timezone.utc)
+RETENTION_CUTOFF_NS = int((NOW - timedelta(days=RETENTION_DAYS)).timestamp() * 1_000_000_000)
+RETENTION_CUTOFF_TS = (NOW - timedelta(days=RETENTION_DAYS))
+
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces_uc_otel"
+DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details_uc_otel"
+
+print(f"Trace summary target: {TRACES_TABLE}")
+print(f"Trace detail target:  {DETAILS_TABLE}")
+print(f"Retention: {RETENTION_DAYS} days")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Delta schemas (shared with REST-discovered defaults)
+
+# COMMAND ----------
+
+TRACES_SCHEMA = StructType([
+    StructField("request_id", StringType(), False),
+    StructField("workspace_id", StringType(), False),
+    StructField("experiment_id", StringType(), True),
+    StructField("trace_name", StringType(), True),
+    StructField("state", StringType(), True),
+    StructField("request_time", StringType(), True),
+    StructField("execution_duration", LongType(), True),
+    StructField("model_id", StringType(), True),
+    StructField("session_id", StringType(), True),
+    StructField("trace_user", StringType(), True),
+    StructField("source", StringType(), True),
+    StructField("tags", StringType(), True),
+    StructField("data_source", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+DETAILS_SCHEMA = StructType([
+    StructField("workspace_id",  StringType(), False),
+    StructField("request_id",    StringType(), False),
+    StructField("experiment_id", StringType(), True),
+    StructField("trace_info",    StringType(), True),
+    StructField("trace_data",    StringType(), True),
+    StructField("request_raw",   StringType(), True),
+    StructField("response_raw",  StringType(), True),
+    StructField("size_bytes",    LongType(),   True),
+    StructField("source_type",   StringType(), True),
+    StructField("cached_at",     TimestampType(), False),
+])
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Schema-based discovery
+
+# COMMAND ----------
+
+# Discovery: name patterns over `system.information_schema.tables`.
+# The two patterns are distinctive enough that we can route to the right
+# normalizer based on suffix alone — no per-table column lookup needed.
+# The data queries themselves are tolerant of column variations (try-fallback
+# in the trace_logs path), so a table that matches the name pattern but has
+# an unexpected schema will be reported as an error and skipped, not crash
+# the run.
+
+print("▸ Scanning system.information_schema.tables for trace-shaped tables ...")
+
+candidate_rows = spark.sql("""
+    SELECT table_catalog, table_schema, table_name
+    FROM system.information_schema.tables
+    WHERE (table_name LIKE '%\\_otel\\_spans' ESCAPE '\\\\'
+        OR table_name LIKE 'trace\\_logs\\_%' ESCAPE '\\\\')
+      AND table_type IN ('MANAGED', 'EXTERNAL')
+    ORDER BY table_catalog, table_schema, table_name
+""").collect()
+
+print(f"  candidate tables (by name): {len(candidate_rows)}")
+
+otel_tables: List[Tuple[str, str, str]] = []
+trace_log_tables: List[Tuple[str, str, str]] = []
+
+for r in candidate_rows:
+    cat, sch, tbl = r["table_catalog"], r["table_schema"], r["table_name"]
+    if tbl.endswith("_otel_spans"):
+        otel_tables.append((cat, sch, tbl))
+    elif tbl.startswith("trace_logs_"):
+        trace_log_tables.append((cat, sch, tbl))
+
+print(f"  ✅ OTel-spans-shape tables:    {len(otel_tables)}")
+for t in otel_tables: print(f"     - {t[0]}.{t[1]}.{t[2]}")
+print(f"  ✅ row-per-trace-shape tables: {len(trace_log_tables)}")
+for t in trace_log_tables: print(f"     - {t[0]}.{t[1]}.{t[2]}")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Process OTel-shape tables (row per span → group into traces)
+
+# COMMAND ----------
+
+all_trace_rows: List[tuple] = []
+all_detail_rows: List[tuple] = []
+per_table_stats: List[Dict[str, Any]] = []
+
+
+def _classify_perm_error(msg: str) -> bool:
+    return any(s in msg for s in (
+        "INSUFFICIENT_PERMISSIONS",
+        "PERMISSION_DENIED",
+        "UnauthorizedAccessException",
+        "USE CATALOG",
+        "USE SCHEMA",
+    ))
+
+
+for cat, sch, tbl in otel_tables:
+    full = f"`{cat}`.`{sch}`.`{tbl}`"
+    label = f"{cat}.{sch}.{tbl}"
+    prefix = tbl[:-len("_otel_spans")] if tbl.endswith("_otel_spans") else tbl
+
+    try:
+        traces_df = spark.sql(f"""
+            WITH recent_trace_ids AS (
+              SELECT trace_id, MAX(start_time_unix_nano) AS latest_ns
+              FROM {full}
+              WHERE start_time_unix_nano >= {RETENTION_CUTOFF_NS}
+              GROUP BY trace_id
+              ORDER BY latest_ns DESC
+              LIMIT {MAX_TRACES_PER_TABLE}
+            ),
+            spans AS (
+              SELECT s.trace_id, s.span_id, s.parent_span_id, s.name,
+                     s.start_time_unix_nano, s.end_time_unix_nano,
+                     CAST(s.attributes AS STRING) AS attributes_json,
+                     CAST(s.status AS STRING)     AS status_json,
+                     s.kind
+              FROM {full} s
+              JOIN recent_trace_ids r USING (trace_id)
+              WHERE s.start_time_unix_nano >= {RETENTION_CUTOFF_NS}
+            ),
+            roots AS (
+              SELECT trace_id, name AS root_name,
+                     start_time_unix_nano AS root_start_ns,
+                     end_time_unix_nano AS root_end_ns,
+                     attributes_json AS root_attrs,
+                     status_json AS root_status
+              FROM spans
+              WHERE parent_span_id IS NULL OR parent_span_id = ''
+            ),
+            agg AS (
+              SELECT trace_id,
+                     COLLECT_LIST(NAMED_STRUCT(
+                       'span_id', span_id, 'parent_span_id', parent_span_id,
+                       'name', name, 'kind', kind,
+                       'start_time_unix_nano', start_time_unix_nano,
+                       'end_time_unix_nano', end_time_unix_nano,
+                       'attributes', attributes_json, 'status', status_json
+                     )) AS span_list,
+                     COUNT(*) AS span_count
+              FROM spans GROUP BY trace_id
+            )
+            SELECT roots.trace_id, roots.root_name, roots.root_start_ns,
+                   roots.root_end_ns, roots.root_attrs, roots.root_status,
+                   agg.span_list, agg.span_count
+            FROM roots JOIN agg USING (trace_id)
+        """).collect()
+    except Exception as exc:
+        if _classify_perm_error(str(exc)):
+            per_table_stats.append({"table": label, "shape": "otel_spans", "skipped": "no UC grants"})
+        else:
+            per_table_stats.append({"table": label, "shape": "otel_spans", "error": str(exc)[:200]})
+            print(f"  ⚠️  {label}: {str(exc)[:100]}")
+        continue
+
+    n = 0
+    for row in traces_df:
+        trace_id = row["trace_id"]
+        request_id = f"trace:/{cat}.{sch}.{prefix}/{trace_id}"
+        root_attrs = {}
+        try:
+            root_attrs = json.loads(row["root_attrs"]) if row["root_attrs"] else {}
+        except Exception:
+            pass
+        request_raw = json.dumps(root_attrs.get("mlflow.spanInputs")) if "mlflow.spanInputs" in root_attrs else ""
+        response_raw = json.dumps(root_attrs.get("mlflow.spanOutputs")) if "mlflow.spanOutputs" in root_attrs else ""
+        state = "UNKNOWN"
+        try:
+            status_obj = json.loads(row["root_status"]) if row["root_status"] else {}
+            code = status_obj.get("status_code") or status_obj.get("code") or ""
+            if code:
+                state = "OK" if str(code).upper() in ("OK","STATUS_CODE_OK","1") else \
+                        "ERROR" if str(code).upper() in ("ERROR","STATUS_CODE_ERROR","2") else str(code)
+        except Exception:
+            pass
+        start_ms = int(row["root_start_ns"]) // 1_000_000 if row["root_start_ns"] else 0
+        end_ms   = int(row["root_end_ns"]) // 1_000_000 if row["root_end_ns"] else 0
+        duration_ms = max(0, end_ms - start_ms) if (start_ms and end_ms) else None
+
+        all_trace_rows.append((
+            request_id, "", "", row["root_name"] or "", state,
+            str(start_ms) if start_ms else "", duration_ms,
+            "", "", "", "",
+            json.dumps({"otel_table": label, "trace_id": trace_id}),
+            "uc_otel", NOW,
+        ))
+
+        spans_list = []
+        for s in (row["span_list"] or []):
+            d = s.asDict() if hasattr(s, "asDict") else dict(s)
+            for k in ("start_time_unix_nano", "end_time_unix_nano"):
+                if k in d and d[k] is not None:
+                    d[k] = int(d[k])
+            spans_list.append(d)
+        td = json.dumps({"spans": spans_list, "trace_id": trace_id, "trace_uri": request_id, "otel_table": label})
+        ti = json.dumps({"trace_id": trace_id, "name": row["root_name"] or "",
+                         "start_time_unix_nano": int(row["root_start_ns"]) if row["root_start_ns"] else 0,
+                         "end_time_unix_nano": int(row["root_end_ns"]) if row["root_end_ns"] else 0,
+                         "span_count": int(row["span_count"]), "state": state})
+        all_detail_rows.append((
+            "", request_id, "", ti, td, request_raw, response_raw,
+            len(ti) + len(td), "uc_otel", NOW,
+        ))
+        n += 1
+
+    print(f"  ✅ otel_spans  {label}: {n} trace(s)")
+    per_table_stats.append({"table": label, "shape": "otel_spans", "traces": n})
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Process row-per-trace tables (`trace_logs_*` shape)
+
+# COMMAND ----------
+
+for cat, sch, tbl in trace_log_tables:
+    full = f"`{cat}`.`{sch}`.`{tbl}`"
+    label = f"{cat}.{sch}.{tbl}"
+
+    try:
+        # Schema reference (from inspection): trace_id, request_time (TIMESTAMP),
+        # state, execution_duration_ms (LONG), request, response, request_preview,
+        # response_preview, trace_metadata (MAP), tags (MAP), trace_location (STRUCT),
+        # assessments (ARRAY), spans (ARRAY).
+        # Some columns may be missing on older variants; we use try/except pattern
+        # via tolerant column projection.
+        rows = spark.sql(f"""
+            SELECT trace_id,
+                   client_request_id,
+                   request_time,
+                   state,
+                   execution_duration_ms,
+                   request,
+                   response,
+                   request_preview,
+                   response_preview,
+                   trace_metadata,
+                   tags,
+                   to_json(trace_location) AS trace_location_json,
+                   to_json(assessments)    AS assessments_json,
+                   to_json(spans)          AS spans_json
+            FROM {full}
+            WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
+            ORDER BY request_time DESC
+            LIMIT {MAX_TRACES_PER_TABLE}
+        """).collect()
+    except Exception as exc:
+        msg = str(exc)
+        if _classify_perm_error(msg):
+            per_table_stats.append({"table": label, "shape": "trace_logs", "skipped": "no UC grants"})
+            continue
+        # If columns differ, retry with a minimal projection
+        try:
+            rows = spark.sql(f"""
+                SELECT trace_id, request_time, state, execution_duration_ms,
+                       request, response,
+                       to_json(spans) AS spans_json
+                FROM {full}
+                WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
+                ORDER BY request_time DESC
+                LIMIT {MAX_TRACES_PER_TABLE}
+            """).collect()
+            # Pad missing columns with None for downstream code
+            class _Row:
+                def __init__(self, src):
+                    self._d = {**{k: None for k in (
+                        'client_request_id','request_preview','response_preview',
+                        'trace_metadata','tags','trace_location_json','assessments_json'
+                    )}, **{k: src[k] for k in src.asDict()}}
+                def __getitem__(self, k): return self._d.get(k)
+                def asDict(self): return self._d
+            rows = [_Row(r) for r in rows]
+        except Exception as exc2:
+            per_table_stats.append({"table": label, "shape": "trace_logs", "error": str(exc2)[:200]})
+            print(f"  ⚠️  {label}: {str(exc2)[:100]}")
+            continue
+
+    n = 0
+    for row in rows:
+        trace_id = row["trace_id"]
+        if not trace_id:
+            continue
+        # Use the table-qualified URI as the cache key — globally unique
+        request_id = f"trace:/{cat}.{sch}.{tbl}/{trace_id}"
+
+        rt = row["request_time"]
+        start_ms = int(rt.timestamp() * 1000) if rt else 0
+        duration_ms = int(row["execution_duration_ms"]) if row["execution_duration_ms"] is not None else None
+
+        # Best-effort root span name + span count from spans JSON
+        root_name = ""
+        n_spans = 0
+        spans_str = row["spans_json"] or ""
+        try:
+            spans_arr = json.loads(spans_str) if spans_str else []
+            if isinstance(spans_arr, list):
+                n_spans = len(spans_arr)
+                if spans_arr:
+                    root = next((s for s in spans_arr if not s.get("parent_id") and not s.get("parent_span_id")), spans_arr[0])
+                    root_name = root.get("name", "") or ""
+        except Exception:
+            pass
+
+        state = (row["state"] or "UNKNOWN").upper() if isinstance(row["state"], str) else "UNKNOWN"
+
+        # MAP columns come back from collect() as Python dicts. Use them as-is
+        # for the parser (which expects `trace_info.trace_metadata` and `tags`
+        # to be dicts), and prefer the `mlflow.traceName` tag for the display
+        # name when present.
+        meta_dict = dict(row["trace_metadata"] or {})
+        tags_dict = dict(row["tags"] or {})
+        if not root_name and tags_dict.get("mlflow.traceName"):
+            root_name = tags_dict["mlflow.traceName"]
+
+        # Synthesize sizeStats so the deep-dive "Spans" tile populates. If the
+        # producer already wrote one, leave it alone.
+        if "mlflow.trace.sizeStats" not in meta_dict:
+            meta_dict["mlflow.trace.sizeStats"] = json.dumps({
+                "num_spans": n_spans,
+                "total_size_bytes": len(spans_str),
+            })
+
+        all_trace_rows.append((
+            request_id, "", "", root_name, state,
+            str(start_ms) if start_ms else "", duration_ms,
+            meta_dict.get("mlflow.modelId", ""),
+            meta_dict.get("mlflow.trace.session", ""),
+            meta_dict.get("mlflow.user", ""),
+            meta_dict.get("mlflow.source.name", ""),
+            json.dumps({"trace_log_table": label, "trace_id": trace_id, **{k: v for k, v in tags_dict.items() if isinstance(v, str)}}),
+            "uc_trace_logs", NOW,
+        ))
+
+        request_raw = row["request"] or ""
+        response_raw = row["response"] or ""
+
+        # Populate the standard MLflow trace_info shape so the existing parser
+        # surfaces token usage / model id / span count / state without UC-specific
+        # branching. Fields the parser reads:
+        #   trace_metadata.mlflow.trace.tokenUsage   → token_usage tile
+        #   trace_metadata.mlflow.trace.sizeStats    → spans tile (num_spans)
+        #   trace_metadata.mlflow.modelId            → model tile
+        #   tags.mlflow.traceName                    → header title
+        ti = json.dumps({
+            "trace_id": trace_id,
+            "name": root_name,
+            "request_time": str(start_ms) if start_ms else "",
+            "request_time_ms": start_ms,
+            "execution_duration": duration_ms,
+            "duration_ms": duration_ms,
+            "state": state,
+            "client_request_id": row["client_request_id"] or "",
+            "request_preview": row["request_preview"] or "",
+            "response_preview": row["response_preview"] or "",
+            "request": request_raw,
+            "response": response_raw,
+            "trace_metadata": meta_dict,
+            "tags": tags_dict,
+        })
+
+        td_payload = {
+            "trace_id": trace_id,
+            "trace_uri": request_id,
+            "trace_logs_table": label,
+            "spans_json": spans_str,
+            "trace_metadata": meta_dict,
+            "tags": tags_dict,
+            "trace_location_json": row["trace_location_json"] or "",
+            "assessments_json": row["assessments_json"] or "",
+        }
+        td = json.dumps(td_payload)
+        all_detail_rows.append((
+            "", request_id, "", ti, td, request_raw, response_raw,
+            len(ti) + len(td), "uc_trace_logs", NOW,
+        ))
+        n += 1
+
+    print(f"  ✅ trace_logs  {label}: {n} trace(s)")
+    per_table_stats.append({"table": label, "shape": "trace_logs", "traces": n})
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Write Delta snapshots
+
+# COMMAND ----------
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+
+if all_trace_rows:
+    df = spark.createDataFrame(all_trace_rows, TRACES_SCHEMA)
+    df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACES_TABLE)
+    n = spark.read.table(TRACES_TABLE).count()
+    print(f"✅ Wrote {n} trace summaries to {TRACES_TABLE}")
+else:
+    spark.createDataFrame([], TRACES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACES_TABLE)
+    print(f"ℹ️  No UC traces — empty {TRACES_TABLE}")
+
+if all_detail_rows:
+    df = spark.createDataFrame(all_detail_rows, DETAILS_SCHEMA)
+    df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(DETAILS_TABLE)
+    n = spark.read.table(DETAILS_TABLE).count()
+    print(f"✅ Wrote {n} trace details to {DETAILS_TABLE}")
+else:
+    spark.createDataFrame([], DETAILS_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(DETAILS_TABLE)
+    print(f"ℹ️  No UC trace details — empty {DETAILS_TABLE}")
+
+# COMMAND ----------
+
+result = {
+    "status": "success",
+    "otel_tables_found": len(otel_tables),
+    "trace_log_tables_found": len(trace_log_tables),
+    "traces": len(all_trace_rows),
+    "details": len(all_detail_rows),
+    "retention_days": RETENTION_DAYS,
+    "per_table": per_table_stats[:40],
+    "discovered_at": NOW.isoformat(),
+}
+print(json.dumps(result, indent=2))
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/08_discover_gateway_inference_logs.py
+++ b/workflows/08_discover_gateway_inference_logs.py
@@ -1,0 +1,271 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Discover AI Gateway / Inference Logs (Tier 2a)
+# MAGIC
+# MAGIC Pure SQL discovery: scans `system.information_schema.tables` for any
+# MAGIC `*_payload` table in Unity Catalog (AI Gateway request-logging output
+# MAGIC and Model Serving inference tables share this convention), then queries
+# MAGIC each one over the retention window. UC governance is the only auth
+# MAGIC boundary — no per-endpoint API calls or per-workspace setup.
+# MAGIC
+# MAGIC Two schema variants are tolerated:
+# MAGIC   • newer AI Gateway: `request_time` (TIMESTAMP), `execution_duration_ms` (LONG)
+# MAGIC   • legacy Model Serving: `timestamp_ms` (LONG), `execution_time_ms` (LONG)
+# MAGIC
+# MAGIC Writes to Delta table `gateway_inference_logs`, which the sync workflow
+# MAGIC upserts into the Lakebase cache.
+
+# COMMAND ----------
+
+# MAGIC %pip install databricks-sdk --upgrade --quiet
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Set
+
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructType, StructField, StringType, LongType, IntegerType, TimestampType,
+)
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name (Delta target)")
+dbutils.widgets.text("schema", "", "Schema name (Delta target)")
+dbutils.widgets.text("retention_days", "30", "Inference-log retention window (days)")
+dbutils.widgets.text("max_rows_per_table", "10000",
+                     "Cap on rows pulled per source table per run")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+
+try:
+    RETENTION_DAYS = max(1, int(dbutils.widgets.get("retention_days") or "30"))
+except ValueError:
+    RETENTION_DAYS = 30
+
+try:
+    MAX_ROWS_PER_TABLE = max(100, int(dbutils.widgets.get("max_rows_per_table") or "10000"))
+except ValueError:
+    MAX_ROWS_PER_TABLE = 10000
+
+NOW = datetime.now(timezone.utc)
+CUTOFF_TS = NOW - timedelta(days=RETENTION_DAYS)
+CUTOFF_MS = int(CUTOFF_TS.timestamp() * 1000)
+
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+OUTPUT_TABLE = f"{CATALOG}.{SCHEMA}.gateway_inference_logs"
+print(f"Output Delta: {OUTPUT_TABLE}")
+print(f"Retention: {RETENTION_DAYS} days  cutoff_ts={CUTOFF_TS.isoformat()}  cutoff_ms={CUTOFF_MS}")
+print(f"Cap per table: {MAX_ROWS_PER_TABLE} rows")
+
+# COMMAND ----------
+
+OUTPUT_SCHEMA = StructType([
+    StructField("request_id",          StringType(), False),  # databricks_request_id
+    StructField("source_table",        StringType(), False),  # "<catalog>.<schema>.<name>"
+    StructField("client_request_id",   StringType(), True),
+    StructField("request_time",        TimestampType(), True),
+    StructField("status_code",         IntegerType(), True),
+    StructField("execution_ms",        LongType(), True),
+    StructField("request_payload",     StringType(), True),
+    StructField("response_payload",    StringType(), True),
+    StructField("request_size_bytes",  LongType(), True),
+    StructField("response_size_bytes", LongType(), True),
+    StructField("served_entity_id",    StringType(), True),
+    StructField("requester",           StringType(), True),
+    StructField("discovered_at",       TimestampType(), False),
+])
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Discover `*_payload` tables (account-wide)
+
+# COMMAND ----------
+
+print("▸ Scanning system.information_schema.tables for *_payload ...")
+discovered = spark.sql("""
+    SELECT table_catalog, table_schema, table_name
+    FROM system.information_schema.tables
+    WHERE table_name LIKE '%\\_payload' ESCAPE '\\\\'
+      AND table_type IN ('MANAGED', 'EXTERNAL')
+    ORDER BY table_catalog, table_schema, table_name
+""").collect()
+
+candidate_tables = [(r["table_catalog"], r["table_schema"], r["table_name"]) for r in discovered]
+print(f"  found {len(candidate_tables)} candidate `_payload` table(s)")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Schema-aware extraction
+# MAGIC
+# MAGIC Column sets vary across tables. We always select the same logical fields
+# MAGIC into the output but build the SELECT per-table based on what's available.
+
+# COMMAND ----------
+
+def get_columns(catalog: str, schema: str, table: str) -> Set[str]:
+    """Return the set of column names for a given UC table (lowercased)."""
+    rows = spark.sql(f"""
+        SELECT column_name FROM system.information_schema.columns
+        WHERE table_catalog = '{catalog}'
+          AND table_schema = '{schema}'
+          AND table_name = '{table}'
+    """).collect()
+    return {r["column_name"].lower() for r in rows}
+
+
+# Required columns; if a table doesn't have these, skip it.
+REQUIRED = {"databricks_request_id", "request", "response"}
+
+per_table_stats: List[Dict[str, Any]] = []
+all_rows: List[tuple] = []
+
+for cat, sch, tbl in candidate_tables:
+    full = f"{cat}.{sch}.{tbl}"
+    try:
+        cols = get_columns(cat, sch, tbl)
+    except Exception as exc:
+        per_table_stats.append({"table": full, "error": f"col-list: {exc}"[:200]})
+        print(f"  ⚠️  {full}: cannot list columns ({exc})")
+        continue
+
+    if not REQUIRED.issubset(cols):
+        per_table_stats.append({"table": full, "skipped": "missing required cols",
+                                "cols_present": sorted(cols)})
+        continue
+
+    # Build a tolerant SELECT. CAST timestamps via the column that exists.
+    if "request_time" in cols:
+        ts_expr = "request_time"
+    elif "timestamp_ms" in cols:
+        ts_expr = "TIMESTAMP_MILLIS(timestamp_ms)"
+    else:
+        ts_expr = "CAST(NULL AS TIMESTAMP)"
+
+    if "execution_duration_ms" in cols:
+        exec_expr = "execution_duration_ms"
+    elif "execution_time_ms" in cols:
+        exec_expr = "execution_time_ms"
+    else:
+        exec_expr = "CAST(NULL AS BIGINT)"
+
+    served_expr = "served_entity_id" if "served_entity_id" in cols else "CAST(NULL AS STRING)"
+    requester_expr = "requester" if "requester" in cols else "CAST(NULL AS STRING)"
+    client_rid_expr = "client_request_id" if "client_request_id" in cols else "CAST(NULL AS STRING)"
+    status_expr = "status_code" if "status_code" in cols else "CAST(NULL AS INT)"
+
+    where_clause = f"{ts_expr} >= TIMESTAMP '{CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'"
+
+    # Backtick-quote each identifier so tables with hyphens or leading digits
+    # (e.g. `mlops-serving-endpoint_payload`, `databricks-claude-sonnet-4-5_payload`)
+    # parse correctly.
+    quoted = f"`{cat}`.`{sch}`.`{tbl}`"
+
+    query = f"""
+        SELECT
+          databricks_request_id      AS request_id,
+          {client_rid_expr}          AS client_request_id,
+          {ts_expr}                  AS request_time,
+          {status_expr}              AS status_code,
+          {exec_expr}                AS execution_ms,
+          request                    AS request_payload,
+          response                   AS response_payload,
+          {served_expr}              AS served_entity_id,
+          {requester_expr}           AS requester
+        FROM {quoted}
+        WHERE {where_clause}
+        ORDER BY request_time DESC
+        LIMIT {MAX_ROWS_PER_TABLE}
+    """
+    try:
+        rows = spark.sql(query).collect()
+    except Exception as exc:
+        msg = str(exc)
+        # Permission denials are expected for catalogs we don't have grants on;
+        # surface them as `skipped` rather than `error` to keep the run output clean.
+        # The Spark exception class can be either AnalysisException or
+        # UnauthorizedAccessException depending on where the check fires.
+        if any(s in msg for s in (
+            "INSUFFICIENT_PERMISSIONS",
+            "PERMISSION_DENIED",
+            "UnauthorizedAccessException",
+            "USE CATALOG",
+            "USE SCHEMA",
+        )):
+            per_table_stats.append({"table": full, "skipped": "no UC grants"})
+        else:
+            per_table_stats.append({"table": full, "error": msg[:200]})
+            print(f"  ⚠️  {full}: select failed: {msg[:120]}")
+        continue
+
+    n = 0
+    for r in rows:
+        rid = r["request_id"]
+        if not rid:
+            continue
+        req_str = r["request_payload"] or ""
+        resp_str = r["response_payload"] or ""
+        all_rows.append((
+            rid,
+            full,
+            r["client_request_id"],
+            r["request_time"],
+            int(r["status_code"]) if r["status_code"] is not None else None,
+            int(r["execution_ms"]) if r["execution_ms"] is not None else None,
+            req_str,
+            resp_str,
+            len(req_str.encode("utf-8")),
+            len(resp_str.encode("utf-8")),
+            r["served_entity_id"],
+            r["requester"],
+            NOW,
+        ))
+        n += 1
+    per_table_stats.append({"table": full, "rows": n})
+    print(f"  ✅ {full}: {n} row(s)")
+
+print(f"\n▸ Total: {len(all_rows)} inference-log rows from {len([s for s in per_table_stats if s.get('rows', 0) > 0])} non-empty table(s)")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Write Delta snapshot
+
+# COMMAND ----------
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+
+if all_rows:
+    df = spark.createDataFrame(all_rows, OUTPUT_SCHEMA)
+    df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(OUTPUT_TABLE)
+    n = spark.read.table(OUTPUT_TABLE).count()
+    print(f"✅ Wrote {n} rows to {OUTPUT_TABLE}")
+else:
+    spark.createDataFrame([], OUTPUT_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(OUTPUT_TABLE)
+    print(f"ℹ️  No rows — empty {OUTPUT_TABLE}")
+
+# COMMAND ----------
+
+result = {
+    "status": "success",
+    "candidate_tables_found": len(candidate_tables),
+    "tables_with_data": len([s for s in per_table_stats if s.get("rows", 0) > 0]),
+    "total_rows": len(all_rows),
+    "retention_days": RETENTION_DAYS,
+    "max_rows_per_table": MAX_ROWS_PER_TABLE,
+    "per_table_sample": per_table_stats[:30],
+    "discovered_at": NOW.isoformat(),
+}
+print(json.dumps(result, indent=2)[:3000])
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/databricks.yml
+++ b/workflows/databricks.yml
@@ -23,6 +23,24 @@ variables:
     description: Databricks account ID for cross-workspace operations (find in your workspace URL or account console)
   warehouse_id:
     description: SQL warehouse ID for system table queries
+  trace_retention_days:
+    default: "90"
+    description: "Time window (days) for trace detail caching. UI offers 7/14/30/90; this is the upper bound the discovery workflow caches."
+  enable_cross_workspace_rest_fanout:
+    default: "false"
+    description: "Tier 3 prototype (parked). When 'true', the observability discovery task fans out MLflow REST calls across all workspaces using SP creds. Off by default — destination workspaces reject these calls today (HTTP 403 cert validation). Cross-workspace observability is served by UC SQL paths instead (Tier 2)."
+  gateway_log_retention_days:
+    default: "30"
+    description: "Time window (days) for AI Gateway / inference-log payload caching."
+  gateway_log_max_rows_per_table:
+    default: "10000"
+    description: "Per-source-table cap on rows pulled per inference-log discovery run."
+  discovery_sp_secret_scope:
+    default: ""
+    description: "Databricks secret scope holding the discovery SP's OAuth creds (keys: client_id, client_secret). Empty disables SP-based cross-workspace auth."
+  narrow_test_workspace_id:
+    default: ""
+    description: "If set, observability discovery only fans out to this single workspace_id. Use during SP rollout testing; leave empty for full fan-out."
 
 resources:
   jobs:
@@ -50,7 +68,7 @@ resources:
           environment_key: default
 
         - task_key: discover_observability
-          description: "Discover MLflow traces cross-workspace via SDK → Delta table"
+          description: "Tier 1: discover local-workspace MLflow traces (default backend) via REST → Delta. Cross-workspace fan-out is parked (Tier 3); see enable_cross_workspace_rest_fanout."
           notebook_task:
             notebook_path: ./04_discover_observability.py
             base_parameters:
@@ -62,6 +80,10 @@ resources:
               lakebase_database: ${var.lakebase_database}
               lakebase_instance: ${var.lakebase_instance}
               lakebase_endpoint_path: ${var.lakebase_endpoint_path}
+              trace_retention_days: ${var.trace_retention_days}
+              enable_cross_workspace_rest_fanout: ${var.enable_cross_workspace_rest_fanout}
+              discovery_sp_secret_scope: ${var.discovery_sp_secret_scope}
+              narrow_test_workspace_id: ${var.narrow_test_workspace_id}
           environment_key: default
 
         - task_key: discover_knowledge_bases
@@ -94,6 +116,27 @@ resources:
               warehouse_id: ${var.warehouse_id}
           environment_key: default
 
+        - task_key: discover_uc_otel_traces
+          description: "Discover UC-stored MLflow OTel traces account-wide via SQL (Tier 2b) → Delta"
+          notebook_task:
+            notebook_path: ./07_discover_uc_otel_traces.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              trace_retention_days: ${var.trace_retention_days}
+          environment_key: default
+
+        - task_key: discover_gateway_inference_logs
+          description: "Discover AI Gateway / Model Serving inference-log payload tables account-wide via SQL (Tier 2a) → Delta"
+          notebook_task:
+            notebook_path: ./08_discover_gateway_inference_logs.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              retention_days: ${var.gateway_log_retention_days}
+              max_rows_per_table: ${var.gateway_log_max_rows_per_table}
+          environment_key: default
+
         - task_key: sync_to_lakebase
           description: "Sync all discovery data (Delta → Lakebase) + system table billing"
           depends_on:
@@ -102,6 +145,8 @@ resources:
             - task_key: discover_knowledge_bases
             - task_key: discover_user_analytics
             - task_key: discover_gateway_usage
+            - task_key: discover_uc_otel_traces
+            - task_key: discover_gateway_inference_logs
           notebook_task:
             notebook_path: ./02_sync_to_lakebase.py
             base_parameters:


### PR DESCRIPTION
## Summary

Three connected outcomes:

- **Account-wide trace + gateway-log discovery via Unity Catalog** (Tiers 2a / 2b). Two new in-cloud workflow tasks (`07_discover_uc_otel_traces`, `08_discover_gateway_inference_logs`) read every reachable AI Gateway `*_payload` table and every UC-stored MLflow trace table (`*_otel_spans` and `trace_logs_*`) account-wide via SQL — no per-workspace SP plumbing. UC governance is the only auth boundary; non-readable tables are caught and labeled `skipped: \"no UC grants\"` rather than failing the run. Sync extracts `model`, token usage, finish_reason, and tool-call count from gateway payloads at sync time.
- **Trace deep-dive overhaul + cross-workspace links.** Span waterfall, tool-call breakdown card, eval/assessments card, source-notebook link, gateway-request time-series, run-metric trend charts. Workspace-host registry endpoint resolves \"Open in MLflow\" links to each record's owning workspace rather than the deploy workspace. Empty-state copy and column widths fixed; cache-only fast-paths replace 1-2s live-MLflow-REST merges. Plus a slate of bug fixes (field-name renames, JSONB shape normalization, ISO/duration-string parsing, `:path` route to support UC URI-form request_ids).
- **External Tier-3 runner** (`runners/tier3_local.py`). Default-backend MLflow trace fan-out from a laptop / GH Actions, bypassing the SNP filter at destination workspaces. Mints workspace-scoped tokens via SP M2M, fetches full span data via the MLflow Python client, upserts into the same Lakebase tables the in-cloud workflow uses (with `data_source = 'rest_fanout'`).

Documentation reflects the model: README explains the three discovery tiers + what agent owners need to enable upstream for traces to exist; `docs/installation.md` adds the run-as principal recommendation (metastore admin vs explicit per-catalog grants); the architecture pivot is captured in `docs/decisions/2026-04-29-...md` and the underlying SNP-block diagnosis in `docs/rca/2026-04-28-...md`.

## Test plan
- [ ] Smoke: deploy bundle to prod, trigger one full discovery run, confirm all 8 tasks SUCCEEDED
- [ ] Trace list (Observability → Traces): KPIs populate, Duration/Tokens columns render, in-row \"MLflow\" link routes to the trace's workspace
- [ ] Trace deep-dive: click a UC `trace_logs_*` trace → Conversation, Assessments, Tool Calls, Span Waterfall all render
- [ ] Gateway Requests tab: list shows model + token columns; trend chart strip renders above the list
- [ ] Experiments tab default opens to all-workspace cache (no longer empty when no workspace filter is selected)
- [ ] Run detail: metric trends card shows charts when the experiment has metrics
- [ ] Sync DDL: confirm no `InFailedSqlTransaction` on first run against a fresh Lakebase (savepoint fix)
- [ ] Tier 3 runner (optional): `pip install psycopg2-binary databricks-sdk requests mlflow` + run `python runners/tier3_local.py --dry-run --max-workspaces 5` from a laptop

## Notes for reviewers / operators

- New Lakebase columns on `gateway_inference_logs` (`model`, `input_tokens`, `output_tokens`, `total_tokens`, `finish_reason`, `tool_call_count`) are added at sync time via idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` wrapped in PostgreSQL savepoints.
- Five new bundle vars with sensible defaults: `trace_retention_days`, `gateway_log_retention_days`, `gateway_log_max_rows_per_table`, `enable_cross_workspace_rest_fanout` (default `false`), `discovery_sp_secret_scope`.
- Tier 3 cross-workspace REST fan-out remains parked behind `enable_cross_workspace_rest_fanout=false` for the in-cloud workflow because of the SNP block (see RCA). The local runner is the working alternative until [Aha! DB-I-12998](https://databricks.aha.io/ideas/ideas/DB-I-12998) lands.

This pull request and its description were written by Isaac.