### PR TITLE
feat(billing): actual per-user cost via Unity AI Gateway v2 attribution

### DIFF
--- a/control-plane-app/backend/api/billing.py
+++ b/control-plane-app/backend/api/billing.py
@@ -20,6 +20,7 @@ from backend.services.billing_service import (
     force_refresh_async,
     maybe_refresh_async,
     get_all_page_data,
+    get_cost_by_user,
 )
 
 router = APIRouter(prefix="/billing", tags=["billing"], dependencies=[Depends(get_current_user)])
@@ -128,3 +129,13 @@ def product_costs(
 ):
     """Total cost per Databricks product."""
     return get_all_product_costs(days, workspace_id=workspace_id)
+
+
+@router.get("/cost-by-user")
+def cost_by_user(
+    days: int = Query(default=30, ge=1, le=365),
+    workspace_id: Optional[str] = Query(default=None),
+):
+    """Top users by cost. Prefers ACTUAL Unity AI Gateway v2 attribution and
+    falls back to the token-share estimate; response ``source`` says which."""
+    return get_cost_by_user(days, workspace_id=workspace_id)

--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -231,11 +231,26 @@ def ensure_billing_tables():
             PRIMARY KEY (usage_date, workspace_id, endpoint_name, user_identity)
         )
         """,
+        # Actual per-user $ via Unity AI Gateway v2 attribution (identity_metadata.run_by).
+        # Populated by 09_discover_billing → 02_sync. Empty on workspaces without v2 attribution.
+        """
+        CREATE TABLE IF NOT EXISTS billing_user_cost_daily (
+            usage_date     DATE          NOT NULL,
+            workspace_id   TEXT          NOT NULL,
+            endpoint_id    TEXT          NOT NULL DEFAULT '',
+            endpoint_name  TEXT          NOT NULL DEFAULT '',
+            run_by         TEXT          NOT NULL DEFAULT '',
+            total_dbus     NUMERIC(18,4) NOT NULL DEFAULT 0,
+            total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            PRIMARY KEY (usage_date, workspace_id, endpoint_id, run_by)
+        )
+        """,
         # Indexes for fast workspace-filtered reads
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bued_ws ON billing_user_endpoint_daily (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_bucd_ws ON billing_user_cost_daily (workspace_id)",
         # Add value_text column (idempotent) for storing non-numeric metadata
         "ALTER TABLE billing_cache_meta ADD COLUMN IF NOT EXISTS value_text TEXT",
     ]
@@ -547,6 +562,44 @@ def get_serving_cost_by_user(days: int = 30, workspace_id: Optional[str] = None)
     )
 
 
+def get_actual_cost_by_user(days: int = 30, workspace_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Top users by ACTUAL model-serving cost.
+
+    Reads billing_user_cost_daily — real per-user dollar cost attributed by the
+    platform via Unity AI Gateway v2 (system.billing.usage identity_metadata.run_by),
+    rather than the token-share estimate in get_serving_cost_by_user(). Returns an
+    empty list on workspaces where v2 attribution is not yet populated; callers
+    should fall back to the estimate in that case.
+    """
+    ws = "AND workspace_id = %s" if workspace_id else ""
+    params: tuple = (days, workspace_id) if workspace_id else (days,)
+
+    return execute_query(
+        f"""SELECT
+                run_by                              AS user_identity,
+                SUM(total_dbus)::NUMERIC(18,2)      AS total_dbus,
+                SUM(total_cost_usd)::NUMERIC(18,2)  AS total_cost_usd
+            FROM billing_user_cost_daily
+            WHERE usage_date >= CURRENT_DATE - %s {ws}
+            GROUP BY run_by
+            ORDER BY total_cost_usd DESC
+            LIMIT 25""",
+        params,
+    )
+
+
+def get_cost_by_user(days: int = 30, workspace_id: Optional[str] = None) -> Dict[str, Any]:
+    """Per-user cost preferring ACTUAL attribution, falling back to the estimate.
+
+    Returns {"source": "actual"|"estimate", "users": [...]} so the UI can label
+    whether numbers are platform-attributed or token-share estimates.
+    """
+    actual = get_actual_cost_by_user(days, workspace_id)
+    if actual:
+        return {"source": "actual", "users": actual}
+    return {"source": "estimate", "users": get_serving_cost_by_user(days, workspace_id)}
+
+
 # ── token usage by user ─────────────────────────────────────────
 
 def get_token_usage_by_user(days: int = 30, workspace_id: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -777,6 +830,24 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         )
         cost_by_user = [dict(r) for r in cur.fetchall()]
 
