### PR TITLE
feat(gateway): guardrail coverage on the AI Gateway page (UAG v2)

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -188,6 +188,14 @@ def uag_mcp_tools():
     return gateway_service.get_uag_mcp_tools()
 
 
+@router.get("/guardrail-coverage")
+def guardrail_coverage():
+    """Guardrail coverage/activity per endpoint from Unity AI Gateway v2
+    (which endpoints are guarded, check volume, judge models). Coverage only —
+    not block/mask outcomes (those need the gated UAG feature-results surface)."""
+    return gateway_service.get_guardrail_coverage()
+
+
 @router.get("/inference-logs")
 def inference_logs(
     limit: int = Query(default=50, le=500),

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -734,6 +734,60 @@ def get_uag_mcp_tools() -> Dict[str, Any]:
     }
 
 
+def get_guardrail_coverage() -> Dict[str, Any]:
+    """Guardrail COVERAGE / activity from `uag_guardrail_daily` — which endpoints
+    have Unity AI Gateway v2 guardrails running, how often, and by which judge
+    model(s). Coverage ratio uses the total endpoint count from uag_usage_summary.
+
+    IMPORTANT: this is coverage/activity only, NOT block/mask outcomes. The
+    guardrail verdict is not present in system.ai_gateway.usage (guardrail rows
+    are the judge-model invocations, which succeed with 200); outcomes require
+    the enrollment-gated UAG feature-results surface. Degrades to empty when the
+    table is unsynced or no endpoint has guardrails active.
+    """
+    from backend.database import execute_query, execute_one
+    empty: Dict[str, Any] = {"as_of": None, "outcomes_available": False, "totals": {}, "endpoints": []}
+    try:
+        rows = execute_query(
+            """SELECT endpoint_name, checked_requests, unique_users, judge_models, max_event_time
+               FROM uag_guardrail_daily
+               ORDER BY checked_requests DESC LIMIT 200"""
+        )
+    except Exception as exc:
+        logger.warning("uag_guardrail_daily not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    total_endpoints = 0
+    try:
+        r = execute_one("SELECT COUNT(*) AS n FROM uag_usage_summary")
+        total_endpoints = int((r or {}).get("n") or 0)
+    except Exception:
+        pass
+
+    return {
+        "as_of": _max_as_of(rows),
+        # No BLOCK/MASK verdicts at this scope — the UI shows coverage only and
+        # flags that outcomes need the gated feature-results surface.
+        "outcomes_available": False,
+        "totals": {
+            "guarded_endpoints": len(rows),
+            "total_endpoints": total_endpoints,
+            "checked_requests": sum(_row_int(r, "checked_requests") for r in rows),
+        },
+        "endpoints": [
+            {
+                "endpoint_name": r.get("endpoint_name", ""),
+                "checked_requests": _row_int(r, "checked_requests"),
+                "unique_users": _row_int(r, "unique_users"),
+                "judge_models": r.get("judge_models") or "",
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
     """Per-endpoint usage summary from Lakebase cache."""
     from backend.database import execute_query

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -737,7 +737,7 @@ def get_uag_mcp_tools() -> Dict[str, Any]:
 def get_guardrail_coverage() -> Dict[str, Any]:
     """Guardrail COVERAGE / activity from `uag_guardrail_daily` — which endpoints
     have Unity AI Gateway v2 guardrails running, how often, and by which judge
-    model(s). Coverage ratio uses the total endpoint count from uag_usage_summary.
+    model(s).
 
     IMPORTANT: this is coverage/activity only, NOT block/mask outcomes. The
     guardrail verdict is not present in system.ai_gateway.usage (guardrail rows
@@ -746,35 +746,35 @@ def get_guardrail_coverage() -> Dict[str, Any]:
     table is unsynced or no endpoint has guardrails active.
     """
     from backend.database import execute_query, execute_one
-    empty: Dict[str, Any] = {"as_of": None, "outcomes_available": False, "totals": {}, "endpoints": []}
+    empty: Dict[str, Any] = {"as_of": None, "totals": {}, "endpoints": []}
+    # Totals from an unbounded aggregate (the row list below is capped for display).
+    # No coverage ratio: a comparable "total guardable endpoints" denominator isn't
+    # derivable here (uag_usage_summary counts MCP + judge endpoints too), so we
+    # report the guarded count rather than a misleading "X of Y".
     try:
-        rows = execute_query(
-            """SELECT endpoint_name, checked_requests, unique_users, judge_models, max_event_time
-               FROM uag_guardrail_daily
-               ORDER BY checked_requests DESC LIMIT 200"""
+        agg = execute_one(
+            """SELECT COUNT(*) AS guarded_endpoints,
+                      COALESCE(SUM(checked_requests), 0) AS checked_requests,
+                      MAX(max_event_time) AS as_of
+               FROM uag_guardrail_daily"""
         )
     except Exception as exc:
         logger.warning("uag_guardrail_daily not available: %s", exc)
         return empty
-    if not rows:
+    agg = dict(agg) if agg else {}
+    if _row_int(agg, "guarded_endpoints") == 0:
         return empty
 
-    total_endpoints = 0
-    try:
-        r = execute_one("SELECT COUNT(*) AS n FROM uag_usage_summary")
-        total_endpoints = int((r or {}).get("n") or 0)
-    except Exception:
-        pass
-
+    rows = execute_query(
+        """SELECT endpoint_name, checked_requests, unique_users, judge_models
+           FROM uag_guardrail_daily
+           ORDER BY checked_requests DESC LIMIT 200"""
+    )
     return {
-        "as_of": _max_as_of(rows),
-        # No BLOCK/MASK verdicts at this scope — the UI shows coverage only and
-        # flags that outcomes need the gated feature-results surface.
-        "outcomes_available": False,
+        "as_of": agg.get("as_of"),
         "totals": {
-            "guarded_endpoints": len(rows),
-            "total_endpoints": total_endpoints,
-            "checked_requests": sum(_row_int(r, "checked_requests") for r in rows),
+            "guarded_endpoints": _row_int(agg, "guarded_endpoints"),
+            "checked_requests": _row_int(agg, "checked_requests"),
         },
         "endpoints": [
             {

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -658,6 +658,30 @@ export function useUagMcpTools() {
   })
 }
 
+export interface GuardrailCoverage {
+  as_of: string | null
+  outcomes_available: boolean
+  totals: Partial<{ guarded_endpoints: number; total_endpoints: number; checked_requests: number }>
+  endpoints: Array<{
+    endpoint_name: string
+    checked_requests: number
+    unique_users: number
+    judge_models: string
+  }>
+}
+
+/** Guardrail coverage/activity per endpoint from Unity AI Gateway v2 (not outcomes). */
+export function useGuardrailCoverage() {
+  return useQuery({
+    queryKey: ['gateway', 'guardrail-coverage'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/guardrail-coverage')
+      return data as GuardrailCoverage
+    },
+    staleTime: GW_STALE,
+  })
+}
+
 export function useGatewayInferenceLogs(limit = 50, endpointName?: string) {
   return useQuery({
     queryKey: ['gateway', 'inference-logs', limit, endpointName],

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -660,8 +660,7 @@ export function useUagMcpTools() {
 
 export interface GuardrailCoverage {
   as_of: string | null
-  outcomes_available: boolean
-  totals: Partial<{ guarded_endpoints: number; total_endpoints: number; checked_requests: number }>
+  totals: Partial<{ guarded_endpoints: number; checked_requests: number }>
   endpoints: Array<{
     endpoint_name: string
     checked_requests: number

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -603,6 +603,7 @@ export interface UagV2Usage {
     requester_type?: UagBreakdownRow[]
     destination_model?: UagBreakdownRow[]
     api_type?: UagBreakdownRow[]
+    source?: UagBreakdownRow[]
     service_type?: UagBreakdownRow[]
     route_action?: UagBreakdownRow[]
   }

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -331,14 +331,13 @@ function GuardrailCoverageCard() {
   const endpoints = data?.endpoints || []
   if (isLoading || endpoints.length === 0) return null
   const guarded = data!.totals.guarded_endpoints ?? endpoints.length
-  const total = data!.totals.total_endpoints ?? 0
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-base flex items-center gap-2">
           Guardrail Coverage
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-            {guarded}{total ? ` of ${total}` : ''} endpoints guarded
+            {guarded} endpoint{guarded === 1 ? '' : 's'} guarded
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -292,8 +292,19 @@ function UagV2Section() {
             limit={8}
           />
           <UagBreakdownCard
+            title="Traffic Source"
+            subtitle="Where requests originate"
+            rows={uag.breakdowns.source}
+            labelMap={{
+              AI_QUERY: 'ai_query (SQL)',
+              EXTERNAL_CLIENT: 'External client',
+              GUARDRAIL: 'Guardrail check',
+              unknown: 'Unknown',
+            }}
+          />
+          <UagBreakdownCard
             title="By API Type"
-            subtitle="Requests by API surface"
+            subtitle="Client API surface (ai_query carries none)"
             rows={uag.breakdowns.api_type}
           />
           <UagBreakdownCard
@@ -328,9 +339,22 @@ function UagV2Section() {
  * feature-results surface). Hidden when no endpoint has guardrails active. */
 function GuardrailCoverageCard() {
   const { data, isLoading } = useGuardrailCoverage()
+  const sort = useSort('checked_requests', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
   const endpoints = data?.endpoints || []
+  const sorted = useMemo(() => sortRows(endpoints, sort.sort, (e: any, k) => {
+    if (k === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
+    if (k === 'judge_models') return (e.judge_models || '').toLowerCase()
+    if (k === 'checked_requests') return Number(e.checked_requests || 0)
+    if (k === 'unique_users') return Number(e.unique_users || 0)
+    return 0
+  }), [endpoints, sort.sort])
   if (isLoading || endpoints.length === 0) return null
   const guarded = data!.totals.guarded_endpoints ?? endpoints.length
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
   return (
     <Card>
       <CardHeader>
@@ -347,26 +371,29 @@ function GuardrailCoverageCard() {
         </p>
       </CardHeader>
       <CardContent>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-              <th className="py-2 font-medium">Guarded Endpoint</th>
-              <th className="py-2 font-medium">Judge Model(s)</th>
-              <th className="py-2 font-medium text-right">Checked Requests</th>
-              <th className="py-2 font-medium text-right">Users</th>
-            </tr>
-          </thead>
-          <tbody>
-            {endpoints.slice(0, 15).map((e, i) => (
-              <tr key={`${e.endpoint_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
-                <td className="py-1.5 font-mono text-xs truncate max-w-[260px]" title={e.endpoint_name}>{e.endpoint_name}</td>
-                <td className="py-1.5 text-gray-600 dark:text-gray-400">{e.judge_models || '—'}</td>
-                <td className="py-1.5 text-right tabular-nums">{e.checked_requests.toLocaleString()}</td>
-                <td className="py-1.5 text-right tabular-nums">{e.unique_users.toLocaleString()}</td>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <SortableHeader label="Guarded Endpoint" sortKey="endpoint_name" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Judge Model(s)" sortKey="judge_models" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Checked Requests" sortKey="checked_requests" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Users" sortKey="unique_users" current={sort.sort} onToggle={sort.toggle} align="right" />
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {paged.map((e: any, i: number) => (
+                <tr key={`${e.endpoint_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                  <td className="py-1.5 font-mono text-xs truncate max-w-[260px]" title={e.endpoint_name}>{e.endpoint_name}</td>
+                  <td className="py-1.5 text-gray-600 dark:text-gray-400">{e.judge_models || '—'}</td>
+                  <td className="py-1.5 text-right tabular-nums">{e.checked_requests.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums">{e.unique_users.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
       </CardContent>
     </Card>
   )
@@ -375,8 +402,23 @@ function GuardrailCoverageCard() {
 /* Top MCP tools — service_type=MCP_SERVICE rows from system.ai_gateway.usage. */
 function UagMcpToolsCard() {
   const { data: mcp, isLoading } = useUagMcpTools()
+  const sort = useSort('request_count', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
   const tools = mcp?.tools || []
+  const sorted = useMemo(() => sortRows(tools, sort.sort, (t: any, k) => {
+    if (k === 'service_name') return (t.service_name || '').toLowerCase()
+    if (k === 'tool_name') return (t.tool_name || '').toLowerCase()
+    if (k === 'server_type') return (t.server_type || '').toLowerCase()
+    if (k === 'request_count') return Number(t.request_count || 0)
+    if (k === 'error_count') return Number(t.error_count || 0)
+    if (k === 'unique_users') return Number(t.unique_users || 0)
+    return 0
+  }), [tools, sort.sort])
   if (isLoading || tools.length === 0) return null
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
   return (
     <Card>
       <CardHeader>
@@ -392,30 +434,33 @@ function UagMcpToolsCard() {
         </p>
       </CardHeader>
       <CardContent>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-              <th className="py-2 font-medium">MCP Service</th>
-              <th className="py-2 font-medium">Tool</th>
-              <th className="py-2 font-medium">Type</th>
-              <th className="py-2 font-medium text-right">Requests</th>
-              <th className="py-2 font-medium text-right">Errors</th>
-              <th className="py-2 font-medium text-right">Users</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tools.map((t, i) => (
-              <tr key={`${t.service_name}-${t.tool_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
-                <td className="py-1.5 font-mono text-xs truncate max-w-[240px]" title={t.service_name}>{t.service_name}</td>
-                <td className="py-1.5">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>
-                <td className="py-1.5 text-gray-500 dark:text-gray-400">{t.server_type || '—'}</td>
-                <td className="py-1.5 text-right tabular-nums">{t.request_count.toLocaleString()}</td>
-                <td className="py-1.5 text-right tabular-nums">{t.error_count.toLocaleString()}</td>
-                <td className="py-1.5 text-right tabular-nums">{t.unique_users.toLocaleString()}</td>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <SortableHeader label="MCP Service" sortKey="service_name" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Tool" sortKey="tool_name" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Type" sortKey="server_type" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Requests" sortKey="request_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Errors" sortKey="error_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Users" sortKey="unique_users" current={sort.sort} onToggle={sort.toggle} align="right" />
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {paged.map((t: any, i: number) => (
+                <tr key={`${t.service_name}-${t.tool_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                  <td className="py-1.5 font-mono text-xs truncate max-w-[240px]" title={t.service_name}>{t.service_name}</td>
+                  <td className="py-1.5">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>
+                  <td className="py-1.5 text-gray-500 dark:text-gray-400">{t.server_type || '—'}</td>
+                  <td className="py-1.5 text-right tabular-nums">{t.request_count.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums">{t.error_count.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums">{t.unique_users.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
       </CardContent>
     </Card>
   )

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -13,6 +13,7 @@ import {
   useGatewayUsageByUser,
   useUagV2Usage,
   useUagMcpTools,
+  useGuardrailCoverage,
   type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
@@ -316,7 +317,59 @@ function UagV2Section() {
       )}
 
       <UagMcpToolsCard />
+      <GuardrailCoverageCard />
     </div>
+  )
+}
+
+/* Guardrail coverage/activity (uag_guardrail_daily). Which endpoints have UAG v2
+ * guardrails running + by which judge model. Coverage only — NOT block/mask
+ * outcomes (the verdict isn't in system.ai_gateway.usage; it needs the gated
+ * feature-results surface). Hidden when no endpoint has guardrails active. */
+function GuardrailCoverageCard() {
+  const { data, isLoading } = useGuardrailCoverage()
+  const endpoints = data?.endpoints || []
+  if (isLoading || endpoints.length === 0) return null
+  const guarded = data!.totals.guarded_endpoints ?? endpoints.length
+  const total = data!.totals.total_endpoints ?? 0
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Guardrail Coverage
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+            {guarded}{total ? ` of ${total}` : ''} endpoints guarded
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          Endpoints with Unity AI Gateway v2 guardrails running + the judge model evaluating them.
+          Coverage &amp; activity only — block/mask outcomes require UAG feature-results (enrollment-gated).
+          {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+              <th className="py-2 font-medium">Guarded Endpoint</th>
+              <th className="py-2 font-medium">Judge Model(s)</th>
+              <th className="py-2 font-medium text-right">Checked Requests</th>
+              <th className="py-2 font-medium text-right">Users</th>
+            </tr>
+          </thead>
+          <tbody>
+            {endpoints.slice(0, 15).map((e, i) => (
+              <tr key={`${e.endpoint_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                <td className="py-1.5 font-mono text-xs truncate max-w-[260px]" title={e.endpoint_name}>{e.endpoint_name}</td>
+                <td className="py-1.5 text-gray-600 dark:text-gray-400">{e.judge_models || '—'}</td>
+                <td className="py-1.5 text-right tabular-nums">{e.checked_requests.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{e.unique_users.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1721,6 +1721,42 @@ try:
 except Exception as exc:
     print(f"  ⚠️  uag_mcp_tool_daily sync failed: {exc}")
 
+# Sync uag_guardrail_daily (guardrail coverage per guarded endpoint).
+UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
+uag_gr_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_guardrail_daily (
+            endpoint_name    TEXT NOT NULL,
+            checked_requests BIGINT DEFAULT 0,
+            unique_users     BIGINT DEFAULT 0,
+            judge_models     TEXT,
+            max_event_time   TEXT,
+            last_synced      TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_ugr_ep ON uag_guardrail_daily (endpoint_name)")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_GUARDRAIL_TABLE} → uag_guardrail_daily ...")
+try:
+    gr_rows = spark.read.table(UAG_GUARDRAIL_TABLE).collect()
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_guardrail_daily")
+        uag_conn.commit()
+    if gr_rows:
+        values = [(r.endpoint_name, int(r.checked_requests or 0), int(r.unique_users or 0),
+                   r.judge_models, r.max_event_time, now) for r in gr_rows]
+        uag_gr_count = len(values)
+        with uag_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO uag_guardrail_daily
+                   (endpoint_name, checked_requests, unique_users, judge_models, max_event_time, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+            uag_conn.commit()
+    print(f"  ✅ {uag_gr_count} UAG guardrail rows synced")
+except Exception as exc:
+    print(f"  ⚠️  uag_guardrail_daily sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -86,6 +86,7 @@ EXPECTED = [
     "vector_search_health_history",
     "kb_billing_daily",              # only populated when Vector Search indexes exist
     "uag_mcp_tool_daily",            # only populated when MCP services route through UAG v2
+    "uag_guardrail_daily",           # only populated when endpoints have UAG v2 guardrails active
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -305,17 +305,22 @@ print(f"✅ Wrote {len(mcp_rows_raw)} rows to {UAG_MCP_TOOL_TABLE}")
 print("▸ Querying ai_gateway.usage guardrail coverage (invocation_metadata.source = GUARDRAIL) …")
 try:
     gr_rows_raw = _execute_sql(f"""
+        -- (verified live on fevm 2026-07-06: GUARDRAIL judge invocations share the
+        -- guarded request's request_id, so the join attributes checks to the
+        -- protected primary endpoint.) collect_set keeps ALL judge models when a
+        -- request runs multiple guardrails; COUNT(DISTINCT request_id) counts
+        -- guarded requests (a request_id can span multiple primary invocation rows).
         WITH g AS (
-            SELECT request_id, MAX(destination_model) AS judge_model
+            SELECT request_id, collect_set(destination_model) AS judges
             FROM system.ai_gateway.usage
             WHERE invocation_metadata.source = 'GUARDRAIL'
               AND event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
             GROUP BY request_id
         )
         SELECT p.endpoint_name                                   AS endpoint_name,
-               COUNT(*)                                          AS checked_requests,
+               COUNT(DISTINCT p.request_id)                      AS checked_requests,
                COUNT(DISTINCT p.requester)                       AS unique_users,
-               concat_ws(', ', array_sort(array_distinct(collect_list(g.judge_model)))) AS judge_models,
+               concat_ws(', ', array_sort(array_distinct(flatten(collect_list(g.judges))))) AS judge_models,
                CAST(MAX(p.event_time) AS STRING)                 AS max_event_time
         FROM system.ai_gateway.usage p
              JOIN g ON p.request_id = g.request_id

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -203,11 +203,12 @@ print(f"✅ Wrote {len(rows_raw)} rows to {UAG_TABLE}")
 
 # Breakdowns: agent-vs-human (requester_type), model (destination_model), api_type,
 # service_type (model vs MCP vs provider), and route_action (routing outcomes).
-print("▸ Querying ai_gateway.usage breakdowns (requester_type / destination_model / api_type / service_type / route_action) …")
+print("▸ Querying ai_gateway.usage breakdowns (requester_type / destination_model / api_type / source / service_type / route_action) …")
 try:
     bd_rows = _execute_sql(f"""
         WITH base AS (
-            SELECT requester_type, destination_model, api_type, service_type, input_tokens, output_tokens,
+            SELECT requester_type, destination_model, api_type, service_type,
+                   invocation_metadata.source AS source, input_tokens, output_tokens,
                    COALESCE(token_details.cache_read_input_tokens, 0)
                  + COALESCE(token_details.cache_creation_input_tokens, 0) AS cached
             FROM system.ai_gateway.usage
@@ -222,9 +223,20 @@ try:
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base GROUP BY destination_model
         UNION ALL
-        SELECT 'api_type', COALESCE(api_type, 'unknown'),
+        -- api_type is only set for external-client LLM traffic; ai_query()/AI Functions
+        -- (source=AI_QUERY) carry no api_type, so label them rather than dump into 'unknown'.
+        SELECT 'api_type',
+               CASE WHEN COALESCE(api_type,'') != '' THEN api_type
+                    WHEN source = 'AI_QUERY' THEN 'ai_query (SQL)'
+                    ELSE 'unknown' END,
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
-        FROM base GROUP BY api_type
+        FROM base GROUP BY 2
+        UNION ALL
+        -- source: where the traffic originates (AI_QUERY / EXTERNAL_CLIENT / GUARDRAIL) —
+        -- explains the api_type mix (most volume is ai_query, which has no api_type).
+        SELECT 'source', COALESCE(source, 'unknown'),
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base GROUP BY source
         UNION ALL
         -- service_type: exclude legacy untyped rows so the model/MCP/provider split is meaningful
         SELECT 'service_type', service_type,

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -54,7 +54,8 @@ spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
 UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
 UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
 UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
-print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE} | retention {RETENTION_DAYS}d")
+UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -95,6 +96,20 @@ UAG_MCP_TOOL_SCHEMA = StructType([
     StructField("request_count", LongType(), True),
     StructField("error_count", LongType(), True),
     StructField("unique_users", LongType(), True),
+    StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Guardrail COVERAGE/ACTIVITY, one row per guarded endpoint. NOTE: this is
+# coverage (which endpoints have guardrails running, how often) — NOT block/mask
+# outcomes. The verdict is not in system.ai_gateway.usage (GUARDRAIL rows are the
+# judge-model invocations, which return 200 = "check ran"); outcomes require the
+# enrollment-gated UAG feature-results surface.
+UAG_GUARDRAIL_SCHEMA = StructType([
+    StructField("endpoint_name", StringType(), False),
+    StructField("checked_requests", LongType(), True),
+    StructField("unique_users", LongType(), True),
+    StructField("judge_models", StringType(), True),
     StructField("max_event_time", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
@@ -283,8 +298,51 @@ print(f"✅ Wrote {len(mcp_rows_raw)} rows to {UAG_MCP_TOOL_TABLE}")
 
 # COMMAND ----------
 
+# Guardrail COVERAGE per guarded endpoint. GUARDRAIL-source rows are the judge-model
+# invocations; the guarded endpoint is the PRIMARY request sharing the request_id, so
+# we join back to attribute checks to the endpoint being protected (its judge model(s)
+# come along). This is coverage/activity only — not block/mask outcomes.
+print("▸ Querying ai_gateway.usage guardrail coverage (invocation_metadata.source = GUARDRAIL) …")
+try:
+    gr_rows_raw = _execute_sql(f"""
+        WITH g AS (
+            SELECT request_id, MAX(destination_model) AS judge_model
+            FROM system.ai_gateway.usage
+            WHERE invocation_metadata.source = 'GUARDRAIL'
+              AND event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+            GROUP BY request_id
+        )
+        SELECT p.endpoint_name                                   AS endpoint_name,
+               COUNT(*)                                          AS checked_requests,
+               COUNT(DISTINCT p.requester)                       AS unique_users,
+               concat_ws(', ', array_sort(array_distinct(collect_list(g.judge_model)))) AS judge_models,
+               CAST(MAX(p.event_time) AS STRING)                 AS max_event_time
+        FROM system.ai_gateway.usage p
+             JOIN g ON p.request_id = g.request_id
+        WHERE p.invocation_metadata.source != 'GUARDRAIL'
+          AND p.event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND p.endpoint_name IS NOT NULL
+        GROUP BY p.endpoint_name
+        ORDER BY checked_requests DESC
+    """)
+    print(f"  ✅ {len(gr_rows_raw)} guarded-endpoint rows")
+except Exception as exc:
+    gr_rows_raw = []
+    print(f"  ⚠️  guardrail coverage query unavailable: {exc}")
+
+if gr_rows_raw:
+    rows = [(r.get("endpoint_name", ""), to_int(r.get("checked_requests")), to_int(r.get("unique_users")),
+             r.get("judge_models"), r.get("max_event_time"), now)
+            for r in gr_rows_raw]
+    spark.createDataFrame(rows, UAG_GUARDRAIL_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_GUARDRAIL_TABLE)
+else:
+    spark.createDataFrame([], UAG_GUARDRAIL_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_GUARDRAIL_TABLE)
+print(f"✅ Wrote {len(gr_rows_raw)} rows to {UAG_GUARDRAIL_TABLE}")
+
+# COMMAND ----------
+
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
-          "uag_mcp_tool_rows": len(mcp_rows_raw), "retention_days": RETENTION_DAYS,
-          "discovered_at": now.isoformat()}
+          "uag_mcp_tool_rows": len(mcp_rows_raw), "uag_guardrail_rows": len(gr_rows_raw),
+          "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## Summary

Adds a **Guardrail Coverage** card to the AI Gateway v2 tab (roadmap **F4**) — which endpoints have Unity AI Gateway v2 guardrails running, how many requests were checked, and the judge model(s) evaluating them. Sourced from `system.ai_gateway.usage` (`invocation_metadata.source = GUARDRAIL`).

### Scope: coverage/activity, NOT block/mask outcomes
A live probe on `fevm` showed the guardrail **verdict isn't in readable data** — GUARDRAIL rows are the judge-model *invocations* (they return `200` = "the check ran"), and 4xx primaries carry no `error_code` to attribute to guardrails. So "blocks" would be noise; I didn't build it. Block/mask outcomes require the enrollment-gated UAG feature-results surface — the card, API, docstrings, and workflow comment all state this. Validated live: **44 endpoints guarded, 2,787 checks/7d.**

### Data model note
Guardrail rows are logged against the **judge-model** endpoint, so the *guarded* endpoint is recovered by joining GUARDRAIL `request_id`s back to their primary request (verified live).

## Plumbing (mirrors W1.1/W1.2)
- workflow 11 → new `uag_guardrail_daily` Delta table
- `02_sync_to_lakebase` → Lakebase mirror (read-before-truncate); smoke check EXPECTED
- backend `get_guardrail_coverage()` + `GET /gateway/guardrail-coverage`
- frontend `useGuardrailCoverage` hook + `GuardrailCoverageCard`

## Review (Isaac Review — applied in the 2nd commit)
1. Dropped the coverage *ratio* — denominator counted MCP/judge endpoints, understating coverage; show the guarded count instead.
2. `collect_set` (not `MAX`) so multi-guardrail requests keep all judge models.
3. `COUNT(DISTINCT request_id)` (not `COUNT(*)`) for checked requests.
4. Totals from an unbounded aggregate, not the capped display rows.
5. Dropped a dead `outcomes_available` field.

`py_compile` + `tsc` clean; queries validated against live `fevm`.

This pull request and its description were written by Isaac.
