### PR TITLE
deps: bump react-router(-dom) to 6.30.4 (GHSA-2j2x-hqr9-3h42)

### DIFF
--- a/control-plane-app/package-lock.json
+++ b/control-plane-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "control-plane-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "control-plane-app",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
         "@tanstack/react-query": "^5.17.0",
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -3131,12 +3131,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3146,13 +3146,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/control-plane-app/package.json
+++ b/control-plane-app/package.json
@@ -19,7 +19,7 @@
     "lucide-react": "^0.577.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.3",
+    "react-router-dom": "^6.30.4",
     "recharts": "^2.10.0",
     "tailwind-merge": "^2.1.0"
   },


### PR DESCRIPTION
Clears **Dependabot #31** — medium open-redirect in `react-router` < 6.30.4 (`GHSA-2j2x-hqr9-3h42`).

## Impact
Not exploitable as deployed: the app uses **declarative `<BrowserRouter>`** (`src/main.tsx`) with **no data-mode `redirect()`**, which the advisory explicitly excludes. Patched for hygiene and to clear the alert.

## Change
- `react-router` + `react-router-dom` 6.30.3 → **6.30.4** (lockfile); `package.json` floor `^6.30.3` → `^6.30.4`.
- No code changes; patch release, no API changes.
- `npm run build` clean. Lockfile resolved URLs sanitized to `registry.npmjs.org`.

This pull request and its description were written by Isaac.