### PR TITLE
fix(billing): un-stale billing_user_cost_daily (owner-side last_synced)

### DIFF
--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -242,6 +242,7 @@ def ensure_billing_tables():
             run_by         TEXT          NOT NULL DEFAULT '',
             total_dbus     NUMERIC(18,4) NOT NULL DEFAULT 0,
             total_cost_usd NUMERIC(18,4) NOT NULL DEFAULT 0,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (usage_date, workspace_id, endpoint_id, run_by)
         )
         """,
@@ -271,6 +272,11 @@ def ensure_billing_tables():
         # on INSERT, so the column must exist before the first sync or the INSERT
         # fails on a missing column and the Cost by Tag tab stays empty.
         "ALTER TABLE billing_cost_by_tag ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        # billing_user_cost_daily is likewise app-SP-owned; the sync workflow (a
+        # different Postgres role) writes last_synced on INSERT but cannot ALTER
+        # a table it does not own. Reconcile the column here, as the owner, so the
+        # INSERT stops failing and the "Actual" per-user cost stops going stale.
+        "ALTER TABLE billing_user_cost_daily ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
     ]
 
     for stmt in ddl_statements:

--- a/workflows/09_discover_billing.py
+++ b/workflows/09_discover_billing.py
@@ -372,7 +372,13 @@ try:
             CAST(u.usage_date AS STRING)                       AS usage_date,
             u.workspace_id,
             u.usage_metadata.ai_gateway.endpoint_id            AS endpoint_id,
-            u.usage_metadata.endpoint_name                     AS endpoint_name,
+            -- endpoint_name is NOT part of the downstream PK
+            -- (usage_date, workspace_id, endpoint_id, run_by); a single
+            -- endpoint_id can carry more than one name in the window (renames,
+            -- null vs populated), so aggregate it rather than grouping by it —
+            -- otherwise the query emits duplicate-PK rows and the Lakebase
+            -- ON CONFLICT upsert fails with "cannot affect row a second time".
+            MAX(u.usage_metadata.endpoint_name)                AS endpoint_name,
             COALESCE(u.identity_metadata.run_by, 'unknown')    AS run_by,
             ROUND(SUM(u.usage_quantity), 4)                    AS total_dbus,
             ROUND(SUM(u.usage_quantity *
@@ -390,7 +396,6 @@ try:
           AND u.workspace_id IS NOT NULL
         GROUP BY u.usage_date, u.workspace_id,
                  u.usage_metadata.ai_gateway.endpoint_id,
-                 u.usage_metadata.endpoint_name,
                  u.identity_metadata.run_by
     """)
     print(f"  ✅ {len(user_cost_rows)} actual per-user cost rows")


### PR DESCRIPTION
## What

`billing_user_cost_daily` (the "Actual" per-user cost on the Governance overview) has been serving **stale data**. Found while shipping G5 (#29).

## Root cause

The table is **app-SP-owned** in Lakebase and was created without a `last_synced` column. The sync workflow runs as a *different* Postgres role: it can `INSERT` (via `databricks_superuser` grants) but **cannot `ALTER`** a table it doesn't own. Its INSERT writes `last_synced`, so it fails on the missing column every run — masked because the table retains old rows and still looks populated.

## Fix (mirrors the G5 ownership fix)

- App `ensure_billing_tables` now creates `billing_user_cost_daily` **with** `last_synced` and runs an owner-side `ALTER … ADD COLUMN IF NOT EXISTS last_synced` (only the owning app SP can alter it).
- The workflow already writes `last_synced` and, since G5 (#29), rolls back on failure so a bad block can't poison later sync blocks.

Requires an app redeploy (so `ensure_billing_tables` runs the owner ALTER) + a discovery run to repopulate. Verified end-to-end on fevm before merge.

This pull request and its description were written by Isaac.