### PR TITLE
feat(tools): MCP usage view on the Tools page + AI Gateway direction note

### DIFF
--- a/control-plane-app/backend/api/tools.py
+++ b/control-plane-app/backend/api/tools.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, List
 from backend.services.tools_service import (
     get_tools_overview,
     get_mcp_servers,
+    get_mcp_activity,
     get_uc_functions,
     get_tool_usage,
     refresh_tools,
@@ -23,6 +24,13 @@ def tools_overview() -> Dict[str, Any]:
 def list_mcp_servers() -> List[Dict[str, Any]]:
     """List MCP server / serving endpoints with managed/custom classification."""
     return get_mcp_servers()
+
+
+@router.get("/mcp-activity")
+def mcp_activity() -> Dict[str, Any]:
+    """Server-grouped MCP tool activity from Unity AI Gateway v2 (managed vs
+    UC-registered services, per-tool request/error/user counts)."""
+    return get_mcp_activity()
 
 
 @router.get("/functions")

--- a/control-plane-app/backend/services/tools_service.py
+++ b/control-plane-app/backend/services/tools_service.py
@@ -559,6 +559,73 @@ def get_mcp_servers() -> List[Dict[str, Any]]:
     return result
 
 
+def get_mcp_activity() -> Dict[str, Any]:
+    """Server-grouped MCP tool activity from `uag_mcp_tool_daily` (Unity AI
+    Gateway v2, service_type = MCP_SERVICE).
+
+    Complements the connection-based inventory in get_mcp_servers(): that lists
+    configured UC MCP connections; this shows what actually routed through the
+    gateway, keyed by UC service FQN. The two are distinct namespaces (a
+    connection named `acorn_mcp` vs a service `system.ai.slack`) and are not
+    joined. Each service is classified Databricks-managed (system.ai.*) vs
+    UC-registered. Degrades to empty when the table is unsynced or no MCP
+    traffic has been routed.
+    """
+    empty: Dict[str, Any] = {"as_of": None, "totals": {}, "servers": []}
+    try:
+        rows = execute_query(
+            """SELECT service_name, tool_name, server_type, request_count,
+                      error_count, unique_users, max_event_time
+               FROM uag_mcp_tool_daily
+               ORDER BY service_name, request_count DESC"""
+        )
+    except Exception as exc:
+        logger.warning("uag_mcp_tool_daily not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    servers: Dict[str, Dict[str, Any]] = {}
+    for r in rows:
+        svc = r.get("service_name") or ""
+        s = servers.get(svc)
+        if s is None:
+            s = servers[svc] = {
+                "service_name": svc,
+                "managed": svc.startswith("system.ai."),
+                "server_type": r.get("server_type") or "",
+                "request_count": 0,
+                "error_count": 0,
+                "tool_count": 0,
+                "tools": [],
+            }
+        rc = int(r.get("request_count") or 0)
+        ec = int(r.get("error_count") or 0)
+        s["request_count"] += rc
+        s["error_count"] += ec
+        tool = r.get("tool_name")
+        if tool:
+            s["tool_count"] += 1
+        s["tools"].append({
+            "tool_name": tool or "",
+            "request_count": rc,
+            "error_count": ec,
+            "unique_users": int(r.get("unique_users") or 0),
+        })
+
+    server_list = sorted(servers.values(), key=lambda x: x["request_count"], reverse=True)
+    as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
+    return {
+        "as_of": as_of,
+        "totals": {
+            "services": len(server_list),
+            "managed": sum(1 for s in server_list if s["managed"]),
+            "request_count": sum(s["request_count"] for s in server_list),
+        },
+        "servers": server_list,
+    }
+
+
 def get_uc_functions() -> List[Dict[str, Any]]:
     """List all UC function entries from the tool registry."""
     maybe_refresh_async()

--- a/control-plane-app/backend/services/tools_service.py
+++ b/control-plane-app/backend/services/tools_service.py
@@ -574,7 +574,7 @@ def get_mcp_activity() -> Dict[str, Any]:
     empty: Dict[str, Any] = {"as_of": None, "totals": {}, "servers": []}
     try:
         rows = execute_query(
-            """SELECT service_name, tool_name, server_type, request_count,
+            """SELECT service_name, tool_name, request_count,
                       error_count, unique_users, max_event_time
                FROM uag_mcp_tool_daily
                ORDER BY service_name, request_count DESC"""
@@ -585,6 +585,10 @@ def get_mcp_activity() -> Dict[str, Any]:
     if not rows:
         return empty
 
+    # Group tool-grain rows into servers. Merge tools by name within a service so
+    # a tool that appears under >1 server_type collapses to one row (summed) —
+    # avoids duplicate tool rows and an inflated tool_count. An empty tool_name
+    # is a server-level call, rendered as "(server)" and excluded from tool_count.
     servers: Dict[str, Dict[str, Any]] = {}
     for r in rows:
         svc = r.get("service_name") or ""
@@ -593,27 +597,31 @@ def get_mcp_activity() -> Dict[str, Any]:
             s = servers[svc] = {
                 "service_name": svc,
                 "managed": svc.startswith("system.ai."),
-                "server_type": r.get("server_type") or "",
                 "request_count": 0,
                 "error_count": 0,
                 "tool_count": 0,
-                "tools": [],
+                "_tools": {},
             }
         rc = int(r.get("request_count") or 0)
         ec = int(r.get("error_count") or 0)
         s["request_count"] += rc
         s["error_count"] += ec
-        tool = r.get("tool_name")
-        if tool:
-            s["tool_count"] += 1
-        s["tools"].append({
-            "tool_name": tool or "",
-            "request_count": rc,
-            "error_count": ec,
-            "unique_users": int(r.get("unique_users") or 0),
-        })
+        tname = r.get("tool_name") or ""
+        t = s["_tools"].get(tname)
+        if t is None:
+            t = s["_tools"][tname] = {"tool_name": tname, "request_count": 0, "error_count": 0, "unique_users": 0}
+        t["request_count"] += rc
+        t["error_count"] += ec
+        # distinct-user counts can't be summed across merged rows; take the max
+        t["unique_users"] = max(t["unique_users"], int(r.get("unique_users") or 0))
 
-    server_list = sorted(servers.values(), key=lambda x: x["request_count"], reverse=True)
+    server_list = []
+    for s in servers.values():
+        tools = sorted(s.pop("_tools").values(), key=lambda x: x["request_count"], reverse=True)
+        s["tool_count"] = sum(1 for t in tools if t["tool_name"])
+        s["tools"] = tools
+        server_list.append(s)
+    server_list.sort(key=lambda x: x["request_count"], reverse=True)
     as_of = max((r.get("max_event_time") for r in rows if r.get("max_event_time")), default=None)
     return {
         "as_of": as_of,

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -761,6 +761,31 @@ export function useMcpServers() {
   })
 }
 
+export interface McpActivity {
+  as_of: string | null
+  totals: Partial<{ services: number; managed: number; request_count: number }>
+  servers: Array<{
+    service_name: string
+    managed: boolean
+    server_type: string
+    request_count: number
+    error_count: number
+    tool_count: number
+    tools: Array<{ tool_name: string; request_count: number; error_count: number; unique_users: number }>
+  }>
+}
+
+/** Server-grouped MCP tool activity from Unity AI Gateway v2. */
+export function useMcpActivity() {
+  return useQuery({
+    queryKey: ['tools', 'mcp-activity'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/tools/mcp-activity')
+      return data as McpActivity
+    },
+  })
+}
+
 export function useUcFunctions() {
   return useQuery({
     queryKey: ['tools', 'uc-functions'],

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -767,7 +767,6 @@ export interface McpActivity {
   servers: Array<{
     service_name: string
     managed: boolean
-    server_type: string
     request_count: number
     error_count: number
     tool_count: number

--- a/control-plane-app/frontend/src/lib/formatters.ts
+++ b/control-plane-app/frontend/src/lib/formatters.ts
@@ -98,6 +98,19 @@ export function formatDateShort(v: any): string {
   return `${base} ${hh}:${mm}`
 }
 
+/** Format a Unity system-table "as of" timestamp for display.
+ *  Spark stringifies timestamps as "YYYY-MM-DD HH:MM:SS[.fff]" — space-separated
+ *  (Invalid Date in Safari) and with no offset though the value is UTC. Normalize
+ *  to ISO-UTC (space→'T', append 'Z') before formatting; fall back to the raw
+ *  string if it still won't parse. */
+export function formatAsOf(v: string | null | undefined): string {
+  if (!v) return ''
+  let s = v.includes('T') ? v : v.replace(' ', 'T')
+  if (!s.endsWith('Z') && !s.includes('+')) s += 'Z'
+  const d = new Date(s)
+  return Number.isNaN(d.getTime()) ? v : d.toLocaleString()
+}
+
 /** Full ISO string for tooltip / title attribute. */
 export function formatDateFull(v: any): string {
   const d = parseDateCell(v)

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -135,10 +135,10 @@ export default function AIGatewayPage() {
         <Sparkles className="w-4 h-4 mt-0.5 flex-shrink-0 text-indigo-500 dark:text-indigo-400" />
         <p className="leading-snug">
           <span className="font-semibold">Unity AI Gateway is where this is headed.</span>{' '}
-          UAG is Databricks' native control plane for AI governance. We integrate its capabilities
+          It's Databricks' native control plane for AI governance. We integrate its capabilities
           as they reach general availability — start with the{' '}
           <span className="font-medium">Unity AI Gateway v2 (Beta)</span> tab — and retire legacy
-          views here as they're superseded. Expect this page to shift toward UAG over time.
+          views here as they're superseded. Expect this page to shift toward Unity AI Gateway over time.
         </p>
       </div>
 

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -136,7 +136,7 @@ export default function AIGatewayPage() {
         <p className="leading-snug">
           <span className="font-semibold">Unity AI Gateway is where this is headed.</span>{' '}
           It's Databricks' native control plane for AI governance. We integrate its capabilities
-          as they reach general availability — start with the{' '}
+          as soon as their APIs are available — start with the{' '}
           <span className="font-medium">Unity AI Gateway v2 (Beta)</span> tab — and retire legacy
           views here as they're superseded. Expect this page to shift toward Unity AI Gateway over time.
         </p>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -21,6 +21,7 @@ import {
   useCurrentUser,
 } from '@/api/hooks'
 import { RefreshButton } from '@/components/RefreshButton'
+import { formatAsOf } from '@/lib/formatters'
 import { SortableHeader, useSort, sortRows } from '@/components/SortableTable'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -174,14 +175,6 @@ export default function AIGatewayPage() {
   )
 }
 
-/* Spark stringifies timestamps as "YYYY-MM-DD HH:MM:SS[.fff]" (space, no 'T'),
- * which Safari parses as Invalid Date. Swap the space for 'T' before formatting;
- * fall back to the raw string if it still won't parse. */
-function fmtAsOf(s: string): string {
-  const d = new Date(s.includes('T') ? s : s.replace(' ', 'T'))
-  return isNaN(d.getTime()) ? s : d.toLocaleString()
-}
-
 /* ── Unity AI Gateway v2 (Beta) Section ───────────────────────── */
 
 function UagV2Section() {
@@ -215,7 +208,7 @@ function UagV2Section() {
             </span>
             {uag?.as_of && (
               <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
-                as of {fmtAsOf(uag.as_of)}
+                as of {formatAsOf(uag.as_of)}
               </span>
             )}
           </CardTitle>
@@ -331,7 +324,7 @@ function UagMcpToolsCard() {
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
           MCP tool invocations governed through Unity AI Gateway v2
-          {mcp?.as_of && <> · as of {fmtAsOf(mcp.as_of)}</>}
+          {mcp?.as_of && <> · as of {formatAsOf(mcp.as_of)}</>}
         </p>
       </CardHeader>
       <CardContent>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -130,6 +130,18 @@ export default function AIGatewayPage() {
         </div>
       </div>
 
+      {/* Product direction */}
+      <div className="flex items-start gap-2.5 rounded-lg border border-indigo-200 bg-indigo-50 px-3.5 py-2.5 text-[13px] text-indigo-900 dark:border-indigo-900/50 dark:bg-indigo-950/30 dark:text-indigo-200">
+        <Sparkles className="w-4 h-4 mt-0.5 flex-shrink-0 text-indigo-500 dark:text-indigo-400" />
+        <p className="leading-snug">
+          <span className="font-semibold">Unity AI Gateway is where this is headed.</span>{' '}
+          UAG is Databricks' native control plane for AI governance. We integrate its capabilities
+          as they reach general availability — start with the{' '}
+          <span className="font-medium">Unity AI Gateway v2 (Beta)</span> tab — and retire legacy
+          views here as they're superseded. Expect this page to shift toward UAG over time.
+        </p>
+      </div>
+
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
         {tabs.map(({ id, label, icon: Icon, beta }) => (

--- a/control-plane-app/frontend/src/pages/Tools.tsx
+++ b/control-plane-app/frontend/src/pages/Tools.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { KpiCard } from '@/components/KpiCard'
 import { TablePagination } from '@/components/TablePagination'
+import { formatAsOf } from '@/lib/formatters'
 import {
   Wrench,
   Server,
@@ -286,7 +287,7 @@ export default function ToolsPage() {
 
         return (
           <div className="space-y-4">
-            <McpUsageSection />
+            <McpUsageSection query={q} />
             {mcpLoading ? (
               <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
             ) : filteredMcp.length === 0 ? (
@@ -503,10 +504,15 @@ export default function ToolsPage() {
  * managed (system.ai.*) vs UC-registered split — a distinct namespace from the
  * connection inventory below, so it's shown as its own panel. Hidden when no MCP
  * traffic has routed through the gateway. */
-function McpUsageSection() {
+function McpUsageSection({ query }: { query: string }) {
   const { data, isLoading } = useMcpActivity()
   const [expanded, setExpanded] = useState<string | null>(null)
-  const servers = data?.servers || []
+  const q = query.trim().toLowerCase()
+  const servers = (data?.servers || []).filter((s) =>
+    !q ||
+    s.service_name.toLowerCase().includes(q) ||
+    s.tools.some((t) => t.tool_name.toLowerCase().includes(q))
+  )
   if (isLoading || servers.length === 0) return null
 
   return (
@@ -515,12 +521,12 @@ function McpUsageSection() {
         <CardTitle className="text-base flex items-center gap-2">
           MCP Usage
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
-            {data!.totals.services ?? 0} services · {data!.totals.managed ?? 0} managed
+            {servers.length} services · {servers.filter((s) => s.managed).length} managed
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
           MCP tool calls governed through Unity AI Gateway v2 (distinct from the configured connections below)
-          {data?.as_of && <> · as of {new Date(data.as_of.includes('T') ? data.as_of : data.as_of.replace(' ', 'T')).toLocaleString()}</>}
+          {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
       </CardHeader>
       <CardContent>

--- a/control-plane-app/frontend/src/pages/Tools.tsx
+++ b/control-plane-app/frontend/src/pages/Tools.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, Fragment } from 'react'
 import {
   useToolsOverview,
   useMcpServers,
+  useMcpActivity,
   useUcFunctions,
   useToolUsage,
   useSyncTools,
@@ -285,6 +286,7 @@ export default function ToolsPage() {
 
         return (
           <div className="space-y-4">
+            <McpUsageSection />
             {mcpLoading ? (
               <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
             ) : filteredMcp.length === 0 ? (
@@ -494,5 +496,102 @@ export default function ToolsPage() {
         )
       })()}
     </div>
+  )
+}
+
+/* MCP usage via Unity AI Gateway v2 (uag_mcp_tool_daily). Server-grouped, with a
+ * managed (system.ai.*) vs UC-registered split — a distinct namespace from the
+ * connection inventory below, so it's shown as its own panel. Hidden when no MCP
+ * traffic has routed through the gateway. */
+function McpUsageSection() {
+  const { data, isLoading } = useMcpActivity()
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const servers = data?.servers || []
+  if (isLoading || servers.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          MCP Usage
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+            {data!.totals.services ?? 0} services · {data!.totals.managed ?? 0} managed
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          MCP tool calls governed through Unity AI Gateway v2 (distinct from the configured connections below)
+          {data?.as_of && <> · as of {new Date(data.as_of.includes('T') ? data.as_of : data.as_of.replace(' ', 'T')).toLocaleString()}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
+                <th className="py-2 font-medium">MCP Service</th>
+                <th className="py-2 font-medium">Class</th>
+                <th className="py-2 font-medium text-right">Tools</th>
+                <th className="py-2 font-medium text-right">Requests</th>
+                <th className="py-2 font-medium text-right">Errors</th>
+              </tr>
+            </thead>
+            <tbody>
+              {servers.map((s) => {
+                const open = expanded === s.service_name
+                return (
+                  <Fragment key={s.service_name}>
+                    <tr
+                      className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer"
+                      onClick={() => setExpanded(open ? null : s.service_name)}
+                    >
+                      <td className="py-2.5">
+                        <div className="flex items-center gap-2">
+                          <Server className="w-4 h-4 text-gray-400 flex-shrink-0" />
+                          <span className="font-mono text-xs truncate max-w-[260px]" title={s.service_name}>{s.service_name}</span>
+                        </div>
+                      </td>
+                      <td className="py-2.5">
+                        <Badge variant={s.managed ? 'default' : 'info'} className="text-xs">
+                          {s.managed ? 'Databricks-managed' : 'UC-registered'}
+                        </Badge>
+                      </td>
+                      <td className="py-2.5 text-right tabular-nums">{s.tool_count}</td>
+                      <td className="py-2.5 text-right tabular-nums">{s.request_count.toLocaleString()}</td>
+                      <td className="py-2.5 text-right tabular-nums">{s.error_count.toLocaleString()}</td>
+                    </tr>
+                    {open && (
+                      <tr key={s.service_name + ':tools'} className="bg-gray-50/60 dark:bg-gray-800/30">
+                        <td colSpan={5} className="px-4 py-2">
+                          <table className="w-full text-xs">
+                            <thead>
+                              <tr className="text-left text-gray-400 dark:text-gray-500">
+                                <th className="py-1 font-medium">Tool</th>
+                                <th className="py-1 font-medium text-right">Requests</th>
+                                <th className="py-1 font-medium text-right">Errors</th>
+                                <th className="py-1 font-medium text-right">Users</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {s.tools.map((t, i) => (
+                                <tr key={`${s.service_name}:${t.tool_name}:${i}`}>
+                                  <td className="py-1">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>
+                                  <td className="py-1 text-right tabular-nums">{t.request_count.toLocaleString()}</td>
+                                  <td className="py-1 text-right tabular-nums">{t.error_count.toLocaleString()}</td>
+                                  <td className="py-1 text-right tabular-nums">{t.unique_users.toLocaleString()}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
   )
 }


### PR DESCRIPTION
## Summary

Adds a **server-grouped MCP usage panel** to the Tools page (roadmap **W1.2**), plus a product-direction note on the AI Gateway page. Sourced from `uag_mcp_tool_daily` (Unity AI Gateway v2, `service_type = MCP_SERVICE`):

- MCP **services** with per-tool request / error / user counts (expandable rows), classified **Databricks-managed (`system.ai.*`) vs UC-registered**; honors the page search.
- A small banner on the AI Gateway page communicating the direction: Unity AI Gateway is the native control plane we build toward — integrate capabilities **as soon as their APIs are available**, retire legacy views as superseded.

> Rebased onto `main` after #22 merged (this replaces the auto-closed #23, which GitHub closed when #22's base branch was deleted). W1.1's commits are already in `main` via #22; this PR is W1.2 only.

## Design note
The activity data and the existing MCP inventory are **distinct namespaces that don't join** (connections named `acorn_mcp` vs services `system.ai.slack`), so this is a separate panel, not a forced join. Validated live on `fevm`: 12 services (7 managed / 5 UC-registered), 1,034 requests.

## Plumbing
- backend: `tools_service.get_mcp_activity()` + `GET /tools/mcp-activity`
- frontend: `useMcpActivity` hook, `McpUsageSection`, shared UTC-aware `formatAsOf` in `lib/formatters` (reused on both Tools and AI Gateway pages)
- no workflow change (reuses W1.1's `uag_mcp_tool_daily`)

## Review
Ran Isaac Review; applied the actionable findings (as_of timezone via shared helper; search filter; tool merge-by-name + correct `tool_count`; dropped dead `server_type`). Deployed to fevm and verified end-to-end.

This pull request and its description were written by Isaac.
