### PR TITLE
feat(observability): agent tool & asset usage from trace spans (W2.1)

### DIFF
--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -29,6 +29,13 @@ def _obo_token(request: Request) -> Optional[str]:
 
 # ── Experiments ─────────────────────────────────────────────────
 
+@router.get("/agent-tool-usage")
+async def agent_tool_usage():
+    """TOOL/RETRIEVER span usage per experiment — which UC functions and vector
+    indexes an agent's traces touch."""
+    return mlflow_service.get_agent_tool_usage()
+
+
 @router.get("/experiments")
 async def list_experiments(
     request: Request,

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -222,6 +222,64 @@ def _execute_system_sql(sql: str) -> List[Dict[str, Any]]:
 
 # ── System table queries (cross-workspace) ─────────────────────
 
+def get_agent_tool_usage() -> Dict[str, Any]:
+    """TOOL/RETRIEVER span usage rolled up per experiment (from `agent_tool_usage`,
+    produced by 07_discover_uc_otel_traces). Answers what UC functions and vector
+    indexes an agent's traces touch.
+
+    Grain is EXPERIMENT — agent traces live under MLflow experiments and the app
+    has no experiment→discovered-agent mapping yet. Degrades to empty when the
+    table is unsynced or no traced agents exist.
+    """
+    empty: Dict[str, Any] = {"totals": {}, "rows": []}
+    try:
+        rows = execute_query(
+            """SELECT experiment_id, tool_name, span_type, call_count, trace_count, last_seen
+               FROM agent_tool_usage ORDER BY call_count DESC LIMIT 1000"""
+        )
+    except Exception as exc:
+        logger.warning("agent_tool_usage not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    names: Dict[str, str] = {}
+    try:
+        for e in execute_query("SELECT experiment_id, name FROM observability_experiments WHERE name IS NOT NULL"):
+            names.setdefault(e.get("experiment_id"), e.get("name"))
+    except Exception:
+        pass
+
+    def _i(r, k):
+        return int(r.get(k) or 0)
+
+    def _asset(name: str, span_type: str) -> str:
+        # TOOL span names come through as catalog__schema__function; render as a UC FQN.
+        return (name or "").replace("__", ".") if span_type == "TOOL" else (name or "")
+
+    out = [
+        {
+            "experiment_id": r.get("experiment_id") or "",
+            "experiment_name": names.get(r.get("experiment_id")) or "",
+            "asset": _asset(r.get("tool_name"), r.get("span_type") or ""),
+            "span_type": r.get("span_type") or "",
+            "call_count": _i(r, "call_count"),
+            "trace_count": _i(r, "trace_count"),
+            "last_seen": r.get("last_seen") or "",
+        }
+        for r in rows
+    ]
+    return {
+        "totals": {
+            "experiments": len({r["experiment_id"] for r in out if r["experiment_id"]}),
+            "tools": sum(1 for r in out if r["span_type"] == "TOOL"),
+            "retrievers": sum(1 for r in out if r["span_type"] == "RETRIEVER"),
+            "calls": sum(r["call_count"] for r in out),
+        },
+        "rows": out,
+    }
+
+
 def search_experiments_system_tables(max_results: int = 5000) -> List[Dict[str, Any]]:
     """Query system.mlflow.experiments_latest for cross-workspace experiments.
 

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -243,19 +243,32 @@ def get_agent_tool_usage() -> Dict[str, Any]:
     if not rows:
         return empty
 
+    exp_ids = {r.get("experiment_id") for r in rows if r.get("experiment_id")}
     names: Dict[str, str] = {}
-    try:
-        for e in execute_query("SELECT experiment_id, name FROM observability_experiments WHERE name IS NOT NULL"):
-            names.setdefault(e.get("experiment_id"), e.get("name"))
-    except Exception:
-        pass
+    if exp_ids:
+        try:
+            placeholders = ",".join("%s" for _ in exp_ids)
+            for e in execute_query(
+                f"SELECT experiment_id, name FROM observability_experiments "
+                f"WHERE name IS NOT NULL AND experiment_id IN ({placeholders})",
+                tuple(exp_ids),
+            ):
+                names.setdefault(e.get("experiment_id"), e.get("name"))
+        except Exception:
+            pass
 
     def _i(r, k):
         return int(r.get(k) or 0)
 
     def _asset(name: str, span_type: str) -> str:
-        # TOOL span names come through as catalog__schema__function; render as a UC FQN.
-        return (name or "").replace("__", ".") if span_type == "TOOL" else (name or "")
+        # TOOL span names arrive as catalog__schema__function (MLflow sanitizes the UC
+        # FQN's dots to '__'). Only reverse when it's exactly that 3-part shape — a
+        # blanket replace would mangle tools like `search__web` or a UC name with '__'.
+        if span_type == "TOOL" and name:
+            parts = name.split("__")
+            if len(parts) == 3 and all(parts):
+                return ".".join(parts)
+        return name or ""
 
     out = [
         {
@@ -272,8 +285,9 @@ def get_agent_tool_usage() -> Dict[str, Any]:
     return {
         "totals": {
             "experiments": len({r["experiment_id"] for r in out if r["experiment_id"]}),
-            "tools": sum(1 for r in out if r["span_type"] == "TOOL"),
-            "retrievers": sum(1 for r in out if r["span_type"] == "RETRIEVER"),
+            # distinct assets, not rollup rows (one tool used in N experiments == 1 tool)
+            "tools": len({r["asset"] for r in out if r["span_type"] == "TOOL"}),
+            "retrievers": len({r["asset"] for r in out if r["span_type"] == "RETRIEVER"}),
             "calls": sum(r["call_count"] for r in out),
         },
         "rows": out,

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -258,6 +258,30 @@ export function useMlflowTraces(workspaceId?: string | null, windowDays?: number
   })
 }
 
+export interface AgentToolUsage {
+  totals: Partial<{ experiments: number; tools: number; retrievers: number; calls: number }>
+  rows: Array<{
+    experiment_id: string
+    experiment_name: string
+    asset: string
+    span_type: string
+    call_count: number
+    trace_count: number
+    last_seen: string
+  }>
+}
+
+/** TOOL/RETRIEVER span usage per experiment — what UC functions / vector indexes agents touch. */
+export function useAgentToolUsage() {
+  return useQuery({
+    queryKey: ['mlflow', 'agent-tool-usage'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/mlflow/agent-tool-usage')
+      return data as AgentToolUsage
+    },
+  })
+}
+
 export function useMlflowTraceDetail(requestId: string | null, workspaceId?: string | null) {
   return useQuery({
     queryKey: ['mlflow', 'trace-detail', requestId, workspaceId],

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useQueryClient, useIsFetching } from '@tanstack/react-query'
 import {
   useAppConfig,
@@ -14,6 +14,7 @@ import {
   useGatewayLogSources,
   useGatewayLogDetail,
   useGatewayLogTimeseries,
+  useAgentToolUsage,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { RefreshButton } from '@/components/RefreshButton'
@@ -21,6 +22,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { KpiCard } from '@/components/KpiCard'
 import { TablePagination } from '@/components/TablePagination'
+import { SortableHeader, useSort, sortRows } from '@/components/SortableTable'
 import { format } from 'date-fns'
 import {
   LineChart as RcLineChart,
@@ -161,6 +163,7 @@ const tabs = [
   { id: 'gateway', label: 'Gateway Requests', icon: Activity },
   { id: 'experiments', label: 'Experiments', icon: FlaskConical },
   { id: 'runs', label: 'Evaluation Runs', icon: Activity },
+  { id: 'tool-usage', label: 'Tool & Asset Usage', icon: Wrench },
   { id: 'models', label: 'Model Registry', icon: Database },
 ] as const
 
@@ -260,7 +263,86 @@ export default function ObservabilityPage() {
       {activeTab === 'gateway' && <GatewayRequestsPanel />}
       {activeTab === 'experiments' && <ExperimentsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
+      {activeTab === 'tool-usage' && <ToolUsagePanel />}
       {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
+    </div>
+  )
+}
+
+/* ── Tool & Asset Usage Panel ────────────────────────────────────
+   TOOL / RETRIEVER spans rolled up per experiment (from agent_tool_usage):
+   which UC functions and vector indexes an agent's traces touch. Grain is
+   experiment — the app has no experiment→discovered-agent mapping yet. */
+function ToolUsagePanel() {
+  const { data, isLoading } = useAgentToolUsage()
+  const sort = useSort('call_count', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(15)
+  const rows = data?.rows || []
+  const sorted = useMemo(() => sortRows(rows, sort.sort, (r: any, k) => {
+    if (k === 'call_count' || k === 'trace_count') return Number(r[k] || 0)
+    return (r[k] || '').toString().toLowerCase()
+  }), [rows, sort.sort])
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+
+  if (isLoading) return <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
+  if (rows.length === 0) {
+    return (
+      <Card><CardContent className="py-12 text-center text-gray-400 dark:text-gray-500">
+        No tool/asset usage yet — agents need MLflow tracing enabled (TOOL/RETRIEVER spans) and the discovery workflow must have synced their traces.
+      </CardContent></Card>
+    )
+  }
+  const t = data!.totals
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <KpiCard title="Experiments" value={t.experiments ?? 0} format="number" />
+        <KpiCard title="Tools (UC functions)" value={t.tools ?? 0} format="number" />
+        <KpiCard title="Retrieved Assets" value={t.retrievers ?? 0} format="number" />
+        <KpiCard title="Total Calls" value={t.calls ?? 0} format="number" />
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Tool & Asset Usage</CardTitle>
+          <p className="text-[11px] text-gray-400 dark:text-gray-500">
+            UC functions (TOOL) and vector indexes (RETRIEVER) an agent's traces touch, per experiment.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <SortableHeader label="Asset" sortKey="asset" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Type" sortKey="span_type" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Experiment" sortKey="experiment_name" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Calls" sortKey="call_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Traces" sortKey="trace_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                </tr>
+              </thead>
+              <tbody>
+                {paged.map((r: any, i: number) => (
+                  <tr key={`${r.experiment_id}-${r.asset}-${r.span_type}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                    <td className="py-1.5 font-mono text-xs truncate max-w-[320px]" title={r.asset}>{r.asset}</td>
+                    <td className="py-1.5">
+                      <Badge variant={r.span_type === 'RETRIEVER' ? 'info' : 'default'} className="text-xs">
+                        {r.span_type === 'RETRIEVER' ? 'Retriever' : 'Tool'}
+                      </Badge>
+                    </td>
+                    <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[220px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
+                    <td className="py-1.5 text-right tabular-nums">{r.call_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right tabular-nums">{r.trace_count.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -292,6 +292,7 @@ function ToolUsagePanel() {
     return (
       <Card><CardContent className="py-12 text-center text-gray-400 dark:text-gray-500">
         No tool/asset usage yet — agents need MLflow tracing enabled (TOOL/RETRIEVER spans) and the discovery workflow must have synced their traces.
+        Currently sourced from Databricks-native <code>trace_logs</code> tables; OpenTelemetry-shaped traces (<code>*_otel_spans</code>) aren't covered yet.
       </CardContent></Card>
     )
   }
@@ -308,7 +309,9 @@ function ToolUsagePanel() {
         <CardHeader>
           <CardTitle className="text-base">Tool & Asset Usage</CardTitle>
           <p className="text-[11px] text-gray-400 dark:text-gray-500">
-            UC functions (TOOL) and vector indexes (RETRIEVER) an agent's traces touch, per experiment.
+            UC functions (TOOL) and vector indexes (RETRIEVER) touched by agent traces.
+            Grain is <strong>experiment</strong>, not per-agent — traces live under MLflow experiments.
+            RETRIEVER assets are the span name (usually the index; some frameworks name the component instead).
           </p>
         </CardHeader>
         <CardContent>
@@ -321,6 +324,7 @@ function ToolUsagePanel() {
                   <SortableHeader label="Experiment" sortKey="experiment_name" current={sort.sort} onToggle={sort.toggle} />
                   <SortableHeader label="Calls" sortKey="call_count" current={sort.sort} onToggle={sort.toggle} align="right" />
                   <SortableHeader label="Traces" sortKey="trace_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Last Seen" sortKey="last_seen" current={sort.sort} onToggle={sort.toggle} align="right" />
                 </tr>
               </thead>
               <tbody>
@@ -335,6 +339,7 @@ function ToolUsagePanel() {
                     <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[220px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.call_count.toLocaleString()}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.trace_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
                   </tr>
                 ))}
               </tbody>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1151,23 +1151,24 @@ TOOL_USAGE_DELTA = f"{CATALOG}.{SCHEMA}.agent_tool_usage"
 atu_count = 0
 print(f"▸ Syncing {TOOL_USAGE_DELTA} → agent_tool_usage ...")
 try:
+    # Read first, then truncate+insert in ONE transaction (single commit): a failed
+    # insert rolls back the truncate rather than leaving the table empty.
     atu_rows = spark.read.table(TOOL_USAGE_DELTA).collect()
+    values = [(r.experiment_id, r.tool_name, r.span_type, int(r.call_count or 0),
+               int(r.trace_count or 0), r.last_seen, now) for r in atu_rows]
     with obs_conn.cursor() as cur:
         cur.execute("TRUNCATE TABLE agent_tool_usage")
-        obs_conn.commit()
-    if atu_rows:
-        values = [(r.experiment_id, r.tool_name, r.span_type, int(r.call_count or 0),
-                   int(r.trace_count or 0), r.last_seen, now) for r in atu_rows]
-        atu_count = len(values)
-        with obs_conn.cursor() as cur:
+        if values:
             execute_values(cur,
                 """INSERT INTO agent_tool_usage
                    (experiment_id, tool_name, span_type, call_count, trace_count, last_seen, last_synced)
                    VALUES %s""",
                 values, page_size=500)
-            obs_conn.commit()
+    obs_conn.commit()
+    atu_count = len(values)
     print(f"  ✅ {atu_count} agent tool-usage rows synced")
 except Exception as exc:
+    obs_conn.rollback()
     print(f"  ⚠️  agent_tool_usage sync failed: {exc}")
 
 # COMMAND ----------

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -676,6 +676,12 @@ with obs_conn.cursor() as cur:
             PRIMARY KEY (workspace_id, request_id))""",
         "CREATE INDEX IF NOT EXISTS idx_otd_ws     ON observability_trace_details (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_otd_cached ON observability_trace_details (cached_at DESC)",
+        """CREATE TABLE IF NOT EXISTS agent_tool_usage (
+            experiment_id TEXT, tool_name TEXT NOT NULL, span_type TEXT NOT NULL,
+            call_count BIGINT DEFAULT 0, trace_count BIGINT DEFAULT 0,
+            last_seen TEXT,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
+        "CREATE INDEX IF NOT EXISTS idx_atu_exp ON agent_tool_usage (experiment_id)",
     ]:
         # Each statement in its own savepoint — protects against the case
         # where the workflow runs as a non-owner of pre-existing tables (the
@@ -1137,6 +1143,32 @@ if gw_log_rows:
             obs_conn.commit()
             gw_log_count = len(values)
 print(f"✅ Upserted {gw_log_count} gateway inference-log rows (from Delta, payload-enriched)")
+
+# COMMAND ----------
+
+# Sync agent_tool_usage (TOOL/RETRIEVER span rollup from 07_discover_uc_otel_traces).
+TOOL_USAGE_DELTA = f"{CATALOG}.{SCHEMA}.agent_tool_usage"
+atu_count = 0
+print(f"▸ Syncing {TOOL_USAGE_DELTA} → agent_tool_usage ...")
+try:
+    atu_rows = spark.read.table(TOOL_USAGE_DELTA).collect()
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE agent_tool_usage")
+        obs_conn.commit()
+    if atu_rows:
+        values = [(r.experiment_id, r.tool_name, r.span_type, int(r.call_count or 0),
+                   int(r.trace_count or 0), r.last_seen, now) for r in atu_rows]
+        atu_count = len(values)
+        with obs_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO agent_tool_usage
+                   (experiment_id, tool_name, span_type, call_count, trace_count, last_seen, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+            obs_conn.commit()
+    print(f"  ✅ {atu_count} agent tool-usage rows synced")
+except Exception as exc:
+    print(f"  ⚠️  agent_tool_usage sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -531,16 +531,25 @@ for cat, sch, tbl in trace_log_tables:
     full = f"`{cat}`.`{sch}`.`{tbl}`"
     label = f"{cat}.{sch}.{tbl}"
     try:
+        # Cap the source to the same recent-N window as the detail loop (bounds the
+        # explode so a large table can't OOM/timeout, and keeps trace counts
+        # consistent with the Traces tab).
         agg = spark.sql(f"""
+            WITH src AS (
+                SELECT trace_id, request_time, trace_location, spans
+                FROM {full}
+                WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
+                ORDER BY request_time DESC
+                LIMIT {MAX_TRACES_PER_TABLE}
+            )
             SELECT trace_location.mlflow_experiment.experiment_id           AS experiment_id,
                    s.name                                                   AS tool_name,
                    trim(BOTH '"' FROM s.attributes['mlflow.spanType'])       AS span_type,
                    COUNT(*)                                                 AS call_count,
                    COUNT(DISTINCT trace_id)                                 AS trace_count,
                    CAST(MAX(request_time) AS STRING)                        AS last_seen
-            FROM {full} LATERAL VIEW explode(spans) t AS s
-            WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
-              AND trim(BOTH '"' FROM s.attributes['mlflow.spanType']) IN ('TOOL', 'RETRIEVER')
+            FROM src LATERAL VIEW explode(spans) t AS s
+            WHERE trim(BOTH '"' FROM s.attributes['mlflow.spanType']) IN ('TOOL', 'RETRIEVER')
               AND s.name IS NOT NULL
             GROUP BY 1, 2, 3
         """).collect()

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -78,9 +78,11 @@ if not CATALOG or not SCHEMA:
 
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces_uc_otel"
 DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details_uc_otel"
+TOOL_USAGE_TABLE = f"{CATALOG}.{SCHEMA}.agent_tool_usage"
 
 print(f"Trace summary target: {TRACES_TABLE}")
 print(f"Trace detail target:  {DETAILS_TABLE}")
+print(f"Tool usage target:    {TOOL_USAGE_TABLE}")
 print(f"Retention: {RETENTION_DAYS} days")
 
 # COMMAND ----------
@@ -118,6 +120,20 @@ DETAILS_SCHEMA = StructType([
     StructField("size_bytes",    LongType(),   True),
     StructField("source_type",   StringType(), True),
     StructField("cached_at",     TimestampType(), False),
+])
+
+# Agent tool/asset usage: TOOL + RETRIEVER spans rolled up per experiment. Answers
+# "what UC functions / vector indexes does this agent's traces touch". One row per
+# (experiment_id, tool_name, span_type). Grain is EXPERIMENT (agent traces live under
+# an experiment); the app has no experiment→discovered-agent mapping yet.
+TOOL_USAGE_SCHEMA = StructType([
+    StructField("experiment_id", StringType(), True),
+    StructField("tool_name",     StringType(), False),
+    StructField("span_type",     StringType(), False),   # TOOL | RETRIEVER
+    StructField("call_count",    LongType(),   True),
+    StructField("trace_count",   LongType(),   True),
+    StructField("last_seen",     StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
 ])
 
 # COMMAND ----------
@@ -498,10 +514,61 @@ else:
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## Agent tool/asset usage (TOOL + RETRIEVER spans → per-experiment rollup)
+# MAGIC
+# MAGIC Explodes the `spans` array from the `trace_logs_*` tables and keeps TOOL/RETRIEVER
+# MAGIC spans: TOOL span name is the UC function identity, RETRIEVER span name is the
+# MAGIC vector index touched. Rolled up per (experiment, tool, type). Fail-open per table.
+# MAGIC
+# MAGIC NOTE: covers the `trace_logs_*` shape (validated). The `*_otel_spans` (OTel
+# MAGIC row-per-span) shape is a follow-up — no such tables exist here to validate against.
+
+# COMMAND ----------
+
+tool_usage_rows = []
+for cat, sch, tbl in trace_log_tables:
+    full = f"`{cat}`.`{sch}`.`{tbl}`"
+    label = f"{cat}.{sch}.{tbl}"
+    try:
+        agg = spark.sql(f"""
+            SELECT trace_location.mlflow_experiment.experiment_id           AS experiment_id,
+                   s.name                                                   AS tool_name,
+                   trim(BOTH '"' FROM s.attributes['mlflow.spanType'])       AS span_type,
+                   COUNT(*)                                                 AS call_count,
+                   COUNT(DISTINCT trace_id)                                 AS trace_count,
+                   CAST(MAX(request_time) AS STRING)                        AS last_seen
+            FROM {full} LATERAL VIEW explode(spans) t AS s
+            WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
+              AND trim(BOTH '"' FROM s.attributes['mlflow.spanType']) IN ('TOOL', 'RETRIEVER')
+              AND s.name IS NOT NULL
+            GROUP BY 1, 2, 3
+        """).collect()
+        for r in agg:
+            tool_usage_rows.append((r["experiment_id"], r["tool_name"], r["span_type"],
+                                    int(r["call_count"] or 0), int(r["trace_count"] or 0),
+                                    r["last_seen"], NOW))
+        print(f"  ✅ tool-usage {label}: {len(agg)} (tool,type) rows")
+    except Exception as exc:
+        if _classify_perm_error(str(exc)):
+            per_table_stats.append({"table": label, "shape": "tool_usage", "skipped": "no UC grants"})
+        else:
+            per_table_stats.append({"table": label, "shape": "tool_usage", "error": str(exc)[:200]})
+
+if tool_usage_rows:
+    spark.createDataFrame(tool_usage_rows, TOOL_USAGE_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TOOL_USAGE_TABLE)
+    print(f"✅ Wrote {len(tool_usage_rows)} tool-usage rows to {TOOL_USAGE_TABLE}")
+else:
+    spark.createDataFrame([], TOOL_USAGE_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TOOL_USAGE_TABLE)
+    print(f"ℹ️  No tool-usage rows — empty {TOOL_USAGE_TABLE}")
+
+# COMMAND ----------
+
 result = {
     "status": "success",
     "otel_tables_found": len(otel_tables),
     "trace_log_tables_found": len(trace_log_tables),
+    "tool_usage_rows": len(tool_usage_rows),
     "traces": len(all_trace_rows),
     "details": len(all_detail_rows),
     "retention_days": RETENTION_DAYS,

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -88,6 +88,7 @@ EXPECTED = [
     "uag_mcp_tool_daily",            # only populated when MCP services route through UAG v2
     "uag_guardrail_daily",           # only populated when endpoints have UAG v2 guardrails active
     "uag_usage_timeseries_daily",    # daily UAG v2 usage series; empty when no v2 traffic
+    "agent_tool_usage",              # TOOL/RETRIEVER span rollup; empty when no traced agents
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP


### PR DESCRIPTION
## Summary

Realizes the long-standing **"what tools/assets do agents touch"** ask (roadmap W2.1/F2b). Explodes the `spans` array from Databricks-native `trace_logs_*` UC tables (already discovered by workflow 07) and keeps **TOOL** + **RETRIEVER** spans:
- a TOOL span's name → the **UC function** the agent called
- a RETRIEVER span's name → the **vector index** touched

Rolled up per (experiment, tool, type) into `agent_tool_usage`, surfaced as a new **"Tool & Asset Usage"** tab on the Observability page (KPIs + sortable/paginated table).

## Design note (flagged)
- **Grain is EXPERIMENT, not per-agent.** Agent traces live under MLflow experiments and the app has no experiment→discovered-agent mapping yet, so this lives on Observability, not AgentDetail. The UI says so explicitly.
- **Why `trace_logs`, not a system table / gateway usage:** I probed the account — there's no `system.mlflow` traces/spans table; `system.ai_gateway.usage` only captures *external MCP* tool calls (no UC functions / retrievers, and keyed by requester not agent). `trace_logs` spans are the only source with UC-function + vector-index usage.
- Covers the `trace_logs_*` shape (validated); `*_otel_spans` is a noted follow-up (none exist here to validate against).

## Plumbing
- workflow 07: new `agent_tool_usage` Delta table (isolated explode-aggregation, capped to `MAX_TRACES_PER_TABLE`, fail-open per table)
- `02_sync`: Lakebase mirror (single-transaction truncate+insert); smoke check EXPECTED
- backend: `mlflow_service.get_agent_tool_usage()` + `GET /mlflow/agent-tool-usage`
- frontend: `useAgentToolUsage` + `ToolUsagePanel`

## Review (Isaac Review — applied in 2nd commit)
Capped the explode (OOM + grain), single-transaction sync, safe 3-part UC-name normalization (no blanket `__`→`.`), distinct-asset KPI counts, rendered `last_seen`, explicit grain caption, OTel gap in empty-state, scoped experiment-name lookup.

## Validation
`py_compile` + `tsc` clean; aggregation validated live on fevm (TOOL 104 calls/73 traces, RETRIEVER 14/11). Note: fevm's demo traces are ~119 days old, so at the default 90-day retention the panel renders empty (correct) — populated data needs a larger `trace_retention_days` at run time.

This pull request and its description were written by Isaac.
