### PR TITLE
feat(gateway): UAG v2 dashboard parity — trends, percentiles, status/workspace

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -188,6 +188,12 @@ def uag_mcp_tools():
     return gateway_service.get_uag_mcp_tools()
 
 
+@router.get("/uag-v2-timeseries")
+def uag_v2_timeseries():
+    """Daily UAG v2 usage series (requests + tokens) for trend charts."""
+    return gateway_service.get_uag_v2_timeseries()
+
+
 @router.get("/guardrail-coverage")
 def guardrail_coverage():
     """Guardrail coverage/activity per endpoint from Unity AI Gateway v2

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -661,6 +661,8 @@ def get_uag_v2_usage() -> Dict[str, Any]:
             "cache_read_pct": cache_pct,
             "endpoints": len(rows),
         },
+        # NOTE: p50/p90/p95/p99 are PER-ENDPOINT percentiles — they are non-additive,
+        # so do not sum/average them into an account-level KPI (that would be wrong).
         "endpoints": [
             {
                 "endpoint_name": r.get("endpoint_name", ""),
@@ -796,7 +798,7 @@ def get_uag_v2_timeseries() -> Dict[str, Any]:
     from backend.database import execute_query
     try:
         rows = execute_query(
-            """SELECT usage_date, request_count, input_tokens, output_tokens, cached_tokens
+            """SELECT usage_date, request_count, input_tokens, output_tokens
                FROM uag_usage_timeseries_daily ORDER BY usage_date"""
         )
     except Exception as exc:
@@ -809,7 +811,6 @@ def get_uag_v2_timeseries() -> Dict[str, Any]:
                 "request_count": _row_int(r, "request_count"),
                 "input_tokens": _row_int(r, "input_tokens"),
                 "output_tokens": _row_int(r, "output_tokens"),
-                "cached_tokens": _row_int(r, "cached_tokens"),
             }
             for r in rows
         ]

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -611,7 +611,7 @@ def get_uag_v2_usage() -> Dict[str, Any]:
         rows = execute_query(
             """SELECT endpoint_name, request_count, input_tokens, output_tokens,
                       cache_read_tokens, cache_creation_tokens,
-                      p50_latency_ms, p95_latency_ms, p95_ttfb_ms,
+                      p50_latency_ms, p90_latency_ms, p95_latency_ms, p99_latency_ms, p95_ttfb_ms,
                       error_count, unique_users, max_event_time
                FROM uag_usage_summary
                ORDER BY request_count DESC LIMIT 200"""
@@ -670,7 +670,9 @@ def get_uag_v2_usage() -> Dict[str, Any]:
                 "cache_read_tokens": _i(r, "cache_read_tokens"),
                 "cache_creation_tokens": _i(r, "cache_creation_tokens"),
                 "p50_latency_ms": _i(r, "p50_latency_ms"),
+                "p90_latency_ms": _i(r, "p90_latency_ms"),
                 "p95_latency_ms": _i(r, "p95_latency_ms"),
+                "p99_latency_ms": _i(r, "p99_latency_ms"),
                 "p95_ttfb_ms": _i(r, "p95_ttfb_ms"),
                 "error_count": _i(r, "error_count"),
                 "unique_users": _i(r, "unique_users"),
@@ -785,6 +787,32 @@ def get_guardrail_coverage() -> Dict[str, Any]:
             }
             for r in rows
         ],