+        # 9b. ACTUAL per-user cost via Unity AI Gateway v2 attribution — preferred
+        # over the token-share estimate above when the v2 table has data.
+        cur.execute(
+            f"""SELECT run_by AS user_identity,
+                       SUM(total_dbus)::NUMERIC(18,2)     AS total_dbus,
+                       SUM(total_cost_usd)::NUMERIC(18,2) AS total_cost_usd
+                FROM billing_user_cost_daily u
+                WHERE u.usage_date >= CURRENT_DATE - %s {ws_filter_u}
+                GROUP BY run_by ORDER BY total_cost_usd DESC LIMIT 25""",
+            _p(),
+        )
+        actual_cost_by_user = [dict(r) for r in cur.fetchall()]
+        if actual_cost_by_user:
+            cost_by_user = actual_cost_by_user
+            cost_by_user_source = "actual"
+        else:
+            cost_by_user_source = "estimate"
+
         # 10. token usage by user
         cur.execute(
             f"""SELECT user_identity,
@@ -830,5 +901,6 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         "daily_tokens": daily_tokens,
         "products": products,
         "cost_by_user": cost_by_user,
+        "cost_by_user_source": cost_by_user_source,
         "tokens_by_user": tokens_by_user,
     }

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -911,6 +911,8 @@ export interface BillingPageData {
   daily_tokens: any[]
   products: any[]
   cost_by_user: any[]
+  /** "actual" = Unity AI Gateway v2 per-user attribution; "estimate" = token-share split */
+  cost_by_user_source: 'actual' | 'estimate'
   tokens_by_user: any[]
 }
 
@@ -938,6 +940,7 @@ export function useBillingPageData(days = 30, workspaceId?: string | null) {
         daily_tokens: [],
         products: [],
         cost_by_user: [],
+        cost_by_user_source: 'estimate',
         tokens_by_user: [],
         ...data,
       } as BillingPageData

--- a/control-plane-app/frontend/src/pages/Governance.tsx
+++ b/control-plane-app/frontend/src/pages/Governance.tsx
@@ -17,7 +17,7 @@ import { LineChart } from '@/components/charts/LineChart'
 import { BarChart } from '@/components/charts/BarChart'
 import { PieChart } from '@/components/charts/PieChart'
 import { DB_CHART } from '@/lib/brand'
-import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users } from 'lucide-react'
+import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info } from 'lucide-react'
 
 /* ── helpers ──────────────────────────────────────────────────── */
 
@@ -353,14 +353,14 @@ function OverviewTab({ data, loading }: { data?: BillingPageData; loading: boole
       </div>
 
       {/* Cost by user */}
-      <CostByUserSection costByUser={data?.cost_by_user || []} />
+      <CostByUserSection costByUser={data?.cost_by_user || []} source={data?.cost_by_user_source || 'estimate'} />
     </div>
   )
 }
 
 /* ── Cost by User (used in Overview tab) ─────────────────────── */
 
-function CostByUserSection({ costByUser }: { costByUser: any[] }) {
+function CostByUserSection({ costByUser, source = 'estimate' }: { costByUser: any[]; source?: 'actual' | 'estimate' }) {
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(10)
   const { sort, toggle } = useSort<string>('total_cost_usd')
@@ -383,6 +383,32 @@ function CostByUserSection({ costByUser }: { costByUser: any[] }) {
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
             <Users className="w-4 h-4 text-blue-600" /> Top Users by Serving Cost
+            <span className="group relative ml-1 inline-flex">
+              <span
+                tabIndex={0}
+                aria-label="How this is calculated"
+                className={`px-1.5 py-0.5 rounded text-[10px] font-medium cursor-help inline-flex items-center gap-0.5 outline-none ${
+                  source === 'actual'
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                    : 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+                }`}
+              >
+                {source === 'actual' ? 'Actual' : 'Estimated'}
+                <Info className="w-2.5 h-2.5 opacity-70" />
+              </span>
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-64 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              >
+                <span className="mb-1 block font-semibold text-gray-900 dark:text-gray-100">How per-user cost is calculated</span>
+                <span className={`block ${source === 'actual' ? 'text-green-700 dark:text-green-300' : 'opacity-70'}`}>
+                  <strong>Actual</strong> — real per-user dollars attributed by Unity AI Gateway (<code>system.billing.usage</code>).
+                </span>
+                <span className={`mt-1.5 block ${source === 'actual' ? 'opacity-70' : 'text-amber-700 dark:text-amber-300'}`}>
+                  <strong>Estimated</strong> — each endpoint’s total cost split across users by their share of tokens. Shown when AI Gateway v2 attribution isn’t available yet.
+                </span>
+              </span>
+            </span>
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1517,12 +1517,14 @@ BSD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_serving_daily"
 BTD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_token_daily"
 BPD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 BUED_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
+BUCD_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
 
 billing_conn = get_lakebase_connection()
 bsd_count = 0
 btd_count = 0
 bpd_count = 0
 bued_count = 0
+bucd_count = 0
 
 # Ensure billing tables (idempotent — also created by app's ensure_billing_tables on startup)
 with billing_conn.cursor() as cur:
@@ -1569,6 +1571,17 @@ with billing_conn.cursor() as cur:
             last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (usage_date, workspace_id, endpoint_name, user_identity)
         )""",
+        """CREATE TABLE IF NOT EXISTS billing_user_cost_daily (
+            usage_date     DATE          NOT NULL,
+            workspace_id   TEXT          NOT NULL,
+            endpoint_id    TEXT          NOT NULL DEFAULT '',
+            endpoint_name  TEXT          NOT NULL DEFAULT '',
+            run_by         TEXT          NOT NULL DEFAULT '',
+            total_dbus     NUMERIC(18,4) NOT NULL DEFAULT 0,
+            total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (usage_date, workspace_id, endpoint_id, run_by)
+        )""",
         """CREATE TABLE IF NOT EXISTS billing_cache_meta (
             cache_key      TEXT PRIMARY KEY,
             last_refreshed TIMESTAMP WITH TIME ZONE,
@@ -1586,6 +1599,7 @@ with billing_conn.cursor() as cur:
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bued_ws ON billing_user_endpoint_daily (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_bucd_ws ON billing_user_cost_daily (workspace_id)",
     ]:
         try:
             cur.execute(ddl)
@@ -1736,6 +1750,38 @@ try:
 except Exception as exc:
     print(f"  ⚠️  billing_user_endpoint_daily sync failed: {exc}")
 
+# Sync billing_user_cost_daily (actual per-user $ — UAG v2 attribution)
+print(f"▸ Syncing {BUCD_TABLE} → billing_user_cost_daily ...")
+try:
+    with billing_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE billing_user_cost_daily")
+        billing_conn.commit()
+    bucd_rows = spark.read.table(BUCD_TABLE).collect()
+    if bucd_rows:
+        values = [(r.usage_date, r.workspace_id, r.endpoint_id or "", r.endpoint_name or "",
+                   r.run_by or "unknown",
+                   float(r.total_dbus or 0), float(r.total_cost_usd or 0))
+                  for r in bucd_rows]
+        bucd_count = len(values)
+        with billing_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO billing_user_cost_daily
+                   (usage_date, workspace_id, endpoint_id, endpoint_name, run_by,
+                    total_dbus, total_cost_usd, last_synced)
+                   VALUES %s
+                   ON CONFLICT (usage_date, workspace_id, endpoint_id, run_by) DO UPDATE SET
+                       endpoint_name = EXCLUDED.endpoint_name,
+                       total_dbus = EXCLUDED.total_dbus,
+                       total_cost_usd = EXCLUDED.total_cost_usd,
+                       last_synced = NOW()""",
+                [(v[0], v[1], v[2], v[3], v[4], v[5], v[6], now) for v in values],
+                page_size=500)
+            billing_conn.commit()
+    print(f"  ✅ {bucd_count} user-cost rows synced")
+    _stamp_cache_meta(billing_conn, "user_cost_daily", bucd_count)
+except Exception as exc:
+    print(f"  ⚠️  billing_user_cost_daily sync failed: {exc}")
+
 billing_conn.close()
 
 # COMMAND ----------
