### PR TITLE
docs(changelog): drop workspace-specific percentage from v0.1.2 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@ in-app budgeting in favor of the platform's native control.
 ### Design decisions
 
 - **Why v2 is a separate tab, not a replacement.** `system.ai_gateway.usage` only
-  covers traffic routed through v2-enabled endpoints — roughly **13%** of all
-  serving requests in our reference workspace — and carries **no dollar cost** and
-  almost no 429s. The broad/authoritative sources remain
+  covers traffic routed through v2-enabled endpoints — a subset of all serving
+  requests — and carries **no dollar cost** and almost no 429s. The
+  broad/authoritative sources remain
   `system.serving.endpoint_usage` (all serving + rate-limit hits) and
   `system.billing.usage` (billed cost). Folding v2 into — or replacing — the main
   view would contaminate broad metrics with a partial-coverage subset and drop


### PR DESCRIPTION
The "~13% of serving requests" figure in the v0.1.2 design-decisions note is specific to our reference workspace and not meaningful to a public audience. Reworded to "a subset of all serving requests".

The published GitHub Release notes for v0.1.2 have already been updated to match.

This pull request and its description were written by Isaac.