+    }
+
+
+def get_uag_v2_timeseries() -> Dict[str, Any]:
+    """Daily UAG v2 usage series (requests + tokens) from `uag_usage_timeseries_daily`
+    for trend charts on the v2 tab. Degrades to empty when unsynced / no v2 traffic."""
+    from backend.database import execute_query
+    try:
+        rows = execute_query(
+            """SELECT usage_date, request_count, input_tokens, output_tokens, cached_tokens
+               FROM uag_usage_timeseries_daily ORDER BY usage_date"""
+        )
+    except Exception as exc:
+        logger.warning("uag_usage_timeseries_daily not available: %s", exc)
+        return {"series": []}
+    return {
+        "series": [
+            {
+                "usage_date": r.get("usage_date", ""),
+                "request_count": _row_int(r, "request_count"),
+                "input_tokens": _row_int(r, "input_tokens"),
+                "output_tokens": _row_int(r, "output_tokens"),
+                "cached_tokens": _row_int(r, "cached_tokens"),
+            }
+            for r in rows
+        ]
     }
 
 

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -619,7 +619,6 @@ export interface UagV2Timeseries {
     request_count: number
     input_tokens: number
     output_tokens: number
-    cached_tokens: number
   }>
 }
 

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -594,7 +594,9 @@ export interface UagV2Usage {
     cache_read_tokens: number
     cache_creation_tokens: number
     p50_latency_ms: number
+    p90_latency_ms: number
     p95_latency_ms: number
+    p99_latency_ms: number
     p95_ttfb_ms: number
     error_count: number
     unique_users: number
@@ -606,7 +608,19 @@ export interface UagV2Usage {
     source?: UagBreakdownRow[]
     service_type?: UagBreakdownRow[]
     route_action?: UagBreakdownRow[]
+    status_code?: UagBreakdownRow[]
+    workspace_id?: UagBreakdownRow[]
   }
+}
+
+export interface UagV2Timeseries {
+  series: Array<{
+    usage_date: string
+    request_count: number
+    input_tokens: number
+    output_tokens: number
+    cached_tokens: number
+  }>
 }
 
 export interface UagMcpTools {
@@ -677,6 +691,18 @@ export function useGuardrailCoverage() {
     queryFn: async () => {
       const { data } = await apiClient.get('/gateway/guardrail-coverage')
       return data as GuardrailCoverage
+    },
+    staleTime: GW_STALE,
+  })
+}
+
+/** Daily UAG v2 usage series (requests + tokens) for trend charts. */
+export function useUagV2Timeseries() {
+  return useQuery({
+    queryKey: ['gateway', 'uag-v2-timeseries'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/uag-v2-timeseries')
+      return data as UagV2Timeseries
     },
     staleTime: GW_STALE,
   })

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -356,8 +356,10 @@ function UagV2TrendCard() {
   const { data, isLoading } = useUagV2Timeseries()
   const series = data?.series || []
   if (isLoading || series.length === 0) return null
-  const requestData = series.map((s) => ({ timestamp: s.usage_date, value: Number(s.request_count) }))
-  const tokenData = series.map((s) => ({ timestamp: s.usage_date, value: Number(s.input_tokens) + Number(s.output_tokens) }))
+  // append a local-midnight time so the date-only string parses in local tz
+  // (not UTC midnight → prior-day label west of UTC)
+  const requestData = series.map((s) => ({ timestamp: `${s.usage_date}T00:00:00`, value: Number(s.request_count) }))
+  const tokenData = series.map((s) => ({ timestamp: `${s.usage_date}T00:00:00`, value: Number(s.input_tokens) + Number(s.output_tokens) }))
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <Card>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -59,7 +59,7 @@ import {
 
 /* ── tab definitions ─────────────────────────────────────────── */
 const baseTabs = [
-  { id: 'uag-v2', label: 'Unity AI Gateway v2', icon: Sparkles, beta: true, legacy: false },
+  { id: 'uag-v2', label: 'Unity AI Gateway', icon: Sparkles, beta: true, legacy: false },
   { id: 'overview', label: 'Overview', icon: LayoutDashboard, beta: false, legacy: true },
   { id: 'metrics', label: 'Metrics', icon: Cpu, beta: false, legacy: true },
   { id: 'permissions', label: 'Permissions', icon: Shield, beta: false, legacy: true },
@@ -139,7 +139,7 @@ export default function AIGatewayPage() {
           <span className="font-semibold">Unity AI Gateway is where this is headed.</span>{' '}
           It's Databricks' native control plane for AI governance. We integrate its capabilities
           as soon as their APIs are available — start with the{' '}
-          <span className="font-medium">Unity AI Gateway v2 (Beta)</span> tab — and retire legacy
+          <span className="font-medium">Unity AI Gateway (Beta)</span> tab — and retire legacy
           views here as they're superseded. Expect this page to shift toward Unity AI Gateway over time.
         </p>
       </div>
@@ -164,7 +164,7 @@ export default function AIGatewayPage() {
               </span>
             )}
             {legacy && (
-              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold tracking-wide bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
                 v1
               </span>
             )}
@@ -194,7 +194,7 @@ export default function AIGatewayPage() {
   )
 }
 
-/* ── Unity AI Gateway v2 (Beta) Section ───────────────────────── */
+/* ── Unity AI Gateway (Beta) Section ───────────────────────── */
 
 function UagV2Section() {
   const { data: uag, isLoading } = useUagV2Usage()
@@ -218,11 +218,11 @@ function UagV2Section() {
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
-            Unity AI Gateway v2 (Beta) Usage
+            Unity AI Gateway (Beta) Usage
             <span className="group relative inline-flex">
               <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
               <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-72 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                Only requests routed through <strong>Unity AI Gateway v2</strong> endpoints (~20-min fresh) — a subset of all serving. Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
+                Only requests routed through <strong>Unity AI Gateway</strong> endpoints (~20-min fresh) — a subset of all serving. Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
               </span>
             </span>
             {uag?.as_of && (
@@ -237,7 +237,7 @@ function UagV2Section() {
             <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading…</div>
           ) : !hasData ? (
             <div className="py-12 text-center text-gray-400 dark:text-gray-500">
-              No Unity AI Gateway v2 usage yet — either no v2-routed traffic in this workspace, or the discovery workflow hasn't synced <code>system.ai_gateway.usage</code> yet.
+              No Unity AI Gateway usage yet — either no gateway-routed traffic in this workspace, or the discovery workflow hasn't synced <code>system.ai_gateway.usage</code> yet.
             </div>
           ) : (
             <>
@@ -411,7 +411,7 @@ function GuardrailCoverageCard() {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          Endpoints with Unity AI Gateway v2 guardrails running + the judge model evaluating them.
+          Endpoints with Unity AI Gateway guardrails running + the judge model evaluating them.
           Coverage &amp; activity only — block/mask outcomes require UAG feature-results (enrollment-gated).
           {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
@@ -475,7 +475,7 @@ function UagMcpToolsCard() {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          MCP tool invocations governed through Unity AI Gateway v2
+          MCP tool invocations governed through Unity AI Gateway
           {mcp?.as_of && <> · as of {formatAsOf(mcp.as_of)}</>}
         </p>
       </CardHeader>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -12,6 +12,7 @@ import {
   useGatewayUsageTimeseries,
   useGatewayUsageByUser,
   useUagV2Usage,
+  useUagV2Timeseries,
   useUagMcpTools,
   useGuardrailCoverage,
   type UagBreakdownRow,
@@ -250,8 +251,10 @@ function UagV2Section() {
                       <SortableHeader label="Endpoint" sortKey="endpoint_name" current={uagSort.sort} onToggle={uagSort.toggle} />
                       <SortableHeader label="Requests" sortKey="request_count" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
                       <SortableHeader label="Cached Tokens" sortKey="cached" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                      <SortableHeader label="p50 Latency" sortKey="p50_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
-                      <SortableHeader label="p95 Latency" sortKey="p95_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p50" sortKey="p50_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p90" sortKey="p90_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p95" sortKey="p95_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
+                      <SortableHeader label="p99" sortKey="p99_latency_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
                       <SortableHeader label="p95 TTFB" sortKey="p95_ttfb_ms" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
                       <SortableHeader label="Users" sortKey="unique_users" current={uagSort.sort} onToggle={uagSort.toggle} align="right" />
                     </tr>
@@ -263,7 +266,9 @@ function UagV2Section() {
                         <td className="py-2 text-right">{Number(e.request_count).toLocaleString()}</td>
                         <td className="py-2 text-right">{Number(e.cache_read_tokens + e.cache_creation_tokens).toLocaleString()}</td>
                         <td className="py-2 text-right">{Number(e.p50_latency_ms).toLocaleString()}ms</td>
+                        <td className="py-2 text-right">{Number(e.p90_latency_ms).toLocaleString()}ms</td>
                         <td className="py-2 text-right">{Number(e.p95_latency_ms).toLocaleString()}ms</td>
+                        <td className="py-2 text-right">{Number(e.p99_latency_ms).toLocaleString()}ms</td>
                         <td className="py-2 text-right">{Number(e.p95_ttfb_ms).toLocaleString()}ms</td>
                         <td className="py-2 text-right">{Number(e.unique_users).toLocaleString()}</td>
                       </tr>
@@ -324,11 +329,45 @@ function UagV2Section() {
             rows={uag.breakdowns.route_action}
             labelMap={{ INITIAL_ATTEMPT: 'Initial', FALLBACK: 'Fallback', unknown: 'Unknown' }}
           />
+          <UagBreakdownCard
+            title="By Status Code"
+            subtitle="Requests by HTTP status"
+            rows={uag.breakdowns.status_code}
+          />
+          <UagBreakdownCard
+            title="By Workspace"
+            subtitle="Requests by workspace ID"
+            rows={uag.breakdowns.workspace_id}
+            limit={8}
+          />
         </div>
       )}
 
+      <UagV2TrendCard />
       <UagMcpToolsCard />
       <GuardrailCoverageCard />
+    </div>
+  )
+}
+
+/* Daily UAG v2 usage trend (uag_usage_timeseries_daily) — requests + tokens over
+ * time. Hidden when there's no v2 traffic. */
+function UagV2TrendCard() {
+  const { data, isLoading } = useUagV2Timeseries()
+  const series = data?.series || []
+  if (isLoading || series.length === 0) return null
+  const requestData = series.map((s) => ({ timestamp: s.usage_date, value: Number(s.request_count) }))
+  const tokenData = series.map((s) => ({ timestamp: s.usage_date, value: Number(s.input_tokens) + Number(s.output_tokens) }))
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card>
+        <CardHeader><CardTitle className="text-base">Requests / day</CardTitle></CardHeader>
+        <CardContent><LineChart data={requestData} name="Requests" color={DB_CHART.primary} /></CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle className="text-base">Tokens / day</CardTitle></CardHeader>
+        <CardContent><LineChart data={tokenData} name="Total Tokens" color={DB_CHART.success} /></CardContent>
+      </Card>
     </div>
   )
 }

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -59,17 +59,17 @@ import {
 
 /* ── tab definitions ─────────────────────────────────────────── */
 const baseTabs = [
-  { id: 'overview', label: 'Overview', icon: LayoutDashboard, beta: false },
-  { id: 'metrics', label: 'Metrics', icon: Cpu, beta: false },
-  { id: 'permissions', label: 'Permissions', icon: Shield, beta: false },
-  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert, beta: false },
-  { id: 'uag-v2', label: 'Unity AI Gateway v2', icon: Sparkles, beta: true },
+  { id: 'uag-v2', label: 'Unity AI Gateway v2', icon: Sparkles, beta: true, legacy: false },
+  { id: 'overview', label: 'Overview', icon: LayoutDashboard, beta: false, legacy: true },
+  { id: 'metrics', label: 'Metrics', icon: Cpu, beta: false, legacy: true },
+  { id: 'permissions', label: 'Permissions', icon: Shield, beta: false, legacy: true },
+  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert, beta: false, legacy: true },
 ] as const
 
 type TabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits' | 'uag-v2'
 
 export default function AIGatewayPage() {
-  const [activeTab, setActiveTab] = useState<TabId>('overview')
+  const [activeTab, setActiveTab] = useState<TabId>('uag-v2')
   const [days, setDays] = useState(7)
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -146,7 +146,7 @@ export default function AIGatewayPage() {
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
-        {tabs.map(({ id, label, icon: Icon, beta }) => (
+        {tabs.map(({ id, label, icon: Icon, beta, legacy }) => (
           <button
             key={id}
             onClick={() => setActiveTab(id)}
@@ -161,6 +161,11 @@ export default function AIGatewayPage() {
             {beta && (
               <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
                 Beta
+              </span>
+            )}
+            {legacy && (
+              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+                v1
               </span>
             )}
           </button>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1775,7 +1775,6 @@ with uag_conn.cursor() as cur:
             request_count  BIGINT DEFAULT 0,
             input_tokens   BIGINT DEFAULT 0,
             output_tokens  BIGINT DEFAULT 0,
-            cached_tokens  BIGINT DEFAULT 0,
             last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (usage_date)
         )""")
@@ -1788,12 +1787,12 @@ try:
         uag_conn.commit()
     if ts_rows:
         values = [(str(r.usage_date), int(r.request_count or 0), int(r.input_tokens or 0),
-                   int(r.output_tokens or 0), int(r.cached_tokens or 0), now) for r in ts_rows]
+                   int(r.output_tokens or 0), now) for r in ts_rows]
         uag_ts_count = len(values)
         with uag_conn.cursor() as cur:
             execute_values(cur,
                 """INSERT INTO uag_usage_timeseries_daily
-                   (usage_date, request_count, input_tokens, output_tokens, cached_tokens, last_synced)
+                   (usage_date, request_count, input_tokens, output_tokens, last_synced)
                    VALUES %s""",
                 values, page_size=500)
             uag_conn.commit()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1584,7 +1584,9 @@ with uag_conn.cursor() as cur:
             cache_read_tokens     BIGINT DEFAULT 0,
             cache_creation_tokens BIGINT DEFAULT 0,
             p50_latency_ms        BIGINT DEFAULT 0,
+            p90_latency_ms        BIGINT DEFAULT 0,
             p95_latency_ms        BIGINT DEFAULT 0,
+            p99_latency_ms        BIGINT DEFAULT 0,
             p95_ttfb_ms           BIGINT DEFAULT 0,
             error_count           BIGINT DEFAULT 0,
             unique_users          BIGINT DEFAULT 0,
@@ -1592,6 +1594,9 @@ with uag_conn.cursor() as cur:
             last_synced           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (endpoint_name)
         )""")
+    # ADD COLUMN for tables that pre-existed without the p90/p99 percentiles.
+    cur.execute("ALTER TABLE uag_usage_summary ADD COLUMN IF NOT EXISTS p90_latency_ms BIGINT DEFAULT 0")
+    cur.execute("ALTER TABLE uag_usage_summary ADD COLUMN IF NOT EXISTS p99_latency_ms BIGINT DEFAULT 0")
     uag_conn.commit()
 
 print(f"▸ Syncing {UAG_TABLE} → uag_usage_summary ...")
@@ -1603,7 +1608,8 @@ try:
     if uag_rows:
         values = [(r.endpoint_name, int(r.request_count or 0), int(r.input_tokens or 0),
                    int(r.output_tokens or 0), int(r.cache_read_tokens or 0), int(r.cache_creation_tokens or 0),
-                   int(r.p50_latency_ms or 0), int(r.p95_latency_ms or 0), int(r.p95_ttfb_ms or 0),
+                   int(r.p50_latency_ms or 0), int(r.p90_latency_ms or 0), int(r.p95_latency_ms or 0),
+                   int(r.p99_latency_ms or 0), int(r.p95_ttfb_ms or 0),
                    int(r.error_count or 0), int(r.unique_users or 0), r.max_event_time, now)
                   for r in uag_rows]
         uag_count = len(values)
@@ -1611,8 +1617,8 @@ try:
             execute_values(cur,
                 """INSERT INTO uag_usage_summary
                    (endpoint_name, request_count, input_tokens, output_tokens, cache_read_tokens,
-                    cache_creation_tokens, p50_latency_ms, p95_latency_ms, p95_ttfb_ms,
-                    error_count, unique_users, max_event_time, last_synced)
+                    cache_creation_tokens, p50_latency_ms, p90_latency_ms, p95_latency_ms, p99_latency_ms,
+                    p95_ttfb_ms, error_count, unique_users, max_event_time, last_synced)
                    VALUES %s
                    ON CONFLICT (endpoint_name) DO UPDATE SET
                        request_count = EXCLUDED.request_count,
@@ -1621,7 +1627,9 @@ try:
                        cache_read_tokens = EXCLUDED.cache_read_tokens,
                        cache_creation_tokens = EXCLUDED.cache_creation_tokens,
                        p50_latency_ms = EXCLUDED.p50_latency_ms,
+                       p90_latency_ms = EXCLUDED.p90_latency_ms,
                        p95_latency_ms = EXCLUDED.p95_latency_ms,
+                       p99_latency_ms = EXCLUDED.p99_latency_ms,
                        p95_ttfb_ms = EXCLUDED.p95_ttfb_ms,
                        error_count = EXCLUDED.error_count,
                        unique_users = EXCLUDED.unique_users,
@@ -1756,6 +1764,42 @@ try:
     print(f"  ✅ {uag_gr_count} UAG guardrail rows synced")
 except Exception as exc:
     print(f"  ⚠️  uag_guardrail_daily sync failed: {exc}")
+
+# Sync uag_usage_timeseries_daily (daily requests/tokens for v2 trend charts).
+UAG_TIMESERIES_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_timeseries_daily"
+uag_ts_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_usage_timeseries_daily (
+            usage_date     TEXT NOT NULL,
+            request_count  BIGINT DEFAULT 0,
+            input_tokens   BIGINT DEFAULT 0,
+            output_tokens  BIGINT DEFAULT 0,
+            cached_tokens  BIGINT DEFAULT 0,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (usage_date)
+        )""")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_TIMESERIES_TABLE} → uag_usage_timeseries_daily ...")
+try:
+    ts_rows = spark.read.table(UAG_TIMESERIES_TABLE).collect()
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_usage_timeseries_daily")
+        uag_conn.commit()
+    if ts_rows:
+        values = [(str(r.usage_date), int(r.request_count or 0), int(r.input_tokens or 0),
+                   int(r.output_tokens or 0), int(r.cached_tokens or 0), now) for r in ts_rows]
+        uag_ts_count = len(values)
+        with uag_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO uag_usage_timeseries_daily
+                   (usage_date, request_count, input_tokens, output_tokens, cached_tokens, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+            uag_conn.commit()
+    print(f"  ✅ {uag_ts_count} UAG time-series rows synced")
+except Exception as exc:
+    print(f"  ⚠️  uag_usage_timeseries_daily sync failed: {exc}")
 
 uag_conn.close()
 

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -87,6 +87,7 @@ EXPECTED = [
     "kb_billing_daily",              # only populated when Vector Search indexes exist
     "uag_mcp_tool_daily",            # only populated when MCP services route through UAG v2
     "uag_guardrail_daily",           # only populated when endpoints have UAG v2 guardrails active
+    "uag_usage_timeseries_daily",    # daily UAG v2 usage series; empty when no v2 traffic
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -109,7 +109,6 @@ UAG_TIMESERIES_SCHEMA = StructType([
     StructField("request_count", LongType(), True),
     StructField("input_tokens", LongType(), True),
     StructField("output_tokens", LongType(), True),
-    StructField("cached_tokens", LongType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -259,7 +258,7 @@ try:
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base GROUP BY status_code
         UNION ALL
-        SELECT 'workspace_id', COALESCE(NULLIF(workspace_id, ''), 'unknown'),
+        SELECT 'workspace_id', COALESCE(NULLIF(CAST(workspace_id AS STRING), ''), 'unknown'),
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base GROUP BY workspace_id
         UNION ALL
@@ -305,11 +304,10 @@ try:
         SELECT CAST(event_time AS DATE)                                 AS usage_date,
                COUNT(*)                                                 AS request_count,
                COALESCE(SUM(input_tokens), 0)                           AS input_tokens,
-               COALESCE(SUM(output_tokens), 0)                          AS output_tokens,
-               COALESCE(SUM(token_details.cache_read_input_tokens), 0)
-             + COALESCE(SUM(token_details.cache_creation_input_tokens), 0) AS cached_tokens
+               COALESCE(SUM(output_tokens), 0)                          AS output_tokens
         FROM system.ai_gateway.usage
         WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND endpoint_name IS NOT NULL   -- match the summary/KPI population so the trend reconciles
         GROUP BY CAST(event_time AS DATE)
         ORDER BY usage_date
     """)
@@ -320,7 +318,7 @@ except Exception as exc:
 
 if ts_rows_raw:
     rows = [(str(r.get("usage_date")), to_int(r.get("request_count")), to_int(r.get("input_tokens")),
-             to_int(r.get("output_tokens")), to_int(r.get("cached_tokens")), now)
+             to_int(r.get("output_tokens")), now)
             for r in ts_rows_raw]
     spark.createDataFrame(rows, UAG_TIMESERIES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TIMESERIES_TABLE)
 else:

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -55,7 +55,8 @@ UAG_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_summary"
 UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
 UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
 UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
-print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE} | retention {RETENTION_DAYS}d")
+UAG_TIMESERIES_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_timeseries_daily"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -67,7 +68,9 @@ UAG_SCHEMA = StructType([
     StructField("cache_read_tokens", LongType(), True),
     StructField("cache_creation_tokens", LongType(), True),
     StructField("p50_latency_ms", LongType(), True),
+    StructField("p90_latency_ms", LongType(), True),
     StructField("p95_latency_ms", LongType(), True),
+    StructField("p99_latency_ms", LongType(), True),
     StructField("p95_ttfb_ms", LongType(), True),
     StructField("error_count", LongType(), True),
     StructField("unique_users", LongType(), True),
@@ -97,6 +100,16 @@ UAG_MCP_TOOL_SCHEMA = StructType([
     StructField("error_count", LongType(), True),
     StructField("unique_users", LongType(), True),
     StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Daily usage time-series (one row per day) for trend charts on the v2 tab.
+UAG_TIMESERIES_SCHEMA = StructType([
+    StructField("usage_date", StringType(), False),
+    StructField("request_count", LongType(), True),
+    StructField("input_tokens", LongType(), True),
+    StructField("output_tokens", LongType(), True),
+    StructField("cached_tokens", LongType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -160,7 +173,9 @@ try:
             COALESCE(SUM(token_details.cache_read_input_tokens), 0)    AS cache_read_tokens,
             COALESCE(SUM(token_details.cache_creation_input_tokens), 0) AS cache_creation_tokens,
             CAST(PERCENTILE_APPROX(latency_ms, 0.5) AS LONG)           AS p50_latency_ms,
+            CAST(PERCENTILE_APPROX(latency_ms, 0.9) AS LONG)           AS p90_latency_ms,
             CAST(PERCENTILE_APPROX(latency_ms, 0.95) AS LONG)          AS p95_latency_ms,
+            CAST(PERCENTILE_APPROX(latency_ms, 0.99) AS LONG)          AS p99_latency_ms,
             CAST(PERCENTILE_APPROX(time_to_first_byte_ms, 0.95) AS LONG) AS p95_ttfb_ms,
             SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END)        AS error_count,
             COUNT(DISTINCT requester)                                  AS unique_users,
@@ -191,7 +206,8 @@ def to_int(x):
 if rows_raw:
     rows = [(r.get("endpoint_name", ""), to_int(r.get("request_count")), to_int(r.get("input_tokens")),
              to_int(r.get("output_tokens")), to_int(r.get("cache_read_tokens")), to_int(r.get("cache_creation_tokens")),
-             to_int(r.get("p50_latency_ms")), to_int(r.get("p95_latency_ms")), to_int(r.get("p95_ttfb_ms")),
+             to_int(r.get("p50_latency_ms")), to_int(r.get("p90_latency_ms")), to_int(r.get("p95_latency_ms")),
+             to_int(r.get("p99_latency_ms")), to_int(r.get("p95_ttfb_ms")),
              to_int(r.get("error_count")), to_int(r.get("unique_users")), r.get("max_event_time"), now)
             for r in rows_raw]
     spark.createDataFrame(rows, UAG_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TABLE)
@@ -208,7 +224,8 @@ try:
     bd_rows = _execute_sql(f"""
         WITH base AS (
             SELECT requester_type, destination_model, api_type, service_type,
-                   invocation_metadata.source AS source, input_tokens, output_tokens,
+                   invocation_metadata.source AS source, workspace_id,
+                   CAST(status_code AS STRING) AS status_code, input_tokens, output_tokens,
                    COALESCE(token_details.cache_read_input_tokens, 0)
                  + COALESCE(token_details.cache_creation_input_tokens, 0) AS cached
             FROM system.ai_gateway.usage
@@ -237,6 +254,14 @@ try:
         SELECT 'source', COALESCE(source, 'unknown'),
                COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
         FROM base GROUP BY source
+        UNION ALL
+        SELECT 'status_code', COALESCE(status_code, 'unknown'),
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base GROUP BY status_code
+        UNION ALL
+        SELECT 'workspace_id', COALESCE(NULLIF(workspace_id, ''), 'unknown'),
+               COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cached), 0)
+        FROM base GROUP BY workspace_id
         UNION ALL
         -- service_type: exclude legacy untyped rows so the model/MCP/provider split is meaningful
         SELECT 'service_type', service_type,
@@ -270,6 +295,37 @@ if bd_rows:
 else:
     spark.createDataFrame([], UAG_BREAKDOWN_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_BREAKDOWN_TABLE)
 print(f"✅ Wrote {len(bd_rows)} rows to {UAG_BREAKDOWN_TABLE}")
+
+# COMMAND ----------
+
+# Daily usage time-series (requests + tokens per day) for trend charts.
+print("▸ Querying ai_gateway.usage daily time-series …")
+try:
+    ts_rows_raw = _execute_sql(f"""
+        SELECT CAST(event_time AS DATE)                                 AS usage_date,
+               COUNT(*)                                                 AS request_count,
+               COALESCE(SUM(input_tokens), 0)                           AS input_tokens,
+               COALESCE(SUM(output_tokens), 0)                          AS output_tokens,
+               COALESCE(SUM(token_details.cache_read_input_tokens), 0)
+             + COALESCE(SUM(token_details.cache_creation_input_tokens), 0) AS cached_tokens
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+        GROUP BY CAST(event_time AS DATE)
+        ORDER BY usage_date
+    """)
+    print(f"  ✅ {len(ts_rows_raw)} time-series rows")
+except Exception as exc:
+    ts_rows_raw = []
+    print(f"  ⚠️  time-series query unavailable: {exc}")
+
+if ts_rows_raw:
+    rows = [(str(r.get("usage_date")), to_int(r.get("request_count")), to_int(r.get("input_tokens")),
+             to_int(r.get("output_tokens")), to_int(r.get("cached_tokens")), now)
+            for r in ts_rows_raw]
+    spark.createDataFrame(rows, UAG_TIMESERIES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TIMESERIES_TABLE)
+else:
+    spark.createDataFrame([], UAG_TIMESERIES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_TIMESERIES_TABLE)
+print(f"✅ Wrote {len(ts_rows_raw)} rows to {UAG_TIMESERIES_TABLE}")
 
 # COMMAND ----------
 
@@ -360,6 +416,7 @@ print(f"✅ Wrote {len(gr_rows_raw)} rows to {UAG_GUARDRAIL_TABLE}")
 
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
           "uag_mcp_tool_rows": len(mcp_rows_raw), "uag_guardrail_rows": len(gr_rows_raw),
+          "uag_timeseries_rows": len(ts_rows_raw),
           "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## Summary

Closes the remaining gaps vs Databricks' built-in AI Gateway usage dashboard on the UAG v2 (Beta) tab (roadmap **G1–G3**):

- **G1 — Daily usage trends.** New `uag_usage_timeseries_daily` table → a Requests/day + Tokens/day trend card (reuses the existing `LineChart`). Filtered to the same population as the summary/KPI so the numbers reconcile.
- **G2 — Performance detail.** p90/p99 latency added to `uag_usage_summary` (+ `ALTER ADD COLUMN` for existing DBs) and the endpoints table; a **By Status Code** breakdown card.
- **G3 — By Workspace.** `workspace_id` breakdown + card.

New breakdown dims (`status_code`, `workspace_id`) ride the generic `uag_usage_breakdown` table — no schema change there.

## Review (Isaac Review — applied in the 2nd commit)
Column-order alignment across all 7 layers (schema→SELECT→tuple→DDL→INSERT→backend→TS) verified clean. Fixes:
1. `CAST(workspace_id AS STRING)` before `NULLIF` (hardening — a failure there would blank the whole shared breakdown table).
2. Added `endpoint_name IS NOT NULL` to the time-series so the trend reconciles with the Requests KPI.
3. Trend x-axis: append `T00:00:00` (was off-by-one day west of UTC).
4. Guard comment: per-endpoint percentiles are non-additive.
5. Dropped a dead `cached_tokens` column from the time-series pipeline.

Deferred (noted): workspace-ID→name resolution (polish), chart-pair extraction.

## Validation
`py_compile` + `tsc` clean; all new/changed queries (p90/p99, status-code, workspace, daily series) validated live against the `fevm` account.

This pull request and its description were written by Isaac.
