### PR TITLE
feat(gateway): surface rate-limit (429) hits per endpoint & user

### DIFF
--- a/control-plane-app/backend/main.py
+++ b/control-plane-app/backend/main.py
@@ -108,7 +108,8 @@ async def lifespan(app: FastAPI):
 
     def _init_gateway():
         try:
-            from backend.services.gateway_service import prewarm_cache
+            from backend.services.gateway_service import prewarm_cache, ensure_gateway_usage_columns
+            ensure_gateway_usage_columns()
             prewarm_cache()
         except Exception as exc:
             logger.warning("AI Gateway startup init skipped: %s", exc)

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -568,6 +568,26 @@ def _get_usage_overview_stats(days: int = 1) -> Dict[str, Any]:
     }
 
 
+def ensure_gateway_usage_columns() -> None:
+    """Defensively add columns the app reads but the discovery workflow owns.
+
+    The gateway_usage_* tables are created/populated by the discovery workflow,
+    not the app. When the app ships a read for a new column (e.g.
+    rate_limited_count) before the workflow's ALTER has run, the SELECT would
+    fail and blank the whole usage view. Adding the column here (idempotent,
+    no-op if the table doesn't exist yet) keeps reads self-healing.
+    """
+    from backend.database import execute_update
+    for stmt in (
+        "ALTER TABLE gateway_usage_daily  ADD COLUMN IF NOT EXISTS rate_limited_count BIGINT DEFAULT 0",
+        "ALTER TABLE gateway_usage_hourly ADD COLUMN IF NOT EXISTS rate_limited_count BIGINT DEFAULT 0",
+    ):
+        try:
+            execute_update(stmt)
+        except Exception as exc:
+            logger.warning("gateway_usage column ensure skipped: %s", exc)
+
+
 def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
     """Per-endpoint usage summary from Lakebase cache."""
     from backend.database import execute_query

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -577,6 +577,7 @@ def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
                   SUM(input_tokens) AS total_input_tokens,
                   SUM(output_tokens) AS total_output_tokens,
                   SUM(error_count) AS error_count,
+                  COALESCE(SUM(rate_limited_count), 0) AS rate_limited_count,
                   COUNT(DISTINCT NULLIF(requester, '')) AS unique_users
            FROM gateway_usage_daily
            WHERE usage_date >= CURRENT_DATE - INTERVAL '%s days'
@@ -590,6 +591,7 @@ def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
             "total_input_tokens": int(r.get("total_input_tokens") or 0),
             "total_output_tokens": int(r.get("total_output_tokens") or 0),
             "error_count": int(r.get("error_count") or 0),
+            "rate_limited_count": int(r.get("rate_limited_count") or 0),
             "unique_users": int(r.get("unique_users") or 0),
         }
         for r in rows
@@ -603,7 +605,8 @@ def get_usage_timeseries(days: int = 7, endpoint_name: Optional[str] = None) -> 
         rows = execute_query(
             """SELECT hour, SUM(request_count) AS request_count,
                       SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
-                      SUM(error_count) AS error_count
+                      SUM(error_count) AS error_count,
+                      COALESCE(SUM(rate_limited_count), 0) AS rate_limited_count
                FROM gateway_usage_hourly WHERE endpoint_name = %s
                GROUP BY hour ORDER BY hour""",
             (endpoint_name,),
@@ -612,7 +615,8 @@ def get_usage_timeseries(days: int = 7, endpoint_name: Optional[str] = None) -> 
         rows = execute_query(
             """SELECT hour, SUM(request_count) AS request_count,
                       SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
-                      SUM(error_count) AS error_count
+                      SUM(error_count) AS error_count,
+                      COALESCE(SUM(rate_limited_count), 0) AS rate_limited_count
                FROM gateway_usage_hourly
                GROUP BY hour ORDER BY hour""",
         )
@@ -623,6 +627,7 @@ def get_usage_timeseries(days: int = 7, endpoint_name: Optional[str] = None) -> 
             "input_tokens": int(r.get("input_tokens") or 0),
             "output_tokens": int(r.get("output_tokens") or 0),
             "error_count": int(r.get("error_count") or 0),
+            "rate_limited_count": int(r.get("rate_limited_count") or 0),
         }
         for r in rows
     ]
