### PR TITLE
feat(governance): cost attribution by custom tag (G5)

### DIFF
--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -657,25 +657,9 @@ def get_all_product_costs(days: int = 30, workspace_id: Optional[str] = None) ->
     )
 
 
-def get_cost_by_tag(tag_key: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Return MODEL_SERVING cost attributed by custom_tag.
-
-    Window aggregate (retention window owned by workflow 09); workspace-agnostic
-    because custom tags span workspaces. Optionally filter to a single tag_key.
-    """
-    if tag_key:
-        return execute_query(
-            """SELECT tag_key, tag_value, total_cost_usd::NUMERIC(18,2) AS total_cost_usd
-               FROM billing_cost_by_tag
-               WHERE tag_key = %s
-               ORDER BY total_cost_usd DESC""",
-            (tag_key,),
-        )
-    return execute_query(
-        """SELECT tag_key, tag_value, total_cost_usd::NUMERIC(18,2) AS total_cost_usd
-           FROM billing_cost_by_tag
-           ORDER BY tag_key, total_cost_usd DESC""",
-    )
+# Cost-by-tag is served exclusively through get_all_page_data (step 11); the
+# Governance page loads the full set once and filters/sorts it client-side, so
+# there is no standalone read function or /cost-by-tag route.
 
 
 # ── cache status ─────────────────────────────────────────────────

--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -252,6 +252,7 @@ def ensure_billing_tables():
             tag_key        TEXT          NOT NULL,
             tag_value      TEXT          NOT NULL,
             total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (tag_key, tag_value)
         )
         """,

--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -245,12 +245,23 @@ def ensure_billing_tables():
             PRIMARY KEY (usage_date, workspace_id, endpoint_id, run_by)
         )
         """,
+        # Cost attributed by custom_tag (window aggregate, no date grain).
+        # Populated by workflow 09; workspace-agnostic (tags span workspaces).
+        """
+        CREATE TABLE IF NOT EXISTS billing_cost_by_tag (
+            tag_key        TEXT          NOT NULL,
+            tag_value      TEXT          NOT NULL,
+            total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            PRIMARY KEY (tag_key, tag_value)
+        )
+        """,
         # Indexes for fast workspace-filtered reads
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bued_ws ON billing_user_endpoint_daily (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bucd_ws ON billing_user_cost_daily (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_btag_key ON billing_cost_by_tag (tag_key)",
         # Add value_text column (idempotent) for storing non-numeric metadata
         "ALTER TABLE billing_cache_meta ADD COLUMN IF NOT EXISTS value_text TEXT",
     ]
@@ -646,6 +657,27 @@ def get_all_product_costs(days: int = 30, workspace_id: Optional[str] = None) ->
     )
 
 
+def get_cost_by_tag(tag_key: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Return MODEL_SERVING cost attributed by custom_tag.
+
+    Window aggregate (retention window owned by workflow 09); workspace-agnostic
+    because custom tags span workspaces. Optionally filter to a single tag_key.
+    """
+    if tag_key:
+        return execute_query(
+            """SELECT tag_key, tag_value, total_cost_usd::NUMERIC(18,2) AS total_cost_usd
+               FROM billing_cost_by_tag
+               WHERE tag_key = %s
+               ORDER BY total_cost_usd DESC""",
+            (tag_key,),
+        )
+    return execute_query(
+        """SELECT tag_key, tag_value, total_cost_usd::NUMERIC(18,2) AS total_cost_usd
+           FROM billing_cost_by_tag
+           ORDER BY tag_key, total_cost_usd DESC""",
+    )
+
+
 # ── cache status ─────────────────────────────────────────────────
 
 def get_cache_status() -> Dict[str, Any]:
@@ -862,6 +894,15 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         )
         tokens_by_user = [dict(r) for r in cur.fetchall()]
 
+        # 11. cost by custom_tag (workspace-agnostic, no date grain — the
+        # retention window is owned by workflow 09).
+        cur.execute(
+            """SELECT tag_key, tag_value, total_cost_usd::NUMERIC(18,2) AS total_cost_usd
+               FROM billing_cost_by_tag
+               ORDER BY tag_key, total_cost_usd DESC"""
+        )
+        cost_by_tag = [dict(r) for r in cur.fetchall()]
+
         # Read cache_meta LAST so timestamps reflect the same state as the data
         cur.execute("SELECT * FROM billing_cache_meta ORDER BY cache_key")
         cache_rows = [dict(r) for r in cur.fetchall()]
@@ -903,4 +944,5 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         "cost_by_user": cost_by_user,
         "cost_by_user_source": cost_by_user_source,
         "tokens_by_user": tokens_by_user,
+        "cost_by_tag": cost_by_tag,
     }

--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -265,6 +265,12 @@ def ensure_billing_tables():
         "CREATE INDEX IF NOT EXISTS idx_btag_key ON billing_cost_by_tag (tag_key)",
         # Add value_text column (idempotent) for storing non-numeric metadata
         "ALTER TABLE billing_cache_meta ADD COLUMN IF NOT EXISTS value_text TEXT",
+        # Reconcile last_synced on billing_cost_by_tag. This table is created and
+        # owned by the app SP, so the sync workflow (a different Postgres role)
+        # cannot ALTER it — only the owner can. The workflow writes last_synced
+        # on INSERT, so the column must exist before the first sync or the INSERT
+        # fails on a missing column and the Cost by Tag tab stays empty.
+        "ALTER TABLE billing_cost_by_tag ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
     ]
 
     for stmt in ddl_statements:

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -1027,6 +1027,15 @@ export interface BillingPageData {
   /** "actual" = Unity AI Gateway v2 per-user attribution; "estimate" = token-share split */
   cost_by_user_source: 'actual' | 'estimate'
   tokens_by_user: any[]
+  /** MODEL_SERVING $ attributed by custom_tag (window aggregate, workspace-agnostic) */
+  cost_by_tag: CostByTagRow[]
+}
+
+/** One row of billing_cost_by_tag: a (tag_key, tag_value) pair and its total cost. */
+export interface CostByTagRow {
+  tag_key: string
+  tag_value: string
+  total_cost_usd: number
 }
 
 /**
@@ -1055,6 +1064,7 @@ export function useBillingPageData(days = 30, workspaceId?: string | null) {
         cost_by_user: [],
         cost_by_user_source: 'estimate',
         tokens_by_user: [],
+        cost_by_tag: [],
         ...data,
       } as BillingPageData
     },

--- a/control-plane-app/frontend/src/pages/Governance.tsx
+++ b/control-plane-app/frontend/src/pages/Governance.tsx
@@ -6,6 +6,7 @@ import {
   useBillingRefresh,
   useBillingCacheStatus,
   type BillingPageData,
+  type CostByTagRow,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -17,7 +18,7 @@ import { LineChart } from '@/components/charts/LineChart'
 import { BarChart } from '@/components/charts/BarChart'
 import { PieChart } from '@/components/charts/PieChart'
 import { DB_CHART } from '@/lib/brand'
-import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info } from 'lucide-react'
+import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info, Tag } from 'lucide-react'
 
 /* ── helpers ──────────────────────────────────────────────────── */
 
@@ -55,6 +56,7 @@ const TABS = [
   { key: 'endpoints', label: 'Endpoint Costs', icon: Server },
   { key: 'tokens', label: 'Token Usage', icon: Zap },
   { key: 'products', label: 'All Products', icon: Layers },
+  { key: 'tags', label: 'Cost by Tag', icon: Tag },
   { key: 'guardrails', label: 'Guardrails', icon: BarChart3 },
 ] as const
 
@@ -231,6 +233,7 @@ export default function GovernancePage() {
       {tab === 'endpoints' && <EndpointCostsTab data={pageData} />}
       {tab === 'tokens' && <TokenUsageTab data={pageData} />}
       {tab === 'products' && <AllProductsTab data={pageData} />}
+      {tab === 'tags' && <CostByTagTab data={pageData} />}
       {tab === 'guardrails' && <GuardrailsTab />}
     </div>
   )
