### PR TITLE
feat(gateway): MCP tool activity, service-type & routing in UAG v2 tab

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -175,8 +175,17 @@ def usage_by_user(days: int = Query(default=7, le=90)):
 @router.get("/uag-v2-usage")
 def uag_v2_usage():
     """Unity AI Gateway (v2) usage summary from system.ai_gateway.usage —
-    v2-routed endpoints only, ~20-min fresh (cached tokens + latency/TTFB)."""
+    v2-routed endpoints only, ~20-min fresh (cached tokens + latency/TTFB).
+    Breakdowns include requester_type, destination_model, api_type,
+    service_type (model/MCP/provider) and route_action (routing outcomes)."""
     return gateway_service.get_uag_v2_usage()
+
+
+@router.get("/uag-mcp-tools")
+def uag_mcp_tools():
+    """Per-tool MCP activity from system.ai_gateway.usage (service_type =
+    MCP_SERVICE): service name, tool, server type, calls, users."""
+    return gateway_service.get_uag_mcp_tools()
 
 
 @router.get("/inference-logs")

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -672,6 +672,57 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     }
 
 
+def get_uag_mcp_tools() -> Dict[str, Any]:
+    """Per-tool MCP activity from `uag_mcp_tool_daily` (sourced from
+    system.ai_gateway.usage rows where service_type = MCP_SERVICE).
+
+    Returns {as_of, totals, tools}. Degrades to empty when the table isn't
+    synced or the workspace routes no MCP traffic through UAG v2.
+    """
+    from backend.database import execute_query
+    empty = {"as_of": None, "totals": {}, "tools": []}
+    try:
+        rows = execute_query(
+            """SELECT service_name, tool_name, server_type, request_count,
+                      error_count, unique_users, max_event_time
+               FROM uag_mcp_tool_daily
+               ORDER BY request_count DESC LIMIT 200"""
+        )
+    except Exception as exc:
+        logger.warning("uag_mcp_tool_daily not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    def _i(r, k):
+        return int(r.get(k) or 0)
+
+    total_req = sum(_i(r, "request_count") for r in rows)
+    total_err = sum(_i(r, "error_count") for r in rows)
+    services = {r.get("service_name") for r in rows if r.get("service_name")}
+    as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+    return {
+        "as_of": as_of,
+        "totals": {
+            "request_count": total_req,
+            "error_count": total_err,
+            "services": len(services),
+            "tools": len(rows),
+        },
+        "tools": [
+            {
+                "service_name": r.get("service_name", ""),
+                "tool_name": r.get("tool_name") or "",
+                "server_type": r.get("server_type") or "",
+                "request_count": _i(r, "request_count"),
+                "error_count": _i(r, "error_count"),
+                "unique_users": _i(r, "unique_users"),
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
     """Per-endpoint usage summary from Lakebase cache."""
     from backend.database import execute_query

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -588,6 +588,16 @@ def ensure_gateway_usage_columns() -> None:
             logger.warning("gateway_usage column ensure skipped: %s", exc)
 
 
+def _row_int(r: Dict[str, Any], k: str) -> int:
+    """Coerce a nullable Lakebase numeric column to int."""
+    return int(r.get(k) or 0)
+
+
+def _max_as_of(rows: List[Dict[str, Any]]) -> Optional[str]:
+    """Latest max_event_time across rows — the cache's 'as of' timestamp."""
+    return max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+
+
 def get_uag_v2_usage() -> Dict[str, Any]:
     """Unity AI Gateway (v2) usage summary from `uag_usage_summary` (sourced from
     system.ai_gateway.usage — v2-routed endpoints only, ~20-min fresh).
@@ -612,9 +622,7 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     if not rows:
         return empty
 
-    def _i(r, k):
-        return int(r.get(k) or 0)
-
+    _i = _row_int
     total_req = sum(_i(r, "request_count") for r in rows)
     total_in = sum(_i(r, "input_tokens") for r in rows)
     total_out = sum(_i(r, "output_tokens") for r in rows)
@@ -622,7 +630,7 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     total_cache_create = sum(_i(r, "cache_creation_tokens") for r in rows)
     cached = total_cache_read + total_cache_create
     cache_pct = round(100.0 * total_cache_read / total_in, 1) if total_in else 0.0
-    as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+    as_of = _max_as_of(rows)
 
     # Additive breakdowns (agent-vs-human / by model / by api_type) — same source table.
     breakdowns: Dict[str, list] = {}
@@ -681,42 +689,45 @@ def get_uag_mcp_tools() -> Dict[str, Any]:
     """
     from backend.database import execute_query
     empty = {"as_of": None, "totals": {}, "tools": []}