@@ -634,7 +639,8 @@ def get_usage_by_user(days: int = 7) -> List[Dict[str, Any]]:
     rows = execute_query(
         """SELECT requester, SUM(request_count) AS total_requests,
                   SUM(input_tokens) AS total_input_tokens, SUM(output_tokens) AS total_output_tokens,
-                  SUM(error_count) AS error_count
+                  SUM(error_count) AS error_count,
+                  COALESCE(SUM(rate_limited_count), 0) AS rate_limited_count
            FROM gateway_usage_daily
            WHERE usage_date >= CURRENT_DATE - INTERVAL '%s days'
              AND requester != ''
@@ -648,6 +654,7 @@ def get_usage_by_user(days: int = 7) -> List[Dict[str, Any]]:
             "total_input_tokens": int(r.get("total_input_tokens") or 0),
             "total_output_tokens": int(r.get("total_output_tokens") or 0),
             "error_count": int(r.get("error_count") or 0),
+            "rate_limited_count": int(r.get("rate_limited_count") or 0),
         }
         for r in rows
     ]

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -203,6 +203,7 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
     if (key === 'total_input_tokens') return Number(s.total_input_tokens || 0)
     if (key === 'total_output_tokens') return Number(s.total_output_tokens || 0)
     if (key === 'error_count') return Number(s.error_count || 0)
+    if (key === 'rate_limited_count') return Number(s.rate_limited_count || 0)
     if (key === 'unique_users') return Number(s.unique_users || 0)
     return 0
   }), [allSummary, usageSort.sort])
@@ -217,6 +218,7 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
     if (key === 'total_input_tokens') return Number(u.total_input_tokens || 0)
     if (key === 'total_output_tokens') return Number(u.total_output_tokens || 0)
     if (key === 'error_count') return Number(u.error_count || 0)
+    if (key === 'rate_limited_count') return Number(u.rate_limited_count || 0)
     return 0
   }), [allUsers, userSort.sort])
   const userTotalPages = Math.max(1, Math.ceil(sortedUsers.length / userPageSize))
@@ -406,6 +408,7 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
                   <SortableHeader label="Input Tokens" sortKey="total_input_tokens" current={usageSort.sort} onToggle={usageSort.toggle} align="right" />
                   <SortableHeader label="Output Tokens" sortKey="total_output_tokens" current={usageSort.sort} onToggle={usageSort.toggle} align="right" />
                   <SortableHeader label="Errors" sortKey="error_count" current={usageSort.sort} onToggle={usageSort.toggle} align="right" />
+                  <SortableHeader label="Rate-Limited" sortKey="rate_limited_count" current={usageSort.sort} onToggle={usageSort.toggle} align="right" />
                   <SortableHeader label="Users" sortKey="unique_users" current={usageSort.sort} onToggle={usageSort.toggle} align="right" />
                 </tr>
               </thead>
@@ -417,11 +420,12 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
                     <td className="py-2 text-right">{Number(s.total_input_tokens).toLocaleString()}</td>
                     <td className="py-2 text-right">{Number(s.total_output_tokens).toLocaleString()}</td>
                     <td className="py-2 text-right text-red-600">{Number(s.error_count).toLocaleString()}</td>
+                    <td className="py-2 text-right text-amber-600 dark:text-amber-400">{Number(s.rate_limited_count || 0).toLocaleString()}</td>
                     <td className="py-2 text-right">{Number(s.unique_users).toLocaleString()}</td>
                   </tr>
                 ))}
                 {sortedUsage.length === 0 && (
-                  <tr><td colSpan={6} className="py-8 text-center text-gray-400 dark:text-gray-500">{usageLoading ? 'Loading…' : 'No usage data'}</td></tr>
+                  <tr><td colSpan={7} className="py-8 text-center text-gray-400 dark:text-gray-500">{usageLoading ? 'Loading…' : 'No usage data'}</td></tr>
                 )}
               </tbody>
             </table>
@@ -447,6 +451,7 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
                   <SortableHeader label="Input Tokens" sortKey="total_input_tokens" current={userSort.sort} onToggle={userSort.toggle} align="right" />
                   <SortableHeader label="Output Tokens" sortKey="total_output_tokens" current={userSort.sort} onToggle={userSort.toggle} align="right" />
                   <SortableHeader label="Errors" sortKey="error_count" current={userSort.sort} onToggle={userSort.toggle} align="right" />
+                  <SortableHeader label="Rate-Limited" sortKey="rate_limited_count" current={userSort.sort} onToggle={userSort.toggle} align="right" />
                 </tr>
               </thead>
               <tbody>
@@ -457,10 +462,11 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
                     <td className="py-2 text-right">{Number(u.total_input_tokens).toLocaleString()}</td>
                     <td className="py-2 text-right">{Number(u.total_output_tokens).toLocaleString()}</td>
                     <td className="py-2 text-right text-red-600">{Number(u.error_count).toLocaleString()}</td>
+                    <td className="py-2 text-right text-amber-600 dark:text-amber-400">{Number(u.rate_limited_count || 0).toLocaleString()}</td>
                   </tr>
                 ))}
                 {sortedUsers.length === 0 && (
-                  <tr><td colSpan={5} className="py-8 text-center text-gray-400 dark:text-gray-500">{usersLoading ? 'Loading…' : 'No user data'}</td></tr>
+                  <tr><td colSpan={6} className="py-8 text-center text-gray-400 dark:text-gray-500">{usersLoading ? 'Loading…' : 'No user data'}</td></tr>
                 )}
               </tbody>
             </table>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1422,11 +1422,15 @@ with gw_conn.cursor() as cur:
             input_tokens    BIGINT DEFAULT 0,
             output_tokens   BIGINT DEFAULT 0,
             error_count     BIGINT DEFAULT 0,
+            rate_limited_count BIGINT DEFAULT 0,
             last_synced     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (usage_date, endpoint_name, requester)
         )""",
         "CREATE INDEX IF NOT EXISTS idx_gud_date ON gateway_usage_daily (usage_date DESC)",
         "CREATE INDEX IF NOT EXISTS idx_gud_ep ON gateway_usage_daily (endpoint_name)",
+        # ADD COLUMN for tables that pre-existed without rate_limited_count
+        "ALTER TABLE gateway_usage_daily  ADD COLUMN IF NOT EXISTS rate_limited_count BIGINT DEFAULT 0",
+        "ALTER TABLE gateway_usage_hourly ADD COLUMN IF NOT EXISTS rate_limited_count BIGINT DEFAULT 0",
         """CREATE TABLE IF NOT EXISTS gateway_usage_hourly (
             hour            TEXT NOT NULL,
             endpoint_name   TEXT DEFAULT '',
@@ -1434,6 +1438,7 @@ with gw_conn.cursor() as cur:
             input_tokens    BIGINT DEFAULT 0,
             output_tokens   BIGINT DEFAULT 0,
             error_count     BIGINT DEFAULT 0,
+            rate_limited_count BIGINT DEFAULT 0,
             last_synced     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (hour, endpoint_name)
         )""",
@@ -1457,13 +1462,14 @@ try:
     gw_rows = gw_df.collect()
     if gw_rows:
         values = [(r.usage_date, r.endpoint_name, r.requester or "",
-                   r.request_count, r.input_tokens, r.output_tokens, r.error_count, now)
+                   r.request_count, r.input_tokens, r.output_tokens, r.error_count,
+                   getattr(r, "rate_limited_count", 0) or 0, now)
                   for r in gw_rows]
         gw_daily_count = len(values)
         with gw_conn.cursor() as cur:
             execute_values(cur,
                 """INSERT INTO gateway_usage_daily
-                   (usage_date, endpoint_name, requester, request_count, input_tokens, output_tokens, error_count, last_synced)
+                   (usage_date, endpoint_name, requester, request_count, input_tokens, output_tokens, error_count, rate_limited_count, last_synced)
                    VALUES %s""",
                 values, page_size=500)
             gw_conn.commit()
