### PR TITLE
gateway(v2): enrich Unity AI Gateway v2 tab with usage breakdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ dist/
 # OS
 .DS_Store
 Thumbs.db
+
+# Local brainstorm / parking-lot notes (not part of the project)
+ideas/

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -596,7 +596,7 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     synced yet or the workflow couldn't read the (account-scoped) system table.
     """
     from backend.database import execute_query
-    empty = {"as_of": None, "totals": {}, "endpoints": []}
+    empty = {"as_of": None, "totals": {}, "endpoints": [], "breakdowns": {}}
     try:
         rows = execute_query(
             """SELECT endpoint_name, request_count, input_tokens, output_tokens,
@@ -623,8 +623,28 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     cached = total_cache_read + total_cache_create
     cache_pct = round(100.0 * total_cache_read / total_in, 1) if total_in else 0.0
     as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+
+    # Additive breakdowns (agent-vs-human / by model / by api_type) — same source table.
+    breakdowns: Dict[str, list] = {}
+    try:
+        bd = execute_query(
+            """SELECT dimension, key, request_count, input_tokens, output_tokens, cached_tokens
+               FROM uag_usage_breakdown ORDER BY request_count DESC"""
+        )
+        for r in bd:
+            breakdowns.setdefault(r.get("dimension") or "unknown", []).append({
+                "key": r.get("key", ""),
+                "request_count": int(r.get("request_count") or 0),
+                "input_tokens": int(r.get("input_tokens") or 0),
+                "output_tokens": int(r.get("output_tokens") or 0),
+                "cached_tokens": int(r.get("cached_tokens") or 0),
+            })
+    except Exception as exc:
+        logger.warning("uag_usage_breakdown not available: %s", exc)
+
     return {
         "as_of": as_of,
+        "breakdowns": breakdowns,
         "totals": {
             "request_count": total_req,
             "input_tokens": total_in,

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -599,6 +599,19 @@ export interface UagV2Usage {
     error_count: number
     unique_users: number
   }>
+  breakdowns?: {
+    requester_type?: UagBreakdownRow[]
+    destination_model?: UagBreakdownRow[]
+    api_type?: UagBreakdownRow[]
+  }
+}
+
+export interface UagBreakdownRow {
+  key: string
+  request_count: number
+  input_tokens: number
+  output_tokens: number
+  cached_tokens: number
 }
 
 /** Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh. */

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -12,6 +12,7 @@ import {
   useGatewayUsageTimeseries,
   useGatewayUsageByUser,
   useUagV2Usage,
+  type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
   useAppConfig,
@@ -54,11 +55,11 @@ import {
 
 /* ── tab definitions ─────────────────────────────────────────── */
 const baseTabs = [
-  { id: 'overview', label: 'Overview', icon: LayoutDashboard },
-  { id: 'metrics', label: 'Metrics', icon: Cpu },
-  { id: 'permissions', label: 'Permissions', icon: Shield },
-  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert },
-  { id: 'uag-v2', label: 'Unity AI Gateway v2 (Beta)', icon: Sparkles },
+  { id: 'overview', label: 'Overview', icon: LayoutDashboard, beta: false },
+  { id: 'metrics', label: 'Metrics', icon: Cpu, beta: false },
+  { id: 'permissions', label: 'Permissions', icon: Shield, beta: false },
+  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert, beta: false },
+  { id: 'uag-v2', label: 'Unity AI Gateway v2', icon: Sparkles, beta: true },
 ] as const
 
 type TabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits' | 'uag-v2'
@@ -129,7 +130,7 @@ export default function AIGatewayPage() {
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
-        {tabs.map(({ id, label, icon: Icon }) => (
+        {tabs.map(({ id, label, icon: Icon, beta }) => (
           <button
             key={id}
             onClick={() => setActiveTab(id)}
@@ -141,19 +142,26 @@ export default function AIGatewayPage() {
           >
             <Icon className="w-4 h-4" />
             {label}
+            {beta && (
+              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
+                Beta
+              </span>
+            )}
           </button>
         ))}
       </div>
 
-      {/* KPI Row */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
-        <KpiCard title="Total Endpoints" value={overview?.total_endpoints ?? 0} format="number" />
-        <KpiCard title="Ready" value={overview?.ready_endpoints ?? 0} format="number" />
-        <KpiCard title="Gateway Enabled" value={overview?.gateway_enabled ?? 0} format="number" />
-        <KpiCard title="Requests (24h)" value={overview?.total_requests_24h ?? 0} format="number" />
-        <KpiCard title="Unique Users (24h)" value={overview?.unique_users_24h ?? 0} format="number" />
-        <KpiCard title="Error Rate (24h)" value={overview?.error_rate_24h ?? 0} format="percentage" />
-      </div>
+      {/* KPI Row — Overview only */}
+      {activeTab === 'overview' && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+          <KpiCard title="Total Endpoints" value={overview?.total_endpoints ?? 0} format="number" />
+          <KpiCard title="Ready" value={overview?.ready_endpoints ?? 0} format="number" />
+          <KpiCard title="Gateway Enabled" value={overview?.gateway_enabled ?? 0} format="number" />
+          <KpiCard title="Requests (24h)" value={overview?.total_requests_24h ?? 0} format="number" />
+          <KpiCard title="Unique Users (24h)" value={overview?.unique_users_24h ?? 0} format="number" />
+          <KpiCard title="Error Rate (24h)" value={overview?.error_rate_24h ?? 0} format="percentage" />
+        </div>
+      )}
 
       {/* Tab content */}
       {activeTab === 'overview' && <OverviewSection endpoints={endpoints} overview={overview} workspaceUrl={workspaceUrl} loading={pageLoading} searchQuery={searchQuery} days={days} />}
@@ -253,7 +261,73 @@ function UagV2Section() {
           )}
         </CardContent>
       </Card>
+
+      {hasData && uag?.breakdowns && (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <UagBreakdownCard
+            title="Agent vs. Human"
+            subtitle="Requests by requester type"
+            rows={uag.breakdowns.requester_type}
+            labelMap={{ AGENT: 'Agent', USER: 'Human', HUMAN: 'Human', unknown: 'Unknown' }}
+          />
+          <UagBreakdownCard
+            title="Top Models"
+            subtitle="Requests by destination model"
+            rows={uag.breakdowns.destination_model}
+            limit={8}
+          />
+          <UagBreakdownCard
+            title="By API Type"
+            subtitle="Requests by API surface"
+            rows={uag.breakdowns.api_type}
+          />
+        </div>
+      )}
     </div>
+  )
+}
+
+/* Compact breakdown card — one ai_gateway.usage dimension, sorted by request volume. */
+function UagBreakdownCard({ title, subtitle, rows, limit, labelMap }: {
+  title: string
+  subtitle: string
+  rows?: UagBreakdownRow[]
+  limit?: number
+  labelMap?: Record<string, string>
+}) {
+  const data = (rows || []).slice().sort((a, b) => b.request_count - a.request_count)
+  const shown = limit ? data.slice(0, limit) : data
+  const total = data.reduce((s, r) => s + r.request_count, 0)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">{subtitle}</p>
+      </CardHeader>
+      <CardContent>
+        {shown.length === 0 ? (
+          <div className="py-8 text-center text-gray-400 dark:text-gray-500 text-sm">No data</div>
+        ) : (
+          <div className="space-y-2">
+            {shown.map((r) => {
+              const pct = total ? Math.round((r.request_count / total) * 100) : 0
+              const label = labelMap?.[r.key] || r.key || 'unknown'
+              return (
+                <div key={r.key}>
+                  <div className="flex items-center justify-between text-sm mb-0.5">
+                    <span className="font-medium truncate max-w-[200px]" title={label}>{label}</span>
+                    <span className="text-gray-500 dark:text-gray-400 tabular-nums">{r.request_count.toLocaleString()} ({pct}%)</span>
+                  </div>
+                  <div className="h-1.5 w-full rounded-full bg-gray-100 dark:bg-gray-700 overflow-hidden">
+                    <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: DB_CHART.primary }} />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1576,6 +1576,50 @@ try:
 except Exception as exc:
     print(f"  ⚠️  uag_usage_summary sync failed: {exc}")
 
+# Sync uag_usage_breakdown (agent-vs-human / by model / by api_type)
+UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
+uag_bd_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_usage_breakdown (
+            dimension     TEXT NOT NULL,
+            key           TEXT NOT NULL,
+            request_count BIGINT DEFAULT 0,
+            input_tokens  BIGINT DEFAULT 0,
+            output_tokens BIGINT DEFAULT 0,
+            cached_tokens BIGINT DEFAULT 0,
+            last_synced   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (dimension, key)
+        )""")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_BREAKDOWN_TABLE} → uag_usage_breakdown ...")
+try:
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_usage_breakdown")
+        uag_conn.commit()
+    bd_rows = spark.read.table(UAG_BREAKDOWN_TABLE).collect()
+    if bd_rows:
+        values = [(r.dimension, r.key, int(r.request_count or 0), int(r.input_tokens or 0),
+                   int(r.output_tokens or 0), int(r.cached_tokens or 0), now)
+                  for r in bd_rows]
+        uag_bd_count = len(values)
+        with uag_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO uag_usage_breakdown
+                   (dimension, key, request_count, input_tokens, output_tokens, cached_tokens, last_synced)
+                   VALUES %s
+                   ON CONFLICT (dimension, key) DO UPDATE SET
+                       request_count = EXCLUDED.request_count,
+                       input_tokens = EXCLUDED.input_tokens,
+                       output_tokens = EXCLUDED.output_tokens,
+                       cached_tokens = EXCLUDED.cached_tokens,
+                       last_synced = NOW()""",
+                values, page_size=500)
+            uag_conn.commit()
+    print(f"  ✅ {uag_bd_count} UAG breakdown rows synced")
+except Exception as exc:
+    print(f"  ⚠️  uag_usage_breakdown sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -52,7 +52,8 @@ if not CATALOG or not SCHEMA:
 spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
 
 UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
-print(f"Target table: {UAG_TABLE} | retention {RETENTION_DAYS}d")
+UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -69,6 +70,18 @@ UAG_SCHEMA = StructType([
     StructField("error_count", LongType(), True),
     StructField("unique_users", LongType(), True),
     StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Flexible breakdown: one row per (dimension, key). dimension ∈
+# {requester_type, destination_model, api_type} — additive v2 cuts.
+UAG_BREAKDOWN_SCHEMA = StructType([
+    StructField("dimension", StringType(), False),
+    StructField("key", StringType(), False),
+    StructField("request_count", LongType(), True),
+    StructField("input_tokens", LongType(), True),
+    StructField("output_tokens", LongType(), True),
+    StructField("cached_tokens", LongType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -140,15 +153,17 @@ except Exception as exc:
 now = datetime.now(timezone.utc)
 
 
-def _i(x):
+# NOTE: don't name this `_i` — IPython/Databricks reserves `_i`, `_ii`, `_iii`
+# for input history and rebinds them to strings between cells.
+def to_int(x):
     return int(x) if x not in (None, "") else 0
 
 
 if rows_raw:
-    rows = [(r.get("endpoint_name", ""), _i(r.get("request_count")), _i(r.get("input_tokens")),
-             _i(r.get("output_tokens")), _i(r.get("cache_read_tokens")), _i(r.get("cache_creation_tokens")),
-             _i(r.get("p50_latency_ms")), _i(r.get("p95_latency_ms")), _i(r.get("p95_ttfb_ms")),
-             _i(r.get("error_count")), _i(r.get("unique_users")), r.get("max_event_time"), now)
+    rows = [(r.get("endpoint_name", ""), to_int(r.get("request_count")), to_int(r.get("input_tokens")),
+             to_int(r.get("output_tokens")), to_int(r.get("cache_read_tokens")), to_int(r.get("cache_creation_tokens")),
+             to_int(r.get("p50_latency_ms")), to_int(r.get("p95_latency_ms")), to_int(r.get("p95_ttfb_ms")),
+             to_int(r.get("error_count")), to_int(r.get("unique_users")), r.get("max_event_time"), now)
             for r in rows_raw]
     spark.createDataFrame(rows, UAG_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TABLE)
 else:
@@ -157,7 +172,47 @@ print(f"✅ Wrote {len(rows_raw)} rows to {UAG_TABLE}")
 
 # COMMAND ----------
 
-result = {"status": "success", "uag_endpoint_rows": len(rows_raw),
+# Breakdowns: agent-vs-human (requester_type), by model (destination_model), by api_type.
+print("▸ Querying ai_gateway.usage breakdowns (requester_type / destination_model / api_type) …")
+try:
+    bd_rows = _execute_sql(f"""
+        WITH base AS (
+            SELECT requester_type, destination_model, api_type, input_tokens, output_tokens,
+                   COALESCE(token_details.cache_read_input_tokens, 0)
+                 + COALESCE(token_details.cache_creation_input_tokens, 0) AS cached
+            FROM system.ai_gateway.usage
+            WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+        )
+        SELECT 'requester_type' AS dimension, COALESCE(requester_type, 'unknown') AS key,
+               COUNT(*) AS request_count, COALESCE(SUM(input_tokens), 0) AS input_tokens,
+               COALESCE(SUM(output_tokens), 0) AS output_tokens, COALESCE(SUM(cached), 0) AS cached_tokens
+        FROM base GROUP BY requester_type
+        UNION ALL
+        SELECT 'destination_model', COALESCE(destination_model, 'unknown'),
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base GROUP BY destination_model
+        UNION ALL
+        SELECT 'api_type', COALESCE(api_type, 'unknown'),
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base GROUP BY api_type
+    """)
+    print(f"  ✅ {len(bd_rows)} breakdown rows")
+except Exception as exc:
+    bd_rows = []
+    print(f"  ⚠️  breakdown query unavailable: {exc}")
+
+if bd_rows:
+    rows = [(r.get("dimension", ""), r.get("key", "") or "unknown", to_int(r.get("request_count")),
+             to_int(r.get("input_tokens")), to_int(r.get("output_tokens")), to_int(r.get("cached_tokens")), now)
+            for r in bd_rows]
+    spark.createDataFrame(rows, UAG_BREAKDOWN_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_BREAKDOWN_TABLE)
+else:
+    spark.createDataFrame([], UAG_BREAKDOWN_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_BREAKDOWN_TABLE)
+print(f"✅ Wrote {len(bd_rows)} rows to {UAG_BREAKDOWN_TABLE}")
+
+# COMMAND ----------
+
+result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
           "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## Summary

Enriches the **Unity AI Gateway v2 (Beta)** tab with additive usage breakdowns sourced from `system.ai_gateway.usage`, plus two UI polish items.

### Data layer
- **`workflows/11_discover_ai_gateway_usage.py`** — new `uag_usage_breakdown` Delta table with three cuts of `system.ai_gateway.usage`: `requester_type` (agent vs. human), `destination_model`, and `api_type`.
- **`workflows/02_sync_to_lakebase.py`** — mirrors `uag_usage_breakdown` into Lakebase (TRUNCATE + upsert).

### Backend
- `get_uag_v2_usage()` now returns a `breakdowns` object keyed by dimension; degrades gracefully to `{}` when the table hasn't synced.

### Frontend (v2 tab)
- Three breakdown cards — **Agent vs. Human**, **Top Models**, **By API Type** — with proportion bars, below the endpoint table.
- The `(Beta)` tab text is now a green pill **label** rather than plain text.
- The top KPI row (Total Endpoints / Ready / Gateway Enabled / Requests 24h / Unique Users 24h / Error Rate 24h) now renders **only on the Overview tab**.

### Notes
- The discovery helper was renamed `_i` → `to_int`: `_i` is reserved by IPython/Databricks (input history) and gets rebound to a string between notebook cells.

## Verification
- `py_compile` clean (workflows + backend); `npm run build` clean.
- Deployed to the `fevm` workspace: app deployment `SUCCEEDED`/`ACTIVE`; workflow run `TERMINATED SUCCESS` (74 endpoint rows + 45 breakdown rows discovered and synced).
- Breakdown Delta table confirmed: 2 `requester_type` + 34 `destination_model` + 9 `api_type` rows.

This pull request and its description were written by Isaac.