### PR TITLE
feat(gateway): Coding Agents activity on the Unity AI Gateway tab (G4)

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -194,6 +194,13 @@ def uag_v2_timeseries():
     return gateway_service.get_uag_v2_timeseries()
 
 
+@router.get("/uag-coding-agents")
+def uag_coding_agents():
+    """Coding-agent activity (Claude Code / Codex / Cursor / Gemini CLI) from
+    Unity AI Gateway usage — requests, users, active days, tokens."""
+    return gateway_service.get_uag_coding_agents()
+
+
 @router.get("/guardrail-coverage")
 def guardrail_coverage():
     """Guardrail coverage/activity per endpoint from Unity AI Gateway v2

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -817,6 +817,42 @@ def get_uag_v2_timeseries() -> Dict[str, Any]:
     }
 
 
+def get_uag_coding_agents() -> Dict[str, Any]:
+    """Coding-agent activity from `uag_coding_agent_usage` (classified from
+    user_agent in system.ai_gateway.usage): Claude Code / Codex / Cursor / Gemini
+    CLI, with requests, users, active days, tokens.
+
+    Activity only — sessions / commits / lines-of-code are not in
+    system.ai_gateway.usage. Degrades to empty when unsynced / no coding-agent traffic.
+    """
+    from backend.database import execute_query
+    empty: Dict[str, Any] = {"as_of": None, "agents": []}
+    try:
+        rows = execute_query(
+            """SELECT coding_agent, request_count, unique_users, active_days,
+                      total_tokens, max_event_time
+               FROM uag_coding_agent_usage ORDER BY request_count DESC"""
+        )
+    except Exception as exc:
+        logger.warning("uag_coding_agent_usage not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+    return {
+        "as_of": _max_as_of(rows),
+        "agents": [
+            {
+                "coding_agent": r.get("coding_agent", ""),
+                "request_count": _row_int(r, "request_count"),
+                "unique_users": _row_int(r, "unique_users"),
+                "active_days": _row_int(r, "active_days"),
+                "total_tokens": _row_int(r, "total_tokens"),
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_usage_summary(days: int = 7) -> List[Dict[str, Any]]:
     """Per-endpoint usage summary from Lakebase cache."""
     from backend.database import execute_query

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -719,6 +719,29 @@ export function useGuardrailCoverage() {
   })
 }
 
+export interface UagCodingAgents {
+  as_of: string | null
+  agents: Array<{
+    coding_agent: string
+    request_count: number
+    unique_users: number
+    active_days: number
+    total_tokens: number
+  }>
+}
+
+/** Coding-agent activity (Claude Code / Codex / Cursor / Gemini CLI) from UAG usage. */
+export function useUagCodingAgents() {
+  return useQuery({
+    queryKey: ['gateway', 'uag-coding-agents'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/uag-coding-agents')
+      return data as UagCodingAgents
+    },
+    staleTime: GW_STALE,
+  })
+}
+
 /** Daily UAG v2 usage series (requests + tokens) for trend charts. */
 export function useUagV2Timeseries() {
   return useQuery({

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -386,7 +386,11 @@ function UagV2TrendCard() {
  * not in the usage table). Hidden when no coding-agent traffic. */
 function CodingAgentsCard() {
   const { data, isLoading } = useUagCodingAgents()
+  const sort = useSort('request_count', 'desc')
   const agents = data?.agents || []
+  const sorted = useMemo(() => sortRows(agents, sort.sort, (a: any, k) =>
+    k === 'coding_agent' ? (a.coding_agent || '').toLowerCase() : Number(a[k] || 0)
+  ), [agents, sort.sort])
   if (isLoading || agents.length === 0) return null
   return (
     <Card>
@@ -402,15 +406,15 @@ function CodingAgentsCard() {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-              <th className="py-2 font-medium">Coding Agent</th>
-              <th className="py-2 font-medium text-right">Requests</th>
-              <th className="py-2 font-medium text-right">Users</th>
-              <th className="py-2 font-medium text-right">Active Days</th>
-              <th className="py-2 font-medium text-right">Tokens</th>
+              <SortableHeader label="Coding Agent" sortKey="coding_agent" current={sort.sort} onToggle={sort.toggle} />
+              <SortableHeader label="Requests" sortKey="request_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+              <SortableHeader label="Users" sortKey="unique_users" current={sort.sort} onToggle={sort.toggle} align="right" />
+              <SortableHeader label="Active Days" sortKey="active_days" current={sort.sort} onToggle={sort.toggle} align="right" />
+              <SortableHeader label="Tokens" sortKey="total_tokens" current={sort.sort} onToggle={sort.toggle} align="right" />
             </tr>
           </thead>
           <tbody>
-            {agents.map((a) => (
+            {sorted.map((a: any) => (
               <tr key={a.coding_agent} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
                 <td className="py-1.5 font-medium">{a.coding_agent}</td>
                 <td className="py-1.5 text-right tabular-nums">{a.request_count.toLocaleString()}</td>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -13,6 +13,7 @@ import {
   useGatewayUsageByUser,
   useUagV2Usage,
   useUagV2Timeseries,
+  useUagCodingAgents,
   useUagMcpTools,
   useGuardrailCoverage,
   type UagBreakdownRow,
@@ -349,6 +350,7 @@ function UagV2Section() {
       )}
 
       <UagV2TrendCard />
+      <CodingAgentsCard />
       <UagMcpToolsCard />
       <GuardrailCoverageCard />
     </div>
@@ -376,6 +378,51 @@ function UagV2TrendCard() {
         <CardContent><LineChart data={tokenData} name="Total Tokens" color={DB_CHART.success} /></CardContent>
       </Card>
     </div>
+  )
+}
+
+/* Coding-agent activity (uag_coding_agent_usage) — Claude Code / Codex / Cursor /
+ * Gemini CLI classified from user_agent. Activity only (no sessions/commits/LOC —
+ * not in the usage table). Hidden when no coding-agent traffic. */
+function CodingAgentsCard() {
+  const { data, isLoading } = useUagCodingAgents()
+  const agents = data?.agents || []
+  if (isLoading || agents.length === 0) return null
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Coding Agents</CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          Activity by coding agent (classified from client user-agent). Requests / users / active days / tokens —
+          sessions &amp; commits aren't in the gateway usage table.
+          {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+              <th className="py-2 font-medium">Coding Agent</th>
+              <th className="py-2 font-medium text-right">Requests</th>
+              <th className="py-2 font-medium text-right">Users</th>
+              <th className="py-2 font-medium text-right">Active Days</th>
+              <th className="py-2 font-medium text-right">Tokens</th>
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((a) => (
+              <tr key={a.coding_agent} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                <td className="py-1.5 font-medium">{a.coding_agent}</td>
+                <td className="py-1.5 text-right tabular-nums">{a.request_count.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{a.unique_users.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{a.active_days.toLocaleString()}</td>
+                <td className="py-1.5 text-right tabular-nums">{a.total_tokens.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
   )
 }
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1760,6 +1760,7 @@ try:
             uag_conn.commit()
     print(f"  ✅ {uag_mcp_count} UAG MCP tool rows synced")
 except Exception as exc:
+    uag_conn.rollback()  # clear aborted txn so the next block's DDL doesn't crash
     print(f"  ⚠️  uag_mcp_tool_daily sync failed: {exc}")
 
 # Sync uag_guardrail_daily (guardrail coverage per guarded endpoint).
@@ -1796,6 +1797,7 @@ try:
             uag_conn.commit()
     print(f"  ✅ {uag_gr_count} UAG guardrail rows synced")
 except Exception as exc:
+    uag_conn.rollback()  # clear aborted txn so the next block's DDL doesn't crash
     print(f"  ⚠️  uag_guardrail_daily sync failed: {exc}")
 
 # Sync uag_usage_timeseries_daily (daily requests/tokens for v2 trend charts).
@@ -1831,6 +1833,7 @@ try:
             uag_conn.commit()
     print(f"  ✅ {uag_ts_count} UAG time-series rows synced")
 except Exception as exc:
+    uag_conn.rollback()  # clear aborted txn so the next block's DDL doesn't crash
     print(f"  ⚠️  uag_usage_timeseries_daily sync failed: {exc}")
 
 # Sync uag_coding_agent_usage (coding-agent activity classified by user_agent).

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1833,6 +1833,41 @@ try:
 except Exception as exc:
     print(f"  ⚠️  uag_usage_timeseries_daily sync failed: {exc}")
 
+# Sync uag_coding_agent_usage (coding-agent activity classified by user_agent).
+UAG_CODING_AGENT_TABLE = f"{CATALOG}.{SCHEMA}.uag_coding_agent_usage"
+uag_ca_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_coding_agent_usage (
+            coding_agent   TEXT NOT NULL,
+            request_count  BIGINT DEFAULT 0,
+            unique_users   BIGINT DEFAULT 0,
+            active_days    BIGINT DEFAULT 0,
+            total_tokens   BIGINT DEFAULT 0,
+            max_event_time TEXT,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (coding_agent))""")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_CODING_AGENT_TABLE} → uag_coding_agent_usage ...")
+try:
+    ca_rows = spark.read.table(UAG_CODING_AGENT_TABLE).collect()
+    values = [(r.coding_agent, int(r.request_count or 0), int(r.unique_users or 0),
+               int(r.active_days or 0), int(r.total_tokens or 0), r.max_event_time, now) for r in ca_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_coding_agent_usage")
+        if values:
+            execute_values(cur,
+                """INSERT INTO uag_coding_agent_usage
+                   (coding_agent, request_count, unique_users, active_days, total_tokens, max_event_time, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    uag_conn.commit()
+    uag_ca_count = len(values)
+    print(f"  ✅ {uag_ca_count} coding-agent rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  uag_coding_agent_usage sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -89,6 +89,7 @@ EXPECTED = [
     "uag_guardrail_daily",           # only populated when endpoints have UAG v2 guardrails active
     "uag_usage_timeseries_daily",    # daily UAG v2 usage series; empty when no v2 traffic
     "agent_tool_usage",              # TOOL/RETRIEVER span rollup; empty when no traced agents
+    "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -349,7 +349,7 @@ try:
     ca_rows_raw = _execute_sql(f"""
         SELECT CASE
                  WHEN lower(user_agent) LIKE 'claude-cli%' OR lower(user_agent) LIKE '%claude-code%' THEN 'Claude Code'
-                 WHEN lower(user_agent) LIKE '%codex%'                                                THEN 'Codex'
+                 WHEN lower(user_agent) LIKE '%codex/%'                                               THEN 'Codex'
                  WHEN lower(user_agent) LIKE 'cursor%'  OR lower(api_type) LIKE 'cursor%'             THEN 'Cursor'
                  WHEN lower(user_agent) LIKE '%gemini-cli%'                                           THEN 'Gemini CLI'
                  ELSE NULL END                                        AS coding_agent,

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -56,6 +56,7 @@ UAG_BREAKDOWN_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_breakdown"
 UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
 UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
 UAG_TIMESERIES_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_timeseries_daily"
+UAG_CODING_AGENT_TABLE = f"{CATALOG}.{SCHEMA}.uag_coding_agent_usage"
 print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
@@ -99,6 +100,20 @@ UAG_MCP_TOOL_SCHEMA = StructType([
     StructField("request_count", LongType(), True),
     StructField("error_count", LongType(), True),
     StructField("unique_users", LongType(), True),
+    StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Coding-agent activity: classify traffic by user_agent (claude-cli → Claude Code,
+# codex, cursor, gemini-cli). One row per coding agent. NOTE: activity only
+# (requests/tokens/users/active-days) — sessions/commits/lines-of-code are NOT in
+# system.ai_gateway.usage and would need coding-agent-specific telemetry.
+UAG_CODING_AGENT_SCHEMA = StructType([
+    StructField("coding_agent",  StringType(), False),
+    StructField("request_count", LongType(), True),
+    StructField("unique_users",  LongType(), True),
+    StructField("active_days",   LongType(), True),
+    StructField("total_tokens",  LongType(), True),
     StructField("max_event_time", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
@@ -327,6 +342,44 @@ print(f"✅ Wrote {len(ts_rows_raw)} rows to {UAG_TIMESERIES_TABLE}")
 
 # COMMAND ----------
 
+# Coding-agent activity — classify by user_agent (Claude Code / Codex / Cursor /
+# Gemini CLI). Activity only; no sessions/commits/LOC (not in this table).
+print("▸ Querying ai_gateway.usage coding-agent activity …")
+try:
+    ca_rows_raw = _execute_sql(f"""
+        SELECT CASE
+                 WHEN lower(user_agent) LIKE 'claude-cli%' OR lower(user_agent) LIKE '%claude-code%' THEN 'Claude Code'
+                 WHEN lower(user_agent) LIKE '%codex%'                                                THEN 'Codex'
+                 WHEN lower(user_agent) LIKE 'cursor%'  OR lower(api_type) LIKE 'cursor%'             THEN 'Cursor'
+                 WHEN lower(user_agent) LIKE '%gemini-cli%'                                           THEN 'Gemini CLI'
+                 ELSE NULL END                                        AS coding_agent,
+               COUNT(*)                                               AS request_count,
+               COUNT(DISTINCT requester)                              AS unique_users,
+               COUNT(DISTINCT CAST(event_time AS DATE))               AS active_days,
+               COALESCE(SUM(total_tokens), 0)                         AS total_tokens,
+               CAST(MAX(event_time) AS STRING)                        AS max_event_time
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+        GROUP BY 1
+        HAVING coding_agent IS NOT NULL
+        ORDER BY request_count DESC
+    """)
+    print(f"  ✅ {len(ca_rows_raw)} coding-agent rows")
+except Exception as exc:
+    ca_rows_raw = []
+    print(f"  ⚠️  coding-agent query unavailable: {exc}")
+
+if ca_rows_raw:
+    rows = [(r.get("coding_agent", ""), to_int(r.get("request_count")), to_int(r.get("unique_users")),
+             to_int(r.get("active_days")), to_int(r.get("total_tokens")), r.get("max_event_time"), now)
+            for r in ca_rows_raw]
+    spark.createDataFrame(rows, UAG_CODING_AGENT_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_CODING_AGENT_TABLE)
+else:
+    spark.createDataFrame([], UAG_CODING_AGENT_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_CODING_AGENT_TABLE)
+print(f"✅ Wrote {len(ca_rows_raw)} rows to {UAG_CODING_AGENT_TABLE}")
+
+# COMMAND ----------
+
 # Per-tool MCP activity — service_type = MCP_SERVICE rows carry service_name (UC FQN)
 # and mcp_metadata.{tool_name, server_type}. tool_name can be null (server-level call).
 print("▸ Querying ai_gateway.usage MCP tool activity (service_type = MCP_SERVICE) …")
@@ -414,7 +467,7 @@ print(f"✅ Wrote {len(gr_rows_raw)} rows to {UAG_GUARDRAIL_TABLE}")
 
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
           "uag_mcp_tool_rows": len(mcp_rows_raw), "uag_guardrail_rows": len(gr_rows_raw),
-          "uag_timeseries_rows": len(ts_rows_raw),
+          "uag_timeseries_rows": len(ts_rows_raw), "uag_coding_agent_rows": len(ca_rows_raw),
           "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## Summary

Adds a **Coding Agents** card to the Unity AI Gateway tab (roadmap G4) — classifies `system.ai_gateway.usage` traffic by `user_agent` into **Claude Code / Codex / Cursor / Gemini CLI**, with requests / users / active-days / tokens per agent.

**Scope (honest, same caveat as F4/guardrails):** activity only. Sessions, commits, and lines-of-code (which the built-in Databricks dashboard shows) aren't in `system.ai_gateway.usage` — the card says so. Validated live at 90d: Claude Code 242,911 reqs (291 users, 90 active days), Codex 34,383, Cursor 9,114. Unlike the trace-based W2.1, gateway usage is fresh so this shows real data at the default retention.

## Plumbing
- workflow 11: `uag_coding_agent_usage` Delta table (user_agent CASE classification)
- 02_sync: Lakebase mirror (single-transaction truncate+insert); smoke EXPECTED
- backend: `get_uag_coding_agents()` + `GET /gateway/uag-coding-agents`
- frontend: `useUagCodingAgents` + sortable `CodingAgentsCard`

## Review (Isaac Review — applied in 2nd commit)
- **sync robustness:** added `rollback()` to the uag_* sync excepts (a failed insert had left the connection aborted → the next unguarded `CREATE TABLE` crashed the sync).
- **classification:** tightened codex match to `%codex/%`.
- **UI:** made the card sortable, matching the sibling v2 cards.
- Refuted (validated live): `total_tokens` exists; the cursor `api_type` branch is live. Noted: UA classification is a heuristic needing periodic pattern upkeep.

`py_compile` + `tsc` clean; classification validated live.

This pull request and its description were written by Isaac.