@@ -1771,6 +1817,7 @@ result = {
     "billing_token_daily_rows": btd_count,
     "billing_product_daily_rows": bpd_count,
     "billing_user_endpoint_daily_rows": bued_count,
+    "billing_user_cost_daily_rows": bucd_count,
     "synced_at": datetime.now(timezone.utc).isoformat(),
 }
 print(json.dumps(result, indent=2))

--- a/workflows/09_discover_billing.py
+++ b/workflows/09_discover_billing.py
@@ -64,12 +64,14 @@ SERVING_TABLE  = f"{CATALOG}.{SCHEMA}.billing_serving_daily"
 TOKEN_TABLE    = f"{CATALOG}.{SCHEMA}.billing_token_daily"
 PRODUCT_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 USER_EP_TABLE  = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
+USER_COST_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
 
 print(f"Target tables:")
 print(f"  {SERVING_TABLE}")
 print(f"  {TOKEN_TABLE}")
 print(f"  {PRODUCT_TABLE}")
 print(f"  {USER_EP_TABLE}")
+print(f"  {USER_COST_TABLE}")
 print(f"Retention: {RETENTION_DAYS} days")
 
 # COMMAND ----------
@@ -118,6 +120,21 @@ USER_EP_SCHEMA = StructType([
     StructField("request_count", LongType(), True),
     StructField("input_tokens", LongType(), True),
     StructField("output_tokens", LongType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Actual per-user dollar cost from system.billing.usage v2 attribution
+# (identity_metadata.run_by + usage_metadata.ai_gateway.endpoint_id). Unlike
+# billing_user_endpoint_daily (tokens only, cost estimated by token-share),
+# this carries real cost attributed by the platform — Unity AI Gateway PPT FM.
+USER_COST_SCHEMA = StructType([
+    StructField("usage_date", StringType(), False),
+    StructField("workspace_id", StringType(), False),
+    StructField("endpoint_id", StringType(), True),
+    StructField("endpoint_name", StringType(), True),
+    StructField("run_by", StringType(), False),
+    StructField("total_dbus", DecimalType(18, 4), True),
+    StructField("total_cost_usd", DecimalType(18, 4), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -327,6 +344,53 @@ print(f"  ✅ {len(user_ep_rows)} user-endpoint rows")
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC ## Query 5: billing_user_cost_daily (ACTUAL per-user $ via UAG v2 attribution)
+# MAGIC
+# MAGIC Uses `identity_metadata.run_by` + `usage_metadata.ai_gateway.endpoint_id`,
+# MAGIC available for Pay-Per-Token Foundation Models queried via Unity AI Gateway
+# MAGIC endpoints. Degrades gracefully (empty) on workspaces where these v2 fields
+# MAGIC are not yet populated.
+
+# COMMAND ----------
+
+print(f"▸ Querying system.billing.usage for actual per-user cost ({RETENTION_DAYS} days) …")
+try:
+    user_cost_rows = _execute_sql(f"""
+        SELECT
+            CAST(u.usage_date AS STRING)                       AS usage_date,
+            u.workspace_id,
+            u.usage_metadata.ai_gateway.endpoint_id            AS endpoint_id,
+            u.usage_metadata.endpoint_name                     AS endpoint_name,
+            COALESCE(u.identity_metadata.run_by, 'unknown')    AS run_by,
+            ROUND(SUM(u.usage_quantity), 4)                    AS total_dbus,
+            ROUND(SUM(u.usage_quantity *
+                COALESCE(lp.pricing.effective_list.default, lp.pricing.default, 0.07)
+            ), 4)                                              AS total_cost_usd
+        FROM system.billing.usage u
+        LEFT JOIN system.billing.list_prices lp
+            ON u.sku_name = lp.sku_name
+            AND u.cloud   = lp.cloud
+            AND u.usage_unit = lp.usage_unit
+            AND lp.price_end_time IS NULL
+        WHERE u.billing_origin_product = 'MODEL_SERVING'
+          AND u.usage_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
+          AND u.identity_metadata.run_by IS NOT NULL
+          AND u.workspace_id IS NOT NULL
+        GROUP BY u.usage_date, u.workspace_id,
+                 u.usage_metadata.ai_gateway.endpoint_id,
+                 u.usage_metadata.endpoint_name,
+                 u.identity_metadata.run_by
+    """)
+    print(f"  ✅ {len(user_cost_rows)} actual per-user cost rows")
+except Exception as exc:
+    # v2 attribution fields (usage_metadata.ai_gateway / identity_metadata.run_by)
+    # may not exist on older system.billing.usage schemas — degrade gracefully.
+    user_cost_rows = []
+    print(f"  ⚠️  per-user cost query unavailable (v2 attribution not present?): {exc}")
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC ## Write to Delta (overwrite — Delta is the canonical source)
 
 # COMMAND ----------
@@ -383,6 +447,18 @@ else:
     spark.createDataFrame([], USER_EP_SCHEMA).write.mode("overwrite").saveAsTable(USER_EP_TABLE)
 print(f"✅ Wrote {len(user_ep_rows)} rows to {USER_EP_TABLE}")
 
+# User cost (actual, v2 attribution)
+if user_cost_rows:
+    rows = [(r.get("usage_date",""), r.get("workspace_id",""),
+             r.get("endpoint_id"), r.get("endpoint_name"),
+             r.get("run_by","unknown") or "unknown",
+             _dec(r.get("total_dbus"), 4), _dec(r.get("total_cost_usd"), 4), now)
+            for r in user_cost_rows]
+    spark.createDataFrame(rows, USER_COST_SCHEMA).write.mode("overwrite").saveAsTable(USER_COST_TABLE)
+else:
+    spark.createDataFrame([], USER_COST_SCHEMA).write.mode("overwrite").saveAsTable(USER_COST_TABLE)
+print(f"✅ Wrote {len(user_cost_rows)} rows to {USER_COST_TABLE}")
+
 # COMMAND ----------
 
 result = {
@@ -391,6 +467,7 @@ result = {
     "token_rows": len(token_rows),
     "product_rows": len(product_rows),
     "user_endpoint_rows": len(user_ep_rows),
+    "user_cost_rows": len(user_cost_rows),
     "retention_days": RETENTION_DAYS,
     "discovered_at": now.isoformat(),
 }


### PR DESCRIPTION
## What

Adds **real per-user dollar attribution** for model-serving cost alongside the existing token-share estimate, and labels which the UI is showing.

| Layer | Change |
|---|---|
| `workflows/09_discover_billing.py` | New query → Delta `billing_user_cost_daily` from `system.billing.usage` v2 fields (`identity_metadata.run_by`, `usage_metadata.ai_gateway.endpoint_id`). Degrades to empty when v2 attribution isn't present. |
| `workflows/02_sync_to_lakebase.py` | Mirror the new table into Lakebase. |
| `billing_service.py` | Table DDL; `get_actual_cost_by_user` / `get_cost_by_user` (actual-preferring, estimate fallback); `page-data` prefers actual and returns `cost_by_user_source`. |
| `api/billing.py` | `GET /billing/cost-by-user`. |
| `Governance.tsx` + `hooks.ts` | Actual/Estimated badge with a right-sized, keyboard-accessible hover info box explaining the difference. |

## Why

Today per-user cost is *estimated* by splitting each endpoint's cost across users by token share. This surfaces the platform's **actual** attribution when available, and is transparent about provenance.

## Verification

- `tsc && vite build` clean; deployed to `ai-control-plane` (RUNNING).
- Actual data requires a `09`/`02` workflow run on a workspace with UAG v2 attribution; UI falls back to the estimate (badge reads "Estimated") otherwise.

This pull request and its description were written by Isaac.