### PR TITLE
deps: bump lodash to 4.18.1 (closes remaining lodash advisory)

### DIFF
--- a/control-plane-app/package-lock.json
+++ b/control-plane-app/package-lock.json
@@ -2621,6 +2621,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3241,12 +3247,6 @@
       "dependencies": {
         "decimal.js-light": "^2.4.1"
       }
-    },
-    "node_modules/recharts/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",

--- a/control-plane-app/package.json
+++ b/control-plane-app/package.json
@@ -36,6 +36,6 @@
   },
   "overrides": {
     "picomatch": "4.0.4",
-    "lodash": "4.17.21"
+    "lodash": "4.18.1"
   }
 }


### PR DESCRIPTION
## What

Bumps the `lodash` override `4.17.21` → **`4.18.1`**, closing the last 2 open Dependabot advisories:

- Code injection via `_.template` imported key names (High)
- Prototype pollution via array-path bypass in `_.unset` / `_.omit`

## Why now

When the earlier security PR (#5) landed, there was no good lodash version to move to:

- `4.18.0` — the advisory's nominal fix, but npm flags it as **"Bad release. Please use lodash@4.17.21 instead."**
- `4.17.21` — clean/known-good, but inside the vulnerable range (`<= 4.17.23`)

So we pinned `4.17.21` and left the advisory open. lodash has since published **`4.18.1`** as the `latest` dist-tag — it supersedes the botched 4.18.0, is **not deprecated**, and is **above the vulnerable range**. That makes it the proper fix.

## Verification

- `tsc && vite build` passes (2798 modules, clean typecheck)
- lodash resolves to 4.18.1 with no deprecation warning (4.18.0 emits one)

This pull request and its description were written by Isaac.