@@ -1480,13 +1486,14 @@ try:
     gh_rows = gh_df.collect()
     if gh_rows:
         values = [(r.hour, r.endpoint_name or "", r.request_count,
-                   r.input_tokens, r.output_tokens, r.error_count, now)
+                   r.input_tokens, r.output_tokens, r.error_count,
+                   getattr(r, "rate_limited_count", 0) or 0, now)
                   for r in gh_rows]
         gw_hourly_count = len(values)
         with gw_conn.cursor() as cur:
             execute_values(cur,
                 """INSERT INTO gateway_usage_hourly
-                   (hour, endpoint_name, request_count, input_tokens, output_tokens, error_count, last_synced)
+                   (hour, endpoint_name, request_count, input_tokens, output_tokens, error_count, rate_limited_count, last_synced)
                    VALUES %s""",
                 values, page_size=500)
             gw_conn.commit()

--- a/workflows/06_discover_gateway_usage.py
+++ b/workflows/06_discover_gateway_usage.py
@@ -184,10 +184,10 @@ if daily_rows:
              int(r.get("output_tokens") or 0), int(r.get("error_count") or 0),
              int(r.get("rate_limited_count") or 0), now)
             for r in daily_rows]
-    spark.createDataFrame(rows, GW_DAILY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_DAILY_TABLE)
+    spark.createDataFrame(rows, GW_DAILY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(GW_USAGE_DAILY_TABLE)
     print(f"✅ Wrote {len(rows)} rows to {GW_USAGE_DAILY_TABLE}")
 else:
-    spark.createDataFrame([], GW_DAILY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_DAILY_TABLE)
+    spark.createDataFrame([], GW_DAILY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(GW_USAGE_DAILY_TABLE)
 
 if hourly_rows:
     rows = [(r.get("hour",""), r.get("endpoint_name",""),
@@ -195,10 +195,10 @@ if hourly_rows:
              int(r.get("output_tokens") or 0), int(r.get("error_count") or 0),
              int(r.get("rate_limited_count") or 0), now)
             for r in hourly_rows]
-    spark.createDataFrame(rows, GW_HOURLY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_HOURLY_TABLE)
+    spark.createDataFrame(rows, GW_HOURLY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(GW_USAGE_HOURLY_TABLE)
     print(f"✅ Wrote {len(rows)} rows to {GW_USAGE_HOURLY_TABLE}")
 else:
-    spark.createDataFrame([], GW_HOURLY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_HOURLY_TABLE)
+    spark.createDataFrame([], GW_HOURLY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(GW_USAGE_HOURLY_TABLE)
 
 # COMMAND ----------
 

--- a/workflows/06_discover_gateway_usage.py
+++ b/workflows/06_discover_gateway_usage.py
@@ -67,6 +67,7 @@ GW_DAILY_SCHEMA = StructType([
     StructField("input_tokens", LongType(), True),
     StructField("output_tokens", LongType(), True),
     StructField("error_count", LongType(), True),
+    StructField("rate_limited_count", LongType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -77,6 +78,7 @@ GW_HOURLY_SCHEMA = StructType([
     StructField("input_tokens", LongType(), True),
     StructField("output_tokens", LongType(), True),
     StructField("error_count", LongType(), True),
+    StructField("rate_limited_count", LongType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -137,7 +139,8 @@ daily_rows = _execute_sql("""
         COUNT(*) AS request_count,
         COALESCE(SUM(u.input_token_count), 0) AS input_tokens,
         COALESCE(SUM(u.output_token_count), 0) AS output_tokens,
-        SUM(CASE WHEN u.status_code >= 400 THEN 1 ELSE 0 END) AS error_count
+        SUM(CASE WHEN u.status_code >= 400 THEN 1 ELSE 0 END) AS error_count,
+        SUM(CASE WHEN u.status_code = 429 THEN 1 ELSE 0 END) AS rate_limited_count
     FROM system.serving.endpoint_usage u
     JOIN system.serving.served_entities se
         ON u.served_entity_id = se.served_entity_id
@@ -157,7 +160,8 @@ hourly_rows = _execute_sql("""
         COUNT(*) AS request_count,
         COALESCE(SUM(u.input_token_count), 0) AS input_tokens,
         COALESCE(SUM(u.output_token_count), 0) AS output_tokens,
-        SUM(CASE WHEN u.status_code >= 400 THEN 1 ELSE 0 END) AS error_count
+        SUM(CASE WHEN u.status_code >= 400 THEN 1 ELSE 0 END) AS error_count,
+        SUM(CASE WHEN u.status_code = 429 THEN 1 ELSE 0 END) AS rate_limited_count
     FROM system.serving.endpoint_usage u
     JOIN system.serving.served_entities se
         ON u.served_entity_id = se.served_entity_id
@@ -177,7 +181,8 @@ print(f"  ✅ {len(hourly_rows)} hourly usage rows")
 if daily_rows:
     rows = [(r.get("usage_date",""), r.get("endpoint_name",""), r.get("requester",""),
              int(r.get("request_count") or 0), int(r.get("input_tokens") or 0),
-             int(r.get("output_tokens") or 0), int(r.get("error_count") or 0), now)
+             int(r.get("output_tokens") or 0), int(r.get("error_count") or 0),
+             int(r.get("rate_limited_count") or 0), now)
             for r in daily_rows]
     spark.createDataFrame(rows, GW_DAILY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_DAILY_TABLE)
     print(f"✅ Wrote {len(rows)} rows to {GW_USAGE_DAILY_TABLE}")
@@ -187,7 +192,8 @@ else:
 if hourly_rows:
     rows = [(r.get("hour",""), r.get("endpoint_name",""),
              int(r.get("request_count") or 0), int(r.get("input_tokens") or 0),
-             int(r.get("output_tokens") or 0), int(r.get("error_count") or 0), now)
+             int(r.get("output_tokens") or 0), int(r.get("error_count") or 0),
+             int(r.get("rate_limited_count") or 0), now)
             for r in hourly_rows]
     spark.createDataFrame(rows, GW_HOURLY_SCHEMA).write.mode("overwrite").saveAsTable(GW_USAGE_HOURLY_TABLE)
     print(f"✅ Wrote {len(rows)} rows to {GW_USAGE_HOURLY_TABLE}")


### PR DESCRIPTION
## What

Adds **rate-limit (429) hit tracking** to the AI Gateway view, which previously showed rate-limit *config* but not actual *enforcement*.

| Layer | Change |
|---|---|
| `workflows/06_discover_gateway_usage.py` | Count `status_code = 429` per endpoint in the daily + hourly aggregates (`rate_limited_count`); writes use `overwriteSchema=true`. |
| `workflows/02_sync_to_lakebase.py` | New `rate_limited_count` column on `gateway_usage_daily` / `_hourly` (+ `ALTER ADD COLUMN IF NOT EXISTS`) + upserts. |
| `backend/services/gateway_service.py` | `rate_limited_count` in usage summary / timeseries / by-user reads; `ensure_gateway_usage_columns()` self-heals the column at startup so reads never break on workflow ordering. |
| `backend/main.py` | Call the column-ensure in `_init_gateway`. |
| `frontend/.../AIGateway.tsx` | Sortable **"Rate-Limited"** column (amber) in the per-endpoint and per-user usage tables. |

## Why / validation

429 is the **single most common status code** in `system.serving.endpoint_usage` (workspace-accessible, no admin). After deploying + running the discovery workflow on fevm, the populated data shows **~289.5M rate-limited requests (~76% of all gateway traffic)** — e.g. the `gte-large-en` embedding endpoint is ~90% throttled. High-signal, real data.

## Verified

- `tsc && vite build` clean; deployed to the `ai-control-plane` app (RUNNING).
- Discovery bundle deployed + run on fevm → `gateway_usage_daily.rate_limited_count` populated; numbers confirmed via direct query.

This pull request and its description were written by Isaac.