+    # Account-wide totals from an unbounded aggregate — deriving them from the
+    # capped list below would undercount services/tools/requests past the LIMIT.
     try:
-        rows = execute_query(
-            """SELECT service_name, tool_name, server_type, request_count,
-                      error_count, unique_users, max_event_time
-               FROM uag_mcp_tool_daily
-               ORDER BY request_count DESC LIMIT 200"""
+        agg = execute_query(
+            """SELECT COUNT(*) AS tools, COUNT(DISTINCT service_name) AS services,
+                      COALESCE(SUM(request_count), 0) AS request_count,
+                      COALESCE(SUM(error_count), 0) AS error_count,
+                      MAX(max_event_time) AS as_of
+               FROM uag_mcp_tool_daily"""
         )
     except Exception as exc:
         logger.warning("uag_mcp_tool_daily not available: %s", exc)
         return empty
-    if not rows:
+    totals = agg[0] if agg else {}
+    if not totals or _row_int(totals, "tools") == 0:
         return empty
 
-    def _i(r, k):
-        return int(r.get(k) or 0)
-
-    total_req = sum(_i(r, "request_count") for r in rows)
-    total_err = sum(_i(r, "error_count") for r in rows)
-    services = {r.get("service_name") for r in rows if r.get("service_name")}
-    as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+    rows = execute_query(
+        """SELECT service_name, tool_name, server_type, request_count,
+                  error_count, unique_users
+           FROM uag_mcp_tool_daily
+           ORDER BY request_count DESC LIMIT 25"""
+    )
     return {
-        "as_of": as_of,
+        "as_of": totals.get("as_of"),
         "totals": {
-            "request_count": total_req,
-            "error_count": total_err,
-            "services": len(services),
-            "tools": len(rows),
+            "request_count": _row_int(totals, "request_count"),
+            "error_count": _row_int(totals, "error_count"),
+            "services": _row_int(totals, "services"),
+            "tools": _row_int(totals, "tools"),
         },
         "tools": [
             {
                 "service_name": r.get("service_name", ""),
                 "tool_name": r.get("tool_name") or "",
                 "server_type": r.get("server_type") or "",
-                "request_count": _i(r, "request_count"),
-                "error_count": _i(r, "error_count"),
-                "unique_users": _i(r, "unique_users"),
+                "request_count": _row_int(r, "request_count"),
+                "error_count": _row_int(r, "error_count"),
+                "unique_users": _row_int(r, "unique_users"),
             }
             for r in rows
         ],

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -603,7 +603,27 @@ export interface UagV2Usage {
     requester_type?: UagBreakdownRow[]
     destination_model?: UagBreakdownRow[]
     api_type?: UagBreakdownRow[]
+    service_type?: UagBreakdownRow[]
+    route_action?: UagBreakdownRow[]
   }
+}
+
+export interface UagMcpTools {
+  as_of: string | null
+  totals: Partial<{
+    request_count: number
+    error_count: number
+    services: number
+    tools: number
+  }>
+  tools: Array<{
+    service_name: string
+    tool_name: string
+    server_type: string
+    request_count: number
+    error_count: number
+    unique_users: number
+  }>
 }
 
 export interface UagBreakdownRow {
@@ -621,6 +641,18 @@ export function useUagV2Usage() {
     queryFn: async () => {
       const { data } = await apiClient.get('/gateway/uag-v2-usage')
       return data as UagV2Usage
+    },
+    staleTime: GW_STALE,
+  })
+}
+
+/** Per-tool MCP activity from system.ai_gateway.usage (service_type = MCP_SERVICE). */
+export function useUagMcpTools() {
+  return useQuery({
+    queryKey: ['gateway', 'uag-mcp-tools'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/uag-mcp-tools')
+      return data as UagMcpTools
     },
     staleTime: GW_STALE,
   })

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -174,6 +174,14 @@ export default function AIGatewayPage() {
   )
 }
 
