### PR TITLE
feat(gateway): Unity AI Gateway v2 (Beta) usage tab

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -172,6 +172,13 @@ def usage_by_user(days: int = Query(default=7, le=90)):
     return gateway_service.get_usage_by_user(days)
 
 
+@router.get("/uag-v2-usage")
+def uag_v2_usage():
+    """Unity AI Gateway (v2) usage summary from system.ai_gateway.usage —
+    v2-routed endpoints only, ~20-min fresh (cached tokens + latency/TTFB)."""
+    return gateway_service.get_uag_v2_usage()
+
+
 @router.get("/inference-logs")
 def inference_logs(
     limit: int = Query(default=50, le=500),

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -588,6 +588,70 @@ def ensure_gateway_usage_columns() -> None:
             logger.warning("gateway_usage column ensure skipped: %s", exc)
 
 
+def get_uag_v2_usage() -> Dict[str, Any]:
+    """Unity AI Gateway (v2) usage summary from `uag_usage_summary` (sourced from
+    system.ai_gateway.usage — v2-routed endpoints only, ~20-min fresh).
+
+    Returns {as_of, totals, endpoints}. Degrades to empty if the table isn't
+    synced yet or the workflow couldn't read the (account-scoped) system table.
+    """
+    from backend.database import execute_query
+    empty = {"as_of": None, "totals": {}, "endpoints": []}
+    try:
+        rows = execute_query(
+            """SELECT endpoint_name, request_count, input_tokens, output_tokens,
+                      cache_read_tokens, cache_creation_tokens,
+                      p50_latency_ms, p95_latency_ms, p95_ttfb_ms,
+                      error_count, unique_users, max_event_time
+               FROM uag_usage_summary
+               ORDER BY request_count DESC LIMIT 200"""
+        )
+    except Exception as exc:
+        logger.warning("uag_usage_summary not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    def _i(r, k):
+        return int(r.get(k) or 0)
+
+    total_req = sum(_i(r, "request_count") for r in rows)
+    total_in = sum(_i(r, "input_tokens") for r in rows)
+    total_out = sum(_i(r, "output_tokens") for r in rows)
+    total_cache_read = sum(_i(r, "cache_read_tokens") for r in rows)
+    total_cache_create = sum(_i(r, "cache_creation_tokens") for r in rows)
+    cached = total_cache_read + total_cache_create
+    cache_pct = round(100.0 * total_cache_read / total_in, 1) if total_in else 0.0
+    as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+    return {
+        "as_of": as_of,
+        "totals": {
+            "request_count": total_req,
+            "input_tokens": total_in,
+            "output_tokens": total_out,
+            "cached_tokens": cached,
+            "cache_read_pct": cache_pct,
+            "endpoints": len(rows),
+        },
+        "endpoints": [
+            {
+                "endpoint_name": r.get("endpoint_name", ""),
+                "request_count": _i(r, "request_count"),
+                "input_tokens": _i(r, "input_tokens"),
+                "output_tokens": _i(r, "output_tokens"),
+                "cache_read_tokens": _i(r, "cache_read_tokens"),
+                "cache_creation_tokens": _i(r, "cache_creation_tokens"),
+                "p50_latency_ms": _i(r, "p50_latency_ms"),
+                "p95_latency_ms": _i(r, "p95_latency_ms"),
+                "p95_ttfb_ms": _i(r, "p95_ttfb_ms"),
+                "error_count": _i(r, "error_count"),
+                "unique_users": _i(r, "unique_users"),
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
     """Per-endpoint usage summary from Lakebase cache."""
     from backend.database import execute_query

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -576,6 +576,43 @@ export function useGatewayUsageByUser(days = 7) {
   })
 }
 
+export interface UagV2Usage {
+  as_of: string | null
+  totals: {
+    request_count?: number
+    input_tokens?: number
+    output_tokens?: number
+    cached_tokens?: number
+    cache_read_pct?: number
+    endpoints?: number
+  }
+  endpoints: Array<{
+    endpoint_name: string
+    request_count: number
+    input_tokens: number
+    output_tokens: number
+    cache_read_tokens: number
+    cache_creation_tokens: number
+    p50_latency_ms: number
+    p95_latency_ms: number
+    p95_ttfb_ms: number
+    error_count: number
+    unique_users: number
+  }>
+}
+
+/** Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh. */
+export function useUagV2Usage() {
+  return useQuery({
+    queryKey: ['gateway', 'uag-v2-usage'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/uag-v2-usage')
+      return data as UagV2Usage
+    },
+    staleTime: GW_STALE,
+  })
+}
+
 export function useGatewayInferenceLogs(limit = 50, endpointName?: string) {
   return useQuery({
     queryKey: ['gateway', 'inference-logs', limit, endpointName],

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -186,6 +186,9 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
 
   // Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh
   const { data: uag } = useUagV2Usage()
+  const uagSort = useSort('request_count', 'desc')
+  const [uagPage, setUagPage] = useState(0)
+  const [uagPageSize, setUagPageSize] = useState(10)
 
   // Usage data
   const { data: summary, isLoading: usageLoading } = useGatewayUsageSummary(days)
@@ -260,6 +263,17 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
   const safePage = Math.min(page, totalPages - 1)
   const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
 
+  // Unity AI Gateway (v2) usage — sortable + paginated
+  const uagEndpoints: any[] = uag?.endpoints || []
+  const sortedUag = useMemo(() => sortRows(uagEndpoints, uagSort.sort, (e: any, key) => {
+    if (key === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
+    if (key === 'cached') return Number((e.cache_read_tokens || 0) + (e.cache_creation_tokens || 0))
+    return Number(e[key] || 0)
+  }), [uagEndpoints, uagSort.sort])
+  const uagTotalPages = Math.max(1, Math.ceil(sortedUag.length / uagPageSize))
+  const uagSafePage = Math.min(uagPage, uagTotalPages - 1)
+  const pagedUag = sortedUag.slice(uagSafePage * uagPageSize, (uagSafePage + 1) * uagPageSize)
+
   return (
     <div className="space-y-6">
       {/* Unity AI Gateway (v2) usage — additive, v2-routed endpoints only */}
@@ -294,16 +308,17 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
-                    <th className="py-2 font-medium">Endpoint</th>
-                    <th className="py-2 font-medium text-right">Requests</th>
-                    <th className="py-2 font-medium text-right">Cached Tokens</th>
-                    <th className="py-2 font-medium text-right">p50 Latency</th>
-                    <th className="py-2 font-medium text-right">p95 Latency</th>
-                    <th className="py-2 font-medium text-right">p95 TTFB</th>
+                    <SortableHeader label="Endpoint" sortKey="endpoint_name" current={uagSort.sort} onToggle={uagSort.toggle} />
+                    <SortableHeader label="Requests" sortKey="request_count" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    <SortableHeader label="Cached Tokens" sortKey="cached" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    <SortableHeader label="p50 Latency" sortKey="p50_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    <SortableHeader label="p95 Latency" sortKey="p95_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    <SortableHeader label="p95 TTFB" sortKey="p95_ttfb_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    <SortableHeader label="Users" sortKey="unique_users" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
                   </tr>
                 </thead>
                 <tbody>
-                  {uag.endpoints.slice(0, 8).map((e) => (
+                  {pagedUag.map((e: any) => (
                     <tr key={e.endpoint_name} className="border-b border-gray-100 dark:border-gray-700">
                       <td className="py-2 font-medium truncate max-w-[260px]">{e.endpoint_name}</td>
                       <td className="py-2 text-right">{Number(e.request_count).toLocaleString()}</td>
@@ -311,11 +326,13 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
                       <td className="py-2 text-right">{Number(e.p50_latency_ms).toLocaleString()}ms</td>
                       <td className="py-2 text-right">{Number(e.p95_latency_ms).toLocaleString()}ms</td>
                       <td className="py-2 text-right">{Number(e.p95_ttfb_ms).toLocaleString()}ms</td>
+                      <td className="py-2 text-right">{Number(e.unique_users).toLocaleString()}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
             </div>
+            <TablePagination page={uagSafePage} totalItems={sortedUag.length} pageSize={uagPageSize} onPageChange={setUagPage} onPageSizeChange={setUagPageSize} />
           </CardContent>
         </Card>
       )}

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -11,6 +11,7 @@ import {
   useGatewayUsageSummary,
   useGatewayUsageTimeseries,
   useGatewayUsageByUser,
+  useUagV2Usage,
   useGatewayInferenceLogs,
   useGatewayMetrics,
   useAppConfig,
@@ -54,6 +55,7 @@ import {
   AlertCircle,
   Pencil,
   Wallet,
+  Info,
 } from 'lucide-react'
 
 /* ── tab definitions ─────────────────────────────────────────── */
@@ -182,6 +184,9 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
   const [pageSize, setPageSize] = useState(10)
   const { sort, toggle } = useSort('name', 'asc')
 
+  // Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh
+  const { data: uag } = useUagV2Usage()
+
   // Usage data
   const { data: summary, isLoading: usageLoading } = useGatewayUsageSummary(days)
   const { data: timeseries } = useGatewayUsageTimeseries(days)
@@ -257,6 +262,64 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
 
   return (
     <div className="space-y-6">
+      {/* Unity AI Gateway (v2) usage — additive, v2-routed endpoints only */}
+      {uag && (uag.totals?.request_count ?? 0) > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              Unity AI Gateway (v2) Usage
+              <span className="group relative inline-flex">
+                <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
+                <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-72 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                  Only requests routed through <strong>Unity AI Gateway v2</strong> endpoints (~20-min fresh). Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
+                </span>
+              </span>
+              {uag.as_of && (
+                <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
+                  as of {new Date(uag.as_of).toLocaleString()}
+                </span>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-4">
+              <KpiCard title="Requests" value={uag.totals.request_count ?? 0} format="number" />
+              <KpiCard title="Input Tokens" value={uag.totals.input_tokens ?? 0} format="number" />
+              <KpiCard title="Output Tokens" value={uag.totals.output_tokens ?? 0} format="number" />
+              <KpiCard title="Cached Tokens" value={uag.totals.cached_tokens ?? 0} format="number" />
+              <KpiCard title="Cache Read %" value={uag.totals.cache_read_pct ?? 0} format="percentage" />
+              <KpiCard title="Endpoints" value={uag.totals.endpoints ?? 0} format="number" />
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
+                    <th className="py-2 font-medium">Endpoint</th>
+                    <th className="py-2 font-medium text-right">Requests</th>
+                    <th className="py-2 font-medium text-right">Cached Tokens</th>
+                    <th className="py-2 font-medium text-right">p50 Latency</th>
+                    <th className="py-2 font-medium text-right">p95 Latency</th>
+                    <th className="py-2 font-medium text-right">p95 TTFB</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {uag.endpoints.slice(0, 8).map((e) => (
+                    <tr key={e.endpoint_name} className="border-b border-gray-100 dark:border-gray-700">
+                      <td className="py-2 font-medium truncate max-w-[260px]">{e.endpoint_name}</td>
+                      <td className="py-2 text-right">{Number(e.request_count).toLocaleString()}</td>
+                      <td className="py-2 text-right">{Number(e.cache_read_tokens + e.cache_creation_tokens).toLocaleString()}</td>
+                      <td className="py-2 text-right">{Number(e.p50_latency_ms).toLocaleString()}ms</td>
+                      <td className="py-2 text-right">{Number(e.p95_latency_ms).toLocaleString()}ms</td>
+                      <td className="py-2 text-right">{Number(e.p95_ttfb_ms).toLocaleString()}ms</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Task distribution */}
       {overview?.tasks && Object.keys(overview.tasks).length > 0 && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -56,6 +56,7 @@ import {
   Pencil,
   Wallet,
   Info,
+  Sparkles,
 } from 'lucide-react'
 
 /* ── tab definitions ─────────────────────────────────────────── */
@@ -64,9 +65,10 @@ const baseTabs = [
   { id: 'metrics', label: 'Metrics', icon: Cpu },
   { id: 'permissions', label: 'Permissions', icon: Shield },
   { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert },
+  { id: 'uag-v2', label: 'Unity AI Gateway v2 (Beta)', icon: Sparkles },
 ] as const
 
-type TabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits' | 'budgets'
+type TabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits' | 'uag-v2' | 'budgets'
 
 export default function AIGatewayPage() {
   const [activeTab, setActiveTab] = useState<TabId>('overview')
@@ -172,7 +174,100 @@ export default function AIGatewayPage() {
       {activeTab === 'metrics' && <MetricsSection />}
       {activeTab === 'permissions' && <PermissionsSection />}
       {activeTab === 'rate-limits' && <RateLimitsAndGuardrailsSection />}
+      {activeTab === 'uag-v2' && <UagV2Section />}
       {activeTab === 'budgets' && budgetsEnabled && <BudgetsSection />}
+    </div>
+  )
+}
+
+/* ── Unity AI Gateway v2 (Beta) Section ───────────────────────── */
+
+function UagV2Section() {
+  const { data: uag, isLoading } = useUagV2Usage()
+  const uagSort = useSort('request_count', 'desc')
+  const [uagPage, setUagPage] = useState(0)
+  const [uagPageSize, setUagPageSize] = useState(10)
+
+  const uagEndpoints: any[] = uag?.endpoints || []
+  const sortedUag = useMemo(() => sortRows(uagEndpoints, uagSort.sort, (e: any, key) => {
+    if (key === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
+    if (key === 'cached') return Number((e.cache_read_tokens || 0) + (e.cache_creation_tokens || 0))
+    return Number(e[key] || 0)
+  }), [uagEndpoints, uagSort.sort])
+  const uagTotalPages = Math.max(1, Math.ceil(sortedUag.length / uagPageSize))
+  const uagSafePage = Math.min(uagPage, uagTotalPages - 1)
+  const pagedUag = sortedUag.slice(uagSafePage * uagPageSize, (uagSafePage + 1) * uagPageSize)
+  const hasData = (uag?.totals?.request_count ?? 0) > 0
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            Unity AI Gateway v2 (Beta) Usage
+            <span className="group relative inline-flex">
+              <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
+              <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-72 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                Only requests routed through <strong>Unity AI Gateway v2</strong> endpoints (~20-min fresh) — a subset of all serving. Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
+              </span>
+            </span>
+            {uag?.as_of && (
+              <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
+                as of {new Date(uag.as_of).toLocaleString()}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading…</div>
+          ) : !hasData ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">
+              No Unity AI Gateway v2 usage yet — either no v2-routed traffic in this workspace, or the discovery workflow hasn't synced <code>system.ai_gateway.usage</code> yet.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-4">
+                <KpiCard title="Requests" value={uag!.totals.request_count ?? 0} format="number" />
+                <KpiCard title="Input Tokens" value={uag!.totals.input_tokens ?? 0} format="number" />
+                <KpiCard title="Output Tokens" value={uag!.totals.output_tokens ?? 0} format="number" />
+                <KpiCard title="Cached Tokens" value={uag!.totals.cached_tokens ?? 0} format="number" />
+                <KpiCard title="Cache Read %" value={uag!.totals.cache_read_pct ?? 0} format="percentage" />
+                <KpiCard title="Endpoints" value={uag!.totals.endpoints ?? 0} format="number" />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
+                      <SortableHeader label="Endpoint" sortKey="endpoint_name" current={uagSort.sort} onToggle={uagSort.toggle} />
+                      <SortableHeader label="Requests" sortKey="request_count" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="Cached Tokens" sortKey="cached" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p50 Latency" sortKey="p50_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p95 Latency" sortKey="p95_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p95 TTFB" sortKey="p95_ttfb_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="Users" sortKey="unique_users" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pagedUag.map((e: any) => (
+                      <tr key={e.endpoint_name} className="border-b border-gray-100 dark:border-gray-700">
+                        <td className="py-2 font-medium truncate max-w-[260px]">{e.endpoint_name}</td>
+                        <td className="py-2 text-right">{Number(e.request_count).toLocaleString()}</td>
+                        <td className="py-2 text-right">{Number(e.cache_read_tokens + e.cache_creation_tokens).toLocaleString()}</td>
+                        <td className="py-2 text-right">{Number(e.p50_latency_ms).toLocaleString()}ms</td>
+                        <td className="py-2 text-right">{Number(e.p95_latency_ms).toLocaleString()}ms</td>
+                        <td className="py-2 text-right">{Number(e.p95_ttfb_ms).toLocaleString()}ms</td>
+                        <td className="py-2 text-right">{Number(e.unique_users).toLocaleString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <TablePagination page={uagSafePage} totalItems={sortedUag.length} pageSize={uagPageSize} onPageChange={setUagPage} onPageSizeChange={setUagPageSize} />
+            </>
+          )}
+        </CardContent>
+      </Card>
     </div>
   )
 }
@@ -183,12 +278,6 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(10)
   const { sort, toggle } = useSort('name', 'asc')
-
-  // Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh
-  const { data: uag } = useUagV2Usage()
-  const uagSort = useSort('request_count', 'desc')
-  const [uagPage, setUagPage] = useState(0)
-  const [uagPageSize, setUagPageSize] = useState(10)
 
   // Usage data
   const { data: summary, isLoading: usageLoading } = useGatewayUsageSummary(days)
@@ -263,80 +352,8 @@ function OverviewSection({ endpoints, overview, workspaceUrl, loading, searchQue
   const safePage = Math.min(page, totalPages - 1)
   const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
 
-  // Unity AI Gateway (v2) usage — sortable + paginated
-  const uagEndpoints: any[] = uag?.endpoints || []
-  const sortedUag = useMemo(() => sortRows(uagEndpoints, uagSort.sort, (e: any, key) => {
-    if (key === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
-    if (key === 'cached') return Number((e.cache_read_tokens || 0) + (e.cache_creation_tokens || 0))
-    return Number(e[key] || 0)
-  }), [uagEndpoints, uagSort.sort])
-  const uagTotalPages = Math.max(1, Math.ceil(sortedUag.length / uagPageSize))
-  const uagSafePage = Math.min(uagPage, uagTotalPages - 1)
-  const pagedUag = sortedUag.slice(uagSafePage * uagPageSize, (uagSafePage + 1) * uagPageSize)
-
   return (
     <div className="space-y-6">
-      {/* Unity AI Gateway (v2) usage — additive, v2-routed endpoints only */}
-      {uag && (uag.totals?.request_count ?? 0) > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
-              Unity AI Gateway (v2) Usage
-              <span className="group relative inline-flex">
-                <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
-                <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-72 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                  Only requests routed through <strong>Unity AI Gateway v2</strong> endpoints (~20-min fresh). Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
-                </span>
-              </span>
-              {uag.as_of && (
-                <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
-                  as of {new Date(uag.as_of).toLocaleString()}
-                </span>
-              )}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-4">
-              <KpiCard title="Requests" value={uag.totals.request_count ?? 0} format="number" />
-              <KpiCard title="Input Tokens" value={uag.totals.input_tokens ?? 0} format="number" />
-              <KpiCard title="Output Tokens" value={uag.totals.output_tokens ?? 0} format="number" />
-              <KpiCard title="Cached Tokens" value={uag.totals.cached_tokens ?? 0} format="number" />
-              <KpiCard title="Cache Read %" value={uag.totals.cache_read_pct ?? 0} format="percentage" />
-              <KpiCard title="Endpoints" value={uag.totals.endpoints ?? 0} format="number" />
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
-                    <SortableHeader label="Endpoint" sortKey="endpoint_name" current={uagSort.sort} onToggle={uagSort.toggle} />
-                    <SortableHeader label="Requests" sortKey="request_count" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                    <SortableHeader label="Cached Tokens" sortKey="cached" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                    <SortableHeader label="p50 Latency" sortKey="p50_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                    <SortableHeader label="p95 Latency" sortKey="p95_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                    <SortableHeader label="p95 TTFB" sortKey="p95_ttfb_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                    <SortableHeader label="Users" sortKey="unique_users" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                  </tr>
-                </thead>
-                <tbody>
-                  {pagedUag.map((e: any) => (
-                    <tr key={e.endpoint_name} className="border-b border-gray-100 dark:border-gray-700">
-                      <td className="py-2 font-medium truncate max-w-[260px]">{e.endpoint_name}</td>
-                      <td className="py-2 text-right">{Number(e.request_count).toLocaleString()}</td>
-                      <td className="py-2 text-right">{Number(e.cache_read_tokens + e.cache_creation_tokens).toLocaleString()}</td>
-                      <td className="py-2 text-right">{Number(e.p50_latency_ms).toLocaleString()}ms</td>
-                      <td className="py-2 text-right">{Number(e.p95_latency_ms).toLocaleString()}ms</td>
-                      <td className="py-2 text-right">{Number(e.p95_ttfb_ms).toLocaleString()}ms</td>
-                      <td className="py-2 text-right">{Number(e.unique_users).toLocaleString()}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <TablePagination page={uagSafePage} totalItems={sortedUag.length} pageSize={uagPageSize} onPageChange={setUagPage} onPageSizeChange={setUagPageSize} />
-          </CardContent>
-        </Card>
-      )}
-
       {/* Task distribution */}
       {overview?.tasks && Object.keys(overview.tasks).length > 0 && (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1508,6 +1508,79 @@ gw_conn.close()
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC ## Sync Unity AI Gateway (v2) usage summary (Delta → Lakebase)
+# MAGIC Mirrors `uag_usage_summary` from `11_discover_ai_gateway_usage`.
+
+# COMMAND ----------
+
+UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
+uag_conn = get_lakebase_connection()
+uag_count = 0
+
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_usage_summary (
+            endpoint_name         TEXT NOT NULL,
+            request_count         BIGINT DEFAULT 0,
+            input_tokens          BIGINT DEFAULT 0,
+            output_tokens         BIGINT DEFAULT 0,
+            cache_read_tokens     BIGINT DEFAULT 0,
+            cache_creation_tokens BIGINT DEFAULT 0,
+            p50_latency_ms        BIGINT DEFAULT 0,
+            p95_latency_ms        BIGINT DEFAULT 0,
+            p95_ttfb_ms           BIGINT DEFAULT 0,
+            error_count           BIGINT DEFAULT 0,
+            unique_users          BIGINT DEFAULT 0,
+            max_event_time        TEXT,
+            last_synced           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (endpoint_name)
+        )""")
+    uag_conn.commit()
+
+print(f"▸ Syncing {UAG_TABLE} → uag_usage_summary ...")
+try:
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_usage_summary")
+        uag_conn.commit()
+    uag_rows = spark.read.table(UAG_TABLE).collect()
+    if uag_rows:
+        values = [(r.endpoint_name, int(r.request_count or 0), int(r.input_tokens or 0),
+                   int(r.output_tokens or 0), int(r.cache_read_tokens or 0), int(r.cache_creation_tokens or 0),
+                   int(r.p50_latency_ms or 0), int(r.p95_latency_ms or 0), int(r.p95_ttfb_ms or 0),
+                   int(r.error_count or 0), int(r.unique_users or 0), r.max_event_time, now)
+                  for r in uag_rows]
+        uag_count = len(values)
+        with uag_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO uag_usage_summary
+                   (endpoint_name, request_count, input_tokens, output_tokens, cache_read_tokens,
+                    cache_creation_tokens, p50_latency_ms, p95_latency_ms, p95_ttfb_ms,
+                    error_count, unique_users, max_event_time, last_synced)
+                   VALUES %s
+                   ON CONFLICT (endpoint_name) DO UPDATE SET
+                       request_count = EXCLUDED.request_count,
+                       input_tokens = EXCLUDED.input_tokens,
+                       output_tokens = EXCLUDED.output_tokens,
+                       cache_read_tokens = EXCLUDED.cache_read_tokens,
+                       cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+                       p50_latency_ms = EXCLUDED.p50_latency_ms,
+                       p95_latency_ms = EXCLUDED.p95_latency_ms,
+                       p95_ttfb_ms = EXCLUDED.p95_ttfb_ms,
+                       error_count = EXCLUDED.error_count,
+                       unique_users = EXCLUDED.unique_users,
+                       max_event_time = EXCLUDED.max_event_time,
+                       last_synced = NOW()""",
+                values, page_size=500)
+            uag_conn.commit()
+    print(f"  ✅ {uag_count} UAG usage rows synced")
+except Exception as exc:
+    print(f"  ⚠️  uag_usage_summary sync failed: {exc}")
+
+uag_conn.close()
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC ## Phase 7: Sync Billing (Delta → Lakebase)
 # MAGIC
 # MAGIC Mirrors the four billing tables populated by `09_discover_billing`:
@@ -1820,6 +1893,7 @@ result = {
     "ua_heatmap_rows": ua_heatmap_count,
     "gw_daily_rows": gw_daily_count,
     "gw_hourly_rows": gw_hourly_count,
+    "uag_usage_rows": uag_count,
     "billing_serving_daily_rows": bsd_count,
     "billing_token_daily_rows": btd_count,
     "billing_product_daily_rows": bpd_count,

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -1,0 +1,163 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Unity AI Gateway (v2) Usage Discovery Job
+# MAGIC
+# MAGIC Queries `system.ai_gateway.usage` (v2 Unity AI Gateway traffic only) for a
+# MAGIC per-endpoint usage summary and writes a Delta table for `02_sync_to_lakebase`.
+# MAGIC
+# MAGIC **Why a separate source:** `system.ai_gateway.usage` is ~20-min fresh (vs
+# MAGIC ~2 hr for `system.billing.usage`) and carries data the others lack — cached
+# MAGIC tokens (`token_details`), time-to-first-byte, per-request tags. It covers
+# MAGIC ONLY requests routed through Unity AI Gateway v2 endpoints (a subset of all
+# MAGIC serving), so it is additive — not a replacement for billing (dollar cost)
+# MAGIC or serving.endpoint_usage (broad coverage + rate-limit hits).
+# MAGIC
+# MAGIC **Tables written:** `uag_usage_summary`
+
+# COMMAND ----------
+
+# MAGIC %pip install databricks-sdk --upgrade
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from databricks.sdk import WorkspaceClient
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    StructType, StructField, StringType, LongType, IntegerType, TimestampType,
+)
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name")
+dbutils.widgets.text("schema", "", "Schema name")
+dbutils.widgets.text("warehouse_id", "", "SQL warehouse ID")
+dbutils.widgets.text("uag_retention_days", "7", "Days of UAG usage to summarize")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+WAREHOUSE_ID = dbutils.widgets.get("warehouse_id")
+RETENTION_DAYS = int(dbutils.widgets.get("uag_retention_days") or "7")
+
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+
+UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
+print(f"Target table: {UAG_TABLE} | retention {RETENTION_DAYS}d")
+
+# COMMAND ----------
+
+UAG_SCHEMA = StructType([
+    StructField("endpoint_name", StringType(), False),
+    StructField("request_count", LongType(), True),
+    StructField("input_tokens", LongType(), True),
+    StructField("output_tokens", LongType(), True),
+    StructField("cache_read_tokens", LongType(), True),
+    StructField("cache_creation_tokens", LongType(), True),
+    StructField("p50_latency_ms", LongType(), True),
+    StructField("p95_latency_ms", LongType(), True),
+    StructField("p95_ttfb_ms", LongType(), True),
+    StructField("error_count", LongType(), True),
+    StructField("unique_users", LongType(), True),
+    StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# COMMAND ----------
+
+def _execute_sql(sql: str) -> List[Dict[str, Any]]:
+    if not WAREHOUSE_ID:
+        print("  No warehouse ID")
+        return []
+    w = WorkspaceClient()
+    body = {"warehouse_id": WAREHOUSE_ID, "statement": sql,
+            "wait_timeout": "50s", "disposition": "INLINE", "format": "JSON_ARRAY"}
+    try:
+        resp = w.api_client.do("POST", "/api/2.0/sql/statements", body=body)
+    except Exception as exc:
+        print(f"  SQL failed: {exc}")
+        return []
+    status = resp.get("status", {}).get("state", "")
+    sid = resp.get("statement_id", "")
+    if status in ("PENDING", "RUNNING") and sid:
+        for _ in range(20):
+            time.sleep(3)
+            try:
+                resp = w.api_client.do("GET", f"/api/2.0/sql/statements/{sid}")
+            except Exception:
+                continue
+            status = resp.get("status", {}).get("state", "")
+            if status not in ("PENDING", "RUNNING"):
+                break
+    if status != "SUCCEEDED":
+        err = resp.get("status", {}).get("error", {})
+        print(f"  SQL {status}: {err.get('message', '')[:300]}")
+        return []
+    cols = [c["name"] for c in resp.get("manifest", {}).get("schema", {}).get("columns", [])]
+    return [dict(zip(cols, row)) for row in resp.get("result", {}).get("data_array", [])]
+
+# COMMAND ----------
+
+print(f"▸ Querying system.ai_gateway.usage (v2 UAG, {RETENTION_DAYS}d) …")
+try:
+    rows_raw = _execute_sql(f"""
+        SELECT
+            endpoint_name,
+            COUNT(*)                                                   AS request_count,
+            COALESCE(SUM(input_tokens), 0)                             AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)                            AS output_tokens,
+            COALESCE(SUM(token_details.cache_read_input_tokens), 0)    AS cache_read_tokens,
+            COALESCE(SUM(token_details.cache_creation_input_tokens), 0) AS cache_creation_tokens,
+            CAST(PERCENTILE_APPROX(latency_ms, 0.5) AS LONG)           AS p50_latency_ms,
+            CAST(PERCENTILE_APPROX(latency_ms, 0.95) AS LONG)          AS p95_latency_ms,
+            CAST(PERCENTILE_APPROX(time_to_first_byte_ms, 0.95) AS LONG) AS p95_ttfb_ms,
+            SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END)        AS error_count,
+            COUNT(DISTINCT requester)                                  AS unique_users,
+            CAST(MAX(event_time) AS STRING)                            AS max_event_time
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND endpoint_name IS NOT NULL
+        GROUP BY endpoint_name
+        ORDER BY request_count DESC
+    """)
+    print(f"  ✅ {len(rows_raw)} UAG endpoint rows")
+except Exception as exc:
+    # Table may be inaccessible (account-admin scoping varies by workspace) — degrade.
+    rows_raw = []
+    print(f"  ⚠️  system.ai_gateway.usage unavailable: {exc}")
+
+# COMMAND ----------
+
+now = datetime.now(timezone.utc)
+
+
+def _i(x):
+    return int(x) if x not in (None, "") else 0
+
+
+if rows_raw:
+    rows = [(r.get("endpoint_name", ""), _i(r.get("request_count")), _i(r.get("input_tokens")),
+             _i(r.get("output_tokens")), _i(r.get("cache_read_tokens")), _i(r.get("cache_creation_tokens")),
+             _i(r.get("p50_latency_ms")), _i(r.get("p95_latency_ms")), _i(r.get("p95_ttfb_ms")),
+             _i(r.get("error_count")), _i(r.get("unique_users")), r.get("max_event_time"), now)
+            for r in rows_raw]
+    spark.createDataFrame(rows, UAG_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TABLE)
+else:
+    spark.createDataFrame([], UAG_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TABLE)
+print(f"✅ Wrote {len(rows_raw)} rows to {UAG_TABLE}")
+
+# COMMAND ----------
+
+result = {"status": "success", "uag_endpoint_rows": len(rows_raw),
+          "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
+print(json.dumps(result, indent=2))
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/databricks.yml
+++ b/workflows/databricks.yml
@@ -151,6 +151,16 @@ resources:
               billing_retention_days: ${var.billing_retention_days}
           environment_key: default
 
+        - task_key: discover_ai_gateway_usage
+          description: "Query system.ai_gateway.usage (v2 Unity AI Gateway, ~20-min fresh) for a per-endpoint usage summary incl. cached tokens + latency/TTFB → Delta. Additive to billing (cost) and serving.endpoint_usage (broad)."
+          notebook_task:
+            notebook_path: ./11_discover_ai_gateway_usage.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              warehouse_id: ${var.warehouse_id}
+          environment_key: default
+
         - task_key: sync_to_lakebase
           description: "Sync all discovery data (Delta → Lakebase) + system table billing"
           depends_on:
@@ -162,6 +172,7 @@ resources:
             - task_key: discover_uc_otel_traces
             - task_key: discover_gateway_inference_logs
             - task_key: discover_billing
+            - task_key: discover_ai_gateway_usage
           notebook_task:
             notebook_path: ./02_sync_to_lakebase.py
             base_parameters:


### PR DESCRIPTION
## What

Adds an additive **"Unity AI Gateway v2 (Beta)"** tab to the AI Gateway page, sourced from `system.ai_gateway.usage` (~20-min fresh, v2-routed endpoints only). Legacy Overview/Metrics/Permissions/Rate-Limits views are unchanged.

| Layer | Change |
|---|---|
| `workflows/11_discover_ai_gateway_usage.py` (new) | Per-endpoint summary from `system.ai_gateway.usage`: tokens incl. **cached** (`token_details`), p50/p95 latency, **p95 TTFB**, users, max event_time. Graceful if the table is unreadable. |
| `workflows/databricks.yml` | New `discover_ai_gateway_usage` task + sync dependency. |
| `workflows/02_sync_to_lakebase.py` | Mirror `uag_usage_summary` → Lakebase. |
| `gateway_service.get_uag_v2_usage()` + `GET /gateway/uag-v2-usage` | Read path (graceful → empty). |
| `AIGateway.tsx` + `hooks.ts` | New tab: KPI cards (requests, tokens, cached tokens, cache-read %), **sortable + paginated** endpoint table (cached tokens, p50/p95 latency, p95 TTFB, users), scope tooltip, "as of" freshness badge, empty/loading states. |

## Why additive (not a replacement)

`system.ai_gateway.usage` covers only ~13% of requests (v2-routed; incl. shared system FM endpoints) and has **no dollar cost** and ~0.1% of 429s. So it complements — not replaces — `billing.usage` (cost, Governance) and `serving.endpoint_usage` (broad coverage + rate-limit hits, Metrics). The tab is clearly scope-labeled.

## Verified

- `tsc && vite build` clean; deployed to `ai-control-plane` (fevm), discovery bundle deployed + run → `uag_usage_summary` populated (74 endpoints, ~1.4M req, ~1.96B cached tokens, ~20-min fresh); confirmed via direct query.

This pull request and its description were written by Isaac.