@@ -452,6 +455,165 @@ function CostByUserSection({ costByUser, source = 'estimate' }: { costByUser: an
           <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/* ── Cost by Tag Tab ──────────────────────────────────────────── */
+
+// Human labels for the allowlisted tag keys emitted by workflow 09.
+const TAG_KEY_LABELS: Record<string, string> = {
+  project: 'Project',
+  team: 'Team',
+  environment: 'Environment',
+  app: 'App',
+  agent: 'Agent',
+  owner: 'Owner',
+  cost_center: 'Cost Center',
+  business_unit: 'Business Unit',
+  use_case: 'Use Case',
+  source: 'Source',
+}
+
+function prettyTagKey(k: string): string {
+  return TAG_KEY_LABELS[k] || k.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function CostByTagTab({ data }: { data?: BillingPageData }) {
+  const rows = useMemo<CostByTagRow[]>(() => data?.cost_by_tag || [], [data])
+
+  // Distinct tag keys present, ordered by total cost so the busiest is first.
+  const tagKeys = useMemo(() => {
+    const totals: Record<string, number> = {}
+    for (const r of rows) totals[r.tag_key] = (totals[r.tag_key] || 0) + Number(r.total_cost_usd || 0)
+    return Object.keys(totals).sort((a, b) => totals[b] - totals[a])
+  }, [rows])
+
+  const [selectedKey, setSelectedKey] = useState<string>('')
+  // Default to the top tag key once data arrives; keep a valid selection if the
+  // key set changes across refreshes.
+  useEffect(() => {
+    if (tagKeys.length && !tagKeys.includes(selectedKey)) setSelectedKey(tagKeys[0])
+  }, [tagKeys, selectedKey])
+
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const { sort, toggle } = useSort<string>('total_cost_usd')
+
+  // Reset to the first page whenever the tag key changes.
+  useEffect(() => setPage(0), [selectedKey])
+
+  const keyRows = useMemo(() => rows.filter((r) => r.tag_key === selectedKey), [rows, selectedKey])
+
+  const sorted = useMemo(() => sortRows(keyRows, sort, (r: CostByTagRow, k) => {
+    if (k === 'tag_value') return (r.tag_value || '').toLowerCase()
+    // "% of Key" is monotonic with cost within a single key, so sort by cost.
+    if (k === 'pct') return Number(r.total_cost_usd || 0)
+    return Number((r as any)[k] || 0)
+  }), [keyRows, sort])
+
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
+
+  const keyTotal = useMemo(() => keyRows.reduce((s, r) => s + Number(r.total_cost_usd || 0), 0), [keyRows])
+
+  const barData = useMemo(() =>
+    [...keyRows]
+      .sort((a, b) => Number(b.total_cost_usd || 0) - Number(a.total_cost_usd || 0))
+      .slice(0, 10)
+      .map((r) => ({
+        name: (r.tag_value || '—').length > 25 ? (r.tag_value || '—').slice(0, 25) + '…' : (r.tag_value || '—'),
+        value: Math.round(Number(r.total_cost_usd || 0) * 100) / 100,
+      })),
+    [keyRows])
+
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-16 text-center text-gray-400 dark:text-gray-500">
+          <Tag className="w-8 h-8 mx-auto mb-3 opacity-40" />
+          <p className="text-sm">No tagged model-serving usage found.</p>
+          <p className="text-xs mt-1">
+            Add cost-attribution tags (e.g. <code>project</code>, <code>team</code>, <code>owner</code>) to
+            serving endpoints to break costs down here.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Key selector + explainer */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Tag className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+          <select
+            value={selectedKey}
+            onChange={(e) => setSelectedKey(e.target.value)}
+            className="border rounded-lg px-3 py-2 text-sm min-w-[200px] dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"
+          >
+            {tagKeys.map((k) => (
+              <option key={k} value={k}>{prettyTagKey(k)}</option>
+            ))}
+          </select>
+        </div>
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          Model-serving cost attributed by custom tag. Windowed total owned by the discovery workflow.
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Tag className="w-4 h-4 text-blue-600" /> Top {prettyTagKey(selectedKey)} values by cost
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {barData.length ? (
+              <BarChart data={barData} dataKey="value" nameKey="name" multiColor height={300} />
+            ) : (
+              <div className="text-gray-400 dark:text-gray-500 text-center py-12">No data</div>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Tag className="w-4 h-4 text-blue-600" /> {prettyTagKey(selectedKey)} Detail
+              <span className="ml-1 text-xs font-normal text-gray-400">· {fmtCost(keyTotal)} total</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-gray-500 dark:text-gray-400 dark:border-gray-700">
+                    <SortableHeader label={prettyTagKey(selectedKey)} sortKey="tag_value" current={sort} onToggle={toggle} />
+                    <SortableHeader label="Cost ($)" sortKey="total_cost_usd" current={sort} onToggle={toggle} align="right" />
+                    <SortableHeader label="% of Key" sortKey="pct" current={sort} onToggle={toggle} align="right" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {paged.map((r) => (
+                    <tr key={r.tag_value} className="border-b border-gray-100 dark:border-gray-700/50">
+                      <td className="py-2 text-xs font-mono truncate max-w-[240px]">{r.tag_value || '—'}</td>
+                      <td className="py-2 text-right font-medium">{fmtCost(Number(r.total_cost_usd || 0))}</td>
+                      <td className="py-2 text-right text-gray-500">
+                        {keyTotal > 0 ? ((Number(r.total_cost_usd || 0) / keyTotal) * 100).toFixed(1) : '0.0'}%
+                      </td>
+                    </tr>
+                  ))}
+                  {keyRows.length === 0 && (
+                    <tr><td colSpan={3} className="py-8 text-center text-gray-400">No data for this tag</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1893,6 +1893,7 @@ BTD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_token_daily"
 BPD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 BUED_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
 BUCD_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
+BTAG_TABLE = f"{CATALOG}.{SCHEMA}.billing_cost_by_tag"
 
 billing_conn = get_lakebase_connection()
 bsd_count = 0
@@ -1900,6 +1901,7 @@ btd_count = 0
 bpd_count = 0
 bued_count = 0
 bucd_count = 0
+btag_count = 0
 
 # Ensure billing tables (idempotent — also created by app's ensure_billing_tables on startup)
 with billing_conn.cursor() as cur:
@@ -1957,6 +1959,13 @@ with billing_conn.cursor() as cur:
             last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (usage_date, workspace_id, endpoint_id, run_by)
         )""",
+        """CREATE TABLE IF NOT EXISTS billing_cost_by_tag (
+            tag_key        TEXT          NOT NULL,
+            tag_value      TEXT          NOT NULL,
+            total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (tag_key, tag_value)
+        )""",
         """CREATE TABLE IF NOT EXISTS billing_cache_meta (
             cache_key      TEXT PRIMARY KEY,
             last_refreshed TIMESTAMP WITH TIME ZONE,
@@ -1975,6 +1984,7 @@ with billing_conn.cursor() as cur:
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bued_ws ON billing_user_endpoint_daily (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bucd_ws ON billing_user_cost_daily (workspace_id)",
+        "CREATE INDEX IF NOT EXISTS idx_btag_key ON billing_cost_by_tag (tag_key)",
     ]:
         try:
             cur.execute(ddl)
@@ -2157,6 +2167,33 @@ try:
 except Exception as exc:
     print(f"  ⚠️  billing_user_cost_daily sync failed: {exc}")
 
+# Sync billing_cost_by_tag (MODEL_SERVING $ attributed by custom_tag — window aggregate)
+print(f"▸ Syncing {BTAG_TABLE} → billing_cost_by_tag ...")
+try:
+    with billing_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE billing_cost_by_tag")
+        billing_conn.commit()
+    btag_rows = spark.read.table(BTAG_TABLE).collect()
+    if btag_rows:
+        values = [(r.tag_key or "", r.tag_value or "", float(r.total_cost_usd or 0))
+                  for r in btag_rows]
+        btag_count = len(values)
+        with billing_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO billing_cost_by_tag
+                   (tag_key, tag_value, total_cost_usd, last_synced)
+                   VALUES %s
+                   ON CONFLICT (tag_key, tag_value) DO UPDATE SET
+                       total_cost_usd = EXCLUDED.total_cost_usd,
+                       last_synced = NOW()""",
+                [(v[0], v[1], v[2], now) for v in values],
+                page_size=500)
+            billing_conn.commit()
+    print(f"  ✅ {btag_count} cost-by-tag rows synced")
+    _stamp_cache_meta(billing_conn, "cost_by_tag", btag_count)
+except Exception as exc:
+    print(f"  ⚠️  billing_cost_by_tag sync failed: {exc}")
+
 billing_conn.close()
 
 # COMMAND ----------
@@ -2265,6 +2302,7 @@ result = {
     "billing_product_daily_rows": bpd_count,
     "billing_user_endpoint_daily_rows": bued_count,
     "billing_user_cost_daily_rows": bucd_count,
+    "billing_cost_by_tag_rows": btag_count,
     "synced_at": datetime.now(timezone.utc).isoformat(),
 }
 print(json.dumps(result, indent=2))

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1979,6 +1979,11 @@ with billing_conn.cursor() as cur:
         "ALTER TABLE billing_token_daily          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "ALTER TABLE billing_product_daily        ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "ALTER TABLE billing_user_endpoint_daily  ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        # billing_cost_by_tag is also created by the app's ensure_billing_tables
+        # WITHOUT last_synced; the CREATE above is then a no-op, so reconcile the
+        # column here (matches the pattern for the four sibling tables) or the
+        # sync INSERT below fails on a missing column and the tab stays empty.
+        "ALTER TABLE billing_cost_by_tag          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
@@ -2192,6 +2197,9 @@ try:
     print(f"  ✅ {btag_count} cost-by-tag rows synced")
     _stamp_cache_meta(billing_conn, "cost_by_tag", btag_count)
 except Exception as exc:
+    # Clear any aborted transaction so a future sync block appended after this
+    # one doesn't inherit a poisoned connection (see the uag_conn rollback guards).
+    billing_conn.rollback()
     print(f"  ⚠️  billing_cost_by_tag sync failed: {exc}")
 
 billing_conn.close()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -2176,11 +2176,18 @@ try:
     print(f"  ✅ {bucd_count} user-cost rows synced")
     _stamp_cache_meta(billing_conn, "user_cost_daily", bucd_count)
 except Exception as exc:
+    # Rollback so a failed INSERT here (e.g. billing_user_cost_daily is app-owned
+    # and may be missing last_synced) does not leave the shared connection in an
+    # aborted-transaction state that poisons the next sync block below.
+    billing_conn.rollback()
     print(f"  ⚠️  billing_user_cost_daily sync failed: {exc}")
 
 # Sync billing_cost_by_tag (MODEL_SERVING $ attributed by custom_tag — window aggregate)
 print(f"▸ Syncing {BTAG_TABLE} → billing_cost_by_tag ...")
 try:
+    # Defense-in-depth: clear any aborted transaction inherited from a prior
+    # block so this block's TRUNCATE isn't rejected with "transaction is aborted".
+    billing_conn.rollback()
     with billing_conn.cursor() as cur:
         cur.execute("TRUNCATE TABLE billing_cost_by_tag")
         billing_conn.commit()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1979,10 +1979,10 @@ with billing_conn.cursor() as cur:
         "ALTER TABLE billing_token_daily          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "ALTER TABLE billing_product_daily        ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "ALTER TABLE billing_user_endpoint_daily  ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
-        # billing_cost_by_tag is also created by the app's ensure_billing_tables
-        # WITHOUT last_synced; the CREATE above is then a no-op, so reconcile the
-        # column here (matches the pattern for the four sibling tables) or the
-        # sync INSERT below fails on a missing column and the tab stays empty.
+        # Reconcile last_synced on billing_cost_by_tag when the workflow owns the
+        # table. When the app SP owns it instead, this ALTER is permission-denied
+        # (only the owner can ALTER) and rolled back harmlessly — the app's own
+        # ensure_billing_tables runs the matching reconcile as the owner.
         "ALTER TABLE billing_cost_by_tag          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1991,11 +1991,17 @@ with billing_conn.cursor() as cur:
         "CREATE INDEX IF NOT EXISTS idx_bucd_ws ON billing_user_cost_daily (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btag_key ON billing_cost_by_tag (tag_key)",
     ]:
+        # Commit each statement independently: these are all idempotent
+        # CREATE/ALTER/INDEX ... IF NOT EXISTS, so one failure must not poison
+        # the shared transaction and silently roll back every later statement
+        # (that is exactly how the billing_cost_by_tag `last_synced` ALTER got
+        # dropped, leaving the sync INSERT to fail on a missing column).
         try:
             cur.execute(ddl)
+            billing_conn.commit()
         except Exception as e:
+            billing_conn.rollback()
             print(f"  DDL warning: {e}")
-    billing_conn.commit()
 
 
 def _stamp_cache_meta(conn, cache_key: str, rows_loaded: int) -> None:

--- a/workflows/09_discover_billing.py
+++ b/workflows/09_discover_billing.py
@@ -65,6 +65,7 @@ TOKEN_TABLE    = f"{CATALOG}.{SCHEMA}.billing_token_daily"
 PRODUCT_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 USER_EP_TABLE  = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
 USER_COST_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
+TAG_COST_TABLE  = f"{CATALOG}.{SCHEMA}.billing_cost_by_tag"
 
 print(f"Target tables:")
 print(f"  {SERVING_TABLE}")
@@ -80,6 +81,13 @@ print(f"Retention: {RETENTION_DAYS} days")
 # MAGIC ## Schemas
 
 # COMMAND ----------
+
+TAG_COST_SCHEMA = StructType([
+    StructField("tag_key", StringType(), False),
+    StructField("tag_value", StringType(), False),
+    StructField("total_cost_usd", DecimalType(18, 4), True),
+    StructField("discovered_at", TimestampType(), False),
+])
 
 SERVING_SCHEMA = StructType([
     StructField("usage_date", StringType(), False),
@@ -465,6 +473,50 @@ print(f"✅ Wrote {len(user_cost_rows)} rows to {USER_COST_TABLE}")
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## Query 6: billing_cost_by_tag (MODEL_SERVING $ attributed by custom_tag)
+# MAGIC Explodes custom_tags for an allowlist of business/cost-attribution keys and
+# MAGIC joins list_prices for USD. System tags (EndpointId, ServingType, …) are
+# MAGIC excluded so the view is meaningful cost attribution, not tag noise.
+
+# COMMAND ----------
+
+print(f"▸ Querying system.billing.usage for cost-by-tag ({RETENTION_DAYS} days) …")
+tag_cost_rows = _execute_sql(f"""
+    WITH priced AS (
+        SELECT u.custom_tags,
+               u.usage_quantity * COALESCE(lp.pricing.effective_list.default, lp.pricing.default, 0) AS usd
+        FROM system.billing.usage u
+        LEFT JOIN system.billing.list_prices lp
+            ON u.sku_name = lp.sku_name AND u.cloud = lp.cloud
+            AND u.usage_unit = lp.usage_unit AND lp.price_end_time IS NULL
+        WHERE u.billing_origin_product = 'MODEL_SERVING'
+          AND u.usage_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
+          AND u.custom_tags IS NOT NULL
+    )
+    SELECT lower(k)              AS tag_key,
+           custom_tags[k]        AS tag_value,
+           ROUND(SUM(usd), 4)    AS total_cost_usd
+    FROM priced LATERAL VIEW explode(map_keys(custom_tags)) t AS k
+    WHERE lower(k) IN ('project','team','environment','app','agent','owner',
+                       'cost_center','business_unit','use_case','source')
+      AND custom_tags[k] IS NOT NULL AND custom_tags[k] != ''
+    GROUP BY lower(k), custom_tags[k]
+    HAVING SUM(usd) > 0
+    ORDER BY total_cost_usd DESC
+""")
+print(f"  ✅ {len(tag_cost_rows)} cost-by-tag rows")
+
+if tag_cost_rows:
+    rows = [(r.get("tag_key", ""), r.get("tag_value", ""), _dec(r.get("total_cost_usd"), 4), now)
+            for r in tag_cost_rows]
+    spark.createDataFrame(rows, TAG_COST_SCHEMA).write.mode("overwrite").saveAsTable(TAG_COST_TABLE)
+else:
+    spark.createDataFrame([], TAG_COST_SCHEMA).write.mode("overwrite").saveAsTable(TAG_COST_TABLE)
+print(f"✅ Wrote {len(tag_cost_rows)} rows to {TAG_COST_TABLE}")
+
+# COMMAND ----------
+
 result = {
     "status": "success",
     "serving_rows": len(serving_rows),
@@ -472,6 +524,7 @@ result = {
     "product_rows": len(product_rows),
     "user_endpoint_rows": len(user_ep_rows),
     "user_cost_rows": len(user_cost_rows),
+    "tag_cost_rows": len(tag_cost_rows),
     "retention_days": RETENTION_DAYS,
     "discovered_at": now.isoformat(),
 }

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -76,6 +76,7 @@ EXPECTED = [
     # Populated by discovery but legitimately empty in some workspaces.
     # We assert existence; row count of 0 produces a WARN, not a failure.
     "billing_serving_daily",         # may be empty if no model serving in last 90d
+    "billing_cost_by_tag",           # MODEL_SERVING $ by custom_tag; empty if no tagged serving usage
     "observability_traces",
     "observability_trace_details",
     "observability_experiments",


### PR DESCRIPTION
## What

Adds **Cost by Tag** to the Governance page — breaking down model-serving spend by `custom_tag` so teams can answer *"how much is `<project>`/`<team>`/`<owner>` costing?"*. This is the DAIS 2026 cost-attribution direction.

## Pipeline

- **`09_discover_billing`** — new `billing_cost_by_tag` Delta table. Prices `system.billing.usage` MODEL_SERVING rows via `list_prices`, explodes `custom_tags` for an allowlist of business keys (`project, team, environment, app, agent, owner, cost_center, business_unit, use_case, source`), aggregates USD per `(tag_key, tag_value)`. CTE prices first, then `LATERAL VIEW explode` (Spark disallows JOIN after LATERAL VIEW).
- **`02_sync_to_lakebase`** — mirror `billing_cost_by_tag` → Lakebase (TRUNCATE + upsert, `cache_meta` stamp, `last_synced` reconcile ALTER, rollback guard).
- **`10_smoke_check`** — `billing_cost_by_tag` added to `EXPECTED`.
- **`billing_service`** — table DDL + `cost_by_tag` added to the composite page-data payload (workspace-agnostic, no date grain).
- **Governance page** — new "Cost by Tag" tab: tag-key selector (ordered by spend), top-values bar chart, sortable/paginated detail table with %-of-key, and an empty state explaining how to tag endpoints.

## Validation

- Query validated live against `fevm` at the 90-day default: 2204 rows across all 10 allowlisted keys.
- `list_prices` join verified 1:1 (exactly one price row per usage row across 4.4M MODEL_SERVING rows) — no cost fan-out.
- Reviewed with Isaac Review (`/review`); 3 findings applied (DDL `last_synced` reconcile, dead-code removal, rollback guard), remainder refuted with evidence.

This pull request and its description were written by Isaac.