+/* Spark stringifies timestamps as "YYYY-MM-DD HH:MM:SS[.fff]" (space, no 'T'),
+ * which Safari parses as Invalid Date. Swap the space for 'T' before formatting;
+ * fall back to the raw string if it still won't parse. */
+function fmtAsOf(s: string): string {
+  const d = new Date(s.includes('T') ? s : s.replace(' ', 'T'))
+  return isNaN(d.getTime()) ? s : d.toLocaleString()
+}
+
 /* ── Unity AI Gateway v2 (Beta) Section ───────────────────────── */
 
 function UagV2Section() {
@@ -207,7 +215,7 @@ function UagV2Section() {
             </span>
             {uag?.as_of && (
               <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
-                as of {new Date(uag.as_of).toLocaleString()}
+                as of {fmtAsOf(uag.as_of)}
               </span>
             )}
           </CardTitle>
@@ -295,7 +303,7 @@ function UagV2Section() {
           />
           <UagBreakdownCard
             title="Routing Outcomes"
-            subtitle="Requests by routing attempt"
+            subtitle="Attempts by outcome (initial vs. fallback)"
             rows={uag.breakdowns.route_action}
             labelMap={{ INITIAL_ATTEMPT: 'Initial', FALLBACK: 'Fallback', unknown: 'Unknown' }}
           />
@@ -323,7 +331,7 @@ function UagMcpToolsCard() {
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
           MCP tool invocations governed through Unity AI Gateway v2
-          {mcp?.as_of && <> · as of {new Date(mcp.as_of).toLocaleString()}</>}
+          {mcp?.as_of && <> · as of {fmtAsOf(mcp.as_of)}</>}
         </p>
       </CardHeader>
       <CardContent>
@@ -339,7 +347,7 @@ function UagMcpToolsCard() {
             </tr>
           </thead>
           <tbody>
-            {tools.slice(0, 15).map((t, i) => (
+            {tools.map((t, i) => (
               <tr key={`${t.service_name}-${t.tool_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
                 <td className="py-1.5 font-mono text-xs truncate max-w-[240px]" title={t.service_name}>{t.service_name}</td>
                 <td className="py-1.5">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -12,6 +12,7 @@ import {
   useGatewayUsageTimeseries,
   useGatewayUsageByUser,
   useUagV2Usage,
+  useUagMcpTools,
   type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
@@ -281,9 +282,77 @@ function UagV2Section() {
             subtitle="Requests by API surface"
             rows={uag.breakdowns.api_type}
           />
+          <UagBreakdownCard
+            title="Service Type"
+            subtitle="Model vs. MCP vs. provider (typed traffic)"
+            rows={uag.breakdowns.service_type}
+            labelMap={{
+              MODEL_SERVICE: 'Model',
+              MCP_SERVICE: 'MCP',
+              MODEL_PROVIDER_SERVICE: 'Provider',
+              unknown: 'Unknown',
+            }}
+          />
+          <UagBreakdownCard
+            title="Routing Outcomes"
+            subtitle="Requests by routing attempt"
+            rows={uag.breakdowns.route_action}
+            labelMap={{ INITIAL_ATTEMPT: 'Initial', FALLBACK: 'Fallback', unknown: 'Unknown' }}
+          />
         </div>
       )}
+
+      <UagMcpToolsCard />
     </div>
+  )
+}
+
+/* Top MCP tools — service_type=MCP_SERVICE rows from system.ai_gateway.usage. */
+function UagMcpToolsCard() {
+  const { data: mcp, isLoading } = useUagMcpTools()
+  const tools = mcp?.tools || []
+  if (isLoading || tools.length === 0) return null
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Top MCP Tools
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+            {mcp!.totals.services ?? 0} services · {mcp!.totals.tools ?? 0} tools
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          MCP tool invocations governed through Unity AI Gateway v2
+          {mcp?.as_of && <> · as of {new Date(mcp.as_of).toLocaleString()}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+              <th className="py-2 font-medium">MCP Service</th>
+              <th className="py-2 font-medium">Tool</th>
+              <th className="py-2 font-medium">Type</th>
+              <th className="py-2 font-medium text-right">Requests</th>
+              <th className="py-2 font-medium text-right">Errors</th>
+              <th className="py-2 font-medium text-right">Users</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tools.slice(0, 15).map((t, i) => (
+              <tr key={`${t.service_name}-${t.tool_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                <td className="py-1.5 font-mono text-xs truncate max-w-[240px]" title={t.service_name}>{t.service_name}</td>
+                <td className="py-1.5">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>
+                <td className="py-1.5 text-gray-500 dark:text-gray-400">{t.server_type || '—'}</td>
+                <td className="py-1.5 text-right tabular-nums">{t.request_count.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{t.error_count.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{t.unique_users.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1697,10 +1697,13 @@ with uag_conn.cursor() as cur:
     uag_conn.commit()
 print(f"▸ Syncing {UAG_MCP_TOOL_TABLE} → uag_mcp_tool_daily ...")
 try:
+    # Read Delta BEFORE truncating: a transient read failure after an early
+    # TRUNCATE would otherwise leave the Lakebase cache empty (silent, since
+    # this table is EXPECTED-not-REQUIRED in the smoke check).
+    mcp_rows = spark.read.table(UAG_MCP_TOOL_TABLE).collect()
     with uag_conn.cursor() as cur:
         cur.execute("TRUNCATE TABLE uag_mcp_tool_daily")
         uag_conn.commit()
-    mcp_rows = spark.read.table(UAG_MCP_TOOL_TABLE).collect()
     if mcp_rows:
         values = [(r.service_name, r.tool_name, r.server_type, int(r.request_count or 0),
                    int(r.error_count or 0), int(r.unique_users or 0), r.max_event_time, now)

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1677,6 +1677,47 @@ try:
 except Exception as exc:
     print(f"  ⚠️  uag_usage_breakdown sync failed: {exc}")
 
+# Sync uag_mcp_tool_daily (per-tool MCP activity). tool_name is nullable
+# (server-level calls), so no composite PK — full-refresh via TRUNCATE + INSERT.
+UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
+uag_mcp_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_mcp_tool_daily (
+            service_name   TEXT NOT NULL,
+            tool_name      TEXT,
+            server_type    TEXT,
+            request_count  BIGINT DEFAULT 0,
+            error_count    BIGINT DEFAULT 0,
+            unique_users   BIGINT DEFAULT 0,
+            max_event_time TEXT,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_umt_service ON uag_mcp_tool_daily (service_name)")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_MCP_TOOL_TABLE} → uag_mcp_tool_daily ...")
+try:
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_mcp_tool_daily")
+        uag_conn.commit()
+    mcp_rows = spark.read.table(UAG_MCP_TOOL_TABLE).collect()
+    if mcp_rows:
+        values = [(r.service_name, r.tool_name, r.server_type, int(r.request_count or 0),
+                   int(r.error_count or 0), int(r.unique_users or 0), r.max_event_time, now)
+                  for r in mcp_rows]
+        uag_mcp_count = len(values)
+        with uag_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO uag_mcp_tool_daily
+                   (service_name, tool_name, server_type, request_count, error_count,
+                    unique_users, max_event_time, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+            uag_conn.commit()
+    print(f"  ✅ {uag_mcp_count} UAG MCP tool rows synced")
+except Exception as exc:
+    print(f"  ⚠️  uag_mcp_tool_daily sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -85,6 +85,7 @@ EXPECTED = [
     "vector_search_indexes",         # endpoints can exist with 0 indexes
     "vector_search_health_history",
     "kb_billing_daily",              # only populated when Vector Search indexes exist
+    "uag_mcp_tool_daily",            # only populated when MCP services route through UAG v2
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -12,7 +12,7 @@
 # MAGIC serving), so it is additive — not a replacement for billing (dollar cost)
 # MAGIC or serving.endpoint_usage (broad coverage + rate-limit hits).
 # MAGIC
-# MAGIC **Tables written:** `uag_usage_summary`
+# MAGIC **Tables written:** `uag_usage_summary`, `uag_usage_breakdown`, `uag_mcp_tool_daily`
 
 # COMMAND ----------
 
@@ -53,7 +53,8 @@ spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
 
 UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
 UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
-print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE} | retention {RETENTION_DAYS}d")
+UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -74,7 +75,7 @@ UAG_SCHEMA = StructType([
 ])
 
 # Flexible breakdown: one row per (dimension, key). dimension ∈
-# {requester_type, destination_model, api_type} — additive v2 cuts.
+# {requester_type, destination_model, api_type, service_type, route_action} — additive v2 cuts.
 UAG_BREAKDOWN_SCHEMA = StructType([
     StructField("dimension", StringType(), False),
     StructField("key", StringType(), False),
@@ -82,6 +83,19 @@ UAG_BREAKDOWN_SCHEMA = StructType([
     StructField("input_tokens", LongType(), True),
     StructField("output_tokens", LongType(), True),
     StructField("cached_tokens", LongType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Per-tool MCP activity (service_type = MCP_SERVICE). One row per
+# (service_name, tool_name, server_type) over the retention window.
+UAG_MCP_TOOL_SCHEMA = StructType([
+    StructField("service_name", StringType(), False),
+    StructField("tool_name", StringType(), True),
+    StructField("server_type", StringType(), True),
+    StructField("request_count", LongType(), True),
+    StructField("error_count", LongType(), True),
+    StructField("unique_users", LongType(), True),
+    StructField("max_event_time", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -172,12 +186,13 @@ print(f"✅ Wrote {len(rows_raw)} rows to {UAG_TABLE}")
 
 # COMMAND ----------
 
-# Breakdowns: agent-vs-human (requester_type), by model (destination_model), by api_type.
-print("▸ Querying ai_gateway.usage breakdowns (requester_type / destination_model / api_type) …")
+# Breakdowns: agent-vs-human (requester_type), model (destination_model), api_type,
+# service_type (model vs MCP vs provider), and route_action (routing outcomes).
+print("▸ Querying ai_gateway.usage breakdowns (requester_type / destination_model / api_type / service_type / route_action) …")
 try:
     bd_rows = _execute_sql(f"""
         WITH base AS (
-            SELECT requester_type, destination_model, api_type, input_tokens, output_tokens,
+            SELECT requester_type, destination_model, api_type, service_type, input_tokens, output_tokens,
                    COALESCE(token_details.cache_read_input_tokens, 0)
                  + COALESCE(token_details.cache_creation_input_tokens, 0) AS cached
             FROM system.ai_gateway.usage
@@ -195,6 +210,19 @@ try:
         SELECT 'api_type', COALESCE(api_type, 'unknown'),
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base GROUP BY api_type
+        UNION ALL
+        -- service_type: exclude legacy untyped rows so the model/MCP/provider split is meaningful
+        SELECT 'service_type', service_type,
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base WHERE service_type IS NOT NULL AND service_type != '' GROUP BY service_type
+        UNION ALL
+        -- route_action: explode routing attempts (fans out rows) → request counts only, tokens N/A
+        SELECT 'route_action', COALESCE(a.action, 'unknown'),
+               COUNT(*), 0, 0, 0
+        FROM system.ai_gateway.usage
+             LATERAL VIEW explode(routing_information.attempts) t AS a
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+        GROUP BY a.action
     """)
     print(f"  ✅ {len(bd_rows)} breakdown rows")
 except Exception as exc:
@@ -212,7 +240,45 @@ print(f"✅ Wrote {len(bd_rows)} rows to {UAG_BREAKDOWN_TABLE}")
 
 # COMMAND ----------
 
+# Per-tool MCP activity — service_type = MCP_SERVICE rows carry service_name (UC FQN)
+# and mcp_metadata.{tool_name, server_type}. tool_name can be null (server-level call).
+print("▸ Querying ai_gateway.usage MCP tool activity (service_type = MCP_SERVICE) …")
+try:
+    mcp_rows_raw = _execute_sql(f"""
+        SELECT
+            service_name,
+            mcp_metadata.tool_name                              AS tool_name,
+            mcp_metadata.server_type                            AS server_type,
+            COUNT(*)                                            AS request_count,
+            SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) AS error_count,
+            COUNT(DISTINCT requester)                           AS unique_users,
+            CAST(MAX(event_time) AS STRING)                     AS max_event_time
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND service_type = 'MCP_SERVICE'
+          AND service_name IS NOT NULL
+        GROUP BY service_name, mcp_metadata.tool_name, mcp_metadata.server_type
+        ORDER BY request_count DESC
+    """)
+    print(f"  ✅ {len(mcp_rows_raw)} MCP tool rows")
+except Exception as exc:
+    mcp_rows_raw = []
+    print(f"  ⚠️  MCP tool query unavailable: {exc}")
+
+if mcp_rows_raw:
+    rows = [(r.get("service_name", ""), r.get("tool_name"), r.get("server_type"),
+             to_int(r.get("request_count")), to_int(r.get("error_count")), to_int(r.get("unique_users")),
+             r.get("max_event_time"), now)
+            for r in mcp_rows_raw]
+    spark.createDataFrame(rows, UAG_MCP_TOOL_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_MCP_TOOL_TABLE)
+else:
+    spark.createDataFrame([], UAG_MCP_TOOL_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_MCP_TOOL_TABLE)
+print(f"✅ Wrote {len(mcp_rows_raw)} rows to {UAG_MCP_TOOL_TABLE}")
+
+# COMMAND ----------
+
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
-          "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
+          "uag_mcp_tool_rows": len(mcp_rows_raw), "retention_days": RETENTION_DAYS,
+          "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -216,7 +216,13 @@ try:
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base WHERE service_type IS NOT NULL AND service_type != '' GROUP BY service_type
         UNION ALL
-        -- route_action: explode routing attempts (fans out rows) → request counts only, tokens N/A
+        -- route_action: per-ATTEMPT outcome, not per-request — a fallback adds a
+        -- second attempt row, so counts are attempt-grain (the UI labels this
+        -- "attempts", not requests, and it won't tie out to the request KPI).
+        -- Plain explode drops rows with no routing attempts, which scopes this to
+        -- v2-routed traffic — parallel to the service_type cut excluding untyped
+        -- legacy rows (explode_outer would flood it with a ~96% 'unknown' bucket).
+        -- Tokens N/A (explode fans out rows).
         SELECT 'route_action', COALESCE(a.action, 'unknown'),
                COUNT(*), 0, 0, 0
         FROM system.ai_gateway.usage


### PR DESCRIPTION
## Summary

Extends the Unity AI Gateway v2 (Beta) tab with three cuts of `system.ai_gateway.usage` that the platform now populates post-DAIS 2026 — making the app **MCP-aware**:

- **Service Type** breakdown — MODEL_SERVICE / MCP_SERVICE / MODEL_PROVIDER_SERVICE (typed traffic; legacy untyped rows excluded so the split is meaningful).
- **Routing Outcomes** breakdown — per-attempt INITIAL_ATTEMPT / FALLBACK from `routing_information.attempts`.
- **Top MCP Tools** table — per-tool MCP invocations: service UC FQN, `mcp_metadata.tool_name`/`server_type`, requests / errors / users.

MCP calls are **first-class rows** in `system.ai_gateway.usage` now (`service_type = MCP_SERVICE` + `mcp_metadata`), not just audit events. This is the first tranche of the DAIS-2026 integration roadmap (F2, folding in the free requester-type/routing columns).

## Plumbing (extends the v0.1.2 UAG v2 pipeline)
- **Workflow 11** — adds `service_type` + `route_action` to the breakdown query; new `uag_mcp_tool_daily` Delta table.
- **02_sync_to_lakebase** — mirrors `uag_mcp_tool_daily` to Lakebase (full-refresh; nullable `tool_name` → no composite PK; reads Delta before TRUNCATE).
- **Smoke check** — `uag_mcp_tool_daily` in EXPECTED (empty when no MCP traffic).
- **Backend** — `get_uag_mcp_tools()` + `GET /gateway/uag-mcp-tools`; `service_type`/`route_action` flow through the existing generic breakdowns map.
- **Frontend** — hook + types, two breakdown cards, and the Top MCP Tools table on the v2 tab.

Degrades to empty when `system.ai_gateway.usage` is unreadable (account-scoping varies) or a workspace routes no MCP traffic through UAG v2.

## Validation
- Queries validated live against the `fevm` account; deployed to the `ai-control-plane` app and a discovery run confirmed the data end-to-end in Lakebase: `uag_mcp_tool_daily` 25 rows, breakdown now carries `service_type` + `route_action`, Top MCP Tools populated (`search_notes`, `system.ai.gmail`, `system.ai.slack`, …).
- Backend/workflows compile; frontend `tsc --noEmit` clean.

## Review
Ran Isaac Review; all five findings applied in the second commit:
1. `route_action` labeled as per-attempt (scoped to v2-routed traffic; `explode_outer` rejected — floods a ~96% legacy 'unknown' bucket).
2. MCP totals from an unbounded aggregate, not the capped list.
3. Sync reads Delta before TRUNCATE (no silent cache-wipe on transient read failure).
4. `fmtAsOf()` normalizes Spark's non-ISO timestamp (Safari "Invalid Date").
5. Hoisted `_row_int` / `_max_as_of` shared helpers.

## Notes
- At merge time, a proper `bundle deploy` from real workflow config is the clean durable step (the fevm validation used a targeted notebook upload of workflows 11 + 02).
- Part of the DAIS-2026 roadmap; F1 (agent registry) stays parked until UC agent securables ship, F3 (managed-MCP inventory) is a follow-up.

This pull request and its description were written by Isaac.
