### PR TITLE
feat(observability): agent eval / quality scores from MLflow-3 assessments (F7)

### DIFF
--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -36,6 +36,13 @@ async def agent_tool_usage():
     return mlflow_service.get_agent_tool_usage()
 
 
+@router.get("/agent-eval-scores")
+async def agent_eval_scores():
+    """MLflow-3 eval / assessment scores per experiment — how each agent's traces
+    score on LLM-judge and human assessments (safety, relevance, groundedness, …)."""
+    return mlflow_service.get_agent_eval_scores()
+
+
 @router.get("/experiments")
 async def list_experiments(
     request: Request,

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -294,6 +294,76 @@ def get_agent_tool_usage() -> Dict[str, Any]:
     }
 
 
+def get_agent_eval_scores() -> Dict[str, Any]:
+    """MLflow-3 online-eval / labeled assessments rolled up per experiment (from
+    `agent_eval_scores`, produced by 07_discover_uc_otel_traces). Answers how each
+    agent's traces score on judges/human labels (safety, relevance, groundedness, …).
+
+    Grain is EXPERIMENT — same caveat as get_agent_tool_usage (no experiment→agent
+    mapping yet). Degrades to empty when the table is unsynced or no eval'd traces
+    exist.
+    """
+    empty: Dict[str, Any] = {"totals": {}, "rows": []}
+    try:
+        rows = execute_query(
+            """SELECT experiment_id, scorer_name, source_type, assessment_count,
+                      pass_count, fail_count, pass_rate, last_seen
+               FROM agent_eval_scores ORDER BY assessment_count DESC LIMIT 1000"""
+        )
+    except Exception as exc:
+        logger.warning("agent_eval_scores not available: %s", exc)
+        return empty
+    if not rows:
+        return empty
+
+    exp_ids = {r.get("experiment_id") for r in rows if r.get("experiment_id")}
+    names: Dict[str, str] = {}
+    if exp_ids:
+        try:
+            placeholders = ",".join("%s" for _ in exp_ids)
+            for e in execute_query(
+                f"SELECT experiment_id, name FROM observability_experiments "
+                f"WHERE name IS NOT NULL AND experiment_id IN ({placeholders})",
+                tuple(exp_ids),
+            ):
+                names.setdefault(e.get("experiment_id"), e.get("name"))
+        except Exception:
+            pass
+
+    def _i(r, k):
+        return int(r.get(k) or 0)
+
+    out = []
+    for r in rows:
+        pr = r.get("pass_rate")
+        out.append({
+            "experiment_id": r.get("experiment_id") or "",
+            "experiment_name": names.get(r.get("experiment_id")) or "",
+            "scorer_name": r.get("scorer_name") or "",
+            "source_type": r.get("source_type") or "",
+            "assessment_count": _i(r, "assessment_count"),
+            "pass_count": _i(r, "pass_count"),
+            "fail_count": _i(r, "fail_count"),
+            # pass_rate is null for scorers with no yes/no verdicts (e.g. numeric feedback)
+            "pass_rate": float(pr) if pr is not None else None,
+            "last_seen": r.get("last_seen") or "",
+        })
+
+    graded = [r for r in out if r["pass_rate"] is not None]
+    overall_pass = sum(r["pass_count"] for r in graded)
+    overall_total = sum(r["pass_count"] + r["fail_count"] for r in graded)
+    return {
+        "totals": {
+            "experiments": len({r["experiment_id"] for r in out if r["experiment_id"]}),
+            "scorers": len({r["scorer_name"] for r in out if r["scorer_name"]}),
+            "assessments": sum(r["assessment_count"] for r in out),
+            # blended pass-rate across all yes/no verdicts; null if nothing gradable
+            "pass_rate": (overall_pass / overall_total) if overall_total > 0 else None,
+        },
+        "rows": out,
+    }
+
+
 def search_experiments_system_tables(max_results: int = 5000) -> List[Dict[str, Any]]:
     """Query system.mlflow.experiments_latest for cross-workspace experiments.
 

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -222,6 +222,27 @@ def _execute_system_sql(sql: str) -> List[Dict[str, Any]]:
 
 # ── System table queries (cross-workspace) ─────────────────────
 
+def _experiment_names(exp_ids) -> Dict[str, str]:
+    """Resolve experiment_id → name from observability_experiments. Best-effort;
+    returns {} on any error or empty input. Shared by the per-experiment rollup
+    endpoints (tool usage, eval scores)."""
+    names: Dict[str, str] = {}
+    ids = {e for e in exp_ids if e}
+    if not ids:
+        return names
+    try:
+        placeholders = ",".join("%s" for _ in ids)
+        for e in execute_query(
+            f"SELECT experiment_id, name FROM observability_experiments "
+            f"WHERE name IS NOT NULL AND experiment_id IN ({placeholders})",
+            tuple(ids),
+        ):
+            names.setdefault(e.get("experiment_id"), e.get("name"))
+    except Exception:
+        pass
+    return names
+
+
 def get_agent_tool_usage() -> Dict[str, Any]:
     """TOOL/RETRIEVER span usage rolled up per experiment (from `agent_tool_usage`,
     produced by 07_discover_uc_otel_traces). Answers what UC functions and vector
@@ -243,19 +264,7 @@ def get_agent_tool_usage() -> Dict[str, Any]:
     if not rows:
         return empty
 
-    exp_ids = {r.get("experiment_id") for r in rows if r.get("experiment_id")}
-    names: Dict[str, str] = {}
-    if exp_ids:
-        try:
-            placeholders = ",".join("%s" for _ in exp_ids)
-            for e in execute_query(
-                f"SELECT experiment_id, name FROM observability_experiments "
-                f"WHERE name IS NOT NULL AND experiment_id IN ({placeholders})",
-                tuple(exp_ids),
-            ):
-                names.setdefault(e.get("experiment_id"), e.get("name"))
-        except Exception:
-            pass
+    names = _experiment_names(r.get("experiment_id") for r in rows)
 
     def _i(r, k):
         return int(r.get(k) or 0)
@@ -316,19 +325,7 @@ def get_agent_eval_scores() -> Dict[str, Any]:
     if not rows:
         return empty
 
-    exp_ids = {r.get("experiment_id") for r in rows if r.get("experiment_id")}
-    names: Dict[str, str] = {}
-    if exp_ids:
-        try:
-            placeholders = ",".join("%s" for _ in exp_ids)
-            for e in execute_query(
-                f"SELECT experiment_id, name FROM observability_experiments "
-                f"WHERE name IS NOT NULL AND experiment_id IN ({placeholders})",
-                tuple(exp_ids),
-            ):
-                names.setdefault(e.get("experiment_id"), e.get("name"))
-        except Exception:
-            pass
+    names = _experiment_names(r.get("experiment_id") for r in rows)
 
     def _i(r, k):
         return int(r.get(k) or 0)
@@ -349,19 +346,31 @@ def get_agent_eval_scores() -> Dict[str, Any]:
             "last_seen": r.get("last_seen") or "",
         })
 
-    graded = [r for r in out if r["pass_rate"] is not None]
-    overall_pass = sum(r["pass_count"] for r in graded)
-    overall_total = sum(r["pass_count"] + r["fail_count"] for r in graded)
-    return {
-        "totals": {
-            "experiments": len({r["experiment_id"] for r in out if r["experiment_id"]}),
-            "scorers": len({r["scorer_name"] for r in out if r["scorer_name"]}),
-            "assessments": sum(r["assessment_count"] for r in out),
-            # blended pass-rate across all yes/no verdicts; null if nothing gradable
-            "pass_rate": (overall_pass / overall_total) if overall_total > 0 else None,
-        },
-        "rows": out,
-    }
+    # Totals come from an UNBOUNDED aggregate, not the LIMIT 1000 row window above,
+    # so KPI cards stay accurate (and the blended pass-rate stays a true global rate)
+    # even when there are more than 1000 (experiment, scorer, source_type) combos.
+    totals: Dict[str, Any] = {"experiments": 0, "scorers": 0, "assessments": 0, "pass_rate": None}
+    try:
+        agg = execute_query(
+            """SELECT COUNT(DISTINCT experiment_id)            AS experiments,
+                      COUNT(DISTINCT scorer_name)              AS scorers,
+                      COALESCE(SUM(assessment_count), 0)       AS assessments,
+                      COALESCE(SUM(pass_count), 0)             AS pass_sum,
+                      COALESCE(SUM(pass_count + fail_count), 0) AS verdict_sum
+               FROM agent_eval_scores"""
+        )
+        a = agg[0] if agg else {}
+        verdicts = int(a.get("verdict_sum") or 0)
+        totals = {
+            "experiments": int(a.get("experiments") or 0),
+            "scorers": int(a.get("scorers") or 0),
+            "assessments": int(a.get("assessments") or 0),
+            "pass_rate": (int(a.get("pass_sum") or 0) / verdicts) if verdicts > 0 else None,
+        }
+    except Exception:
+        pass
+
+    return {"totals": totals, "rows": out}
 
 
 def search_experiments_system_tables(max_results: int = 5000) -> List[Dict[str, Any]]:

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -282,6 +282,32 @@ export function useAgentToolUsage() {
   })
 }
 
+export interface AgentEvalScores {
+  totals: Partial<{ experiments: number; scorers: number; assessments: number; pass_rate: number | null }>
+  rows: Array<{
+    experiment_id: string
+    experiment_name: string
+    scorer_name: string
+    source_type: string
+    assessment_count: number
+    pass_count: number
+    fail_count: number
+    pass_rate: number | null
+    last_seen: string
+  }>
+}
+
+/** MLflow-3 eval / assessment scores per experiment — LLM-judge & human quality signals. */
+export function useAgentEvalScores() {
+  return useQuery({
+    queryKey: ['mlflow', 'agent-eval-scores'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/mlflow/agent-eval-scores')
+      return data as AgentEvalScores
+    },
+  })
+}
+
 export function useMlflowTraceDetail(requestId: string | null, workspaceId?: string | null) {
   return useQuery({
     queryKey: ['mlflow', 'trace-detail', requestId, workspaceId],

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -15,6 +15,7 @@ import {
   useGatewayLogDetail,
   useGatewayLogTimeseries,
   useAgentToolUsage,
+  useAgentEvalScores,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { RefreshButton } from '@/components/RefreshButton'
@@ -64,6 +65,7 @@ import {
   Calendar,
   Info,
   Wrench,
+  ShieldCheck,
 } from 'lucide-react'
 import { DB_RED_SHADES } from '@/lib/brand'
 
@@ -164,6 +166,7 @@ const tabs = [
   { id: 'experiments', label: 'Experiments', icon: FlaskConical },
   { id: 'runs', label: 'Evaluation Runs', icon: Activity },
   { id: 'tool-usage', label: 'Tool & Asset Usage', icon: Wrench },
+  { id: 'eval-scores', label: 'Quality & Evals', icon: ShieldCheck },
   { id: 'models', label: 'Model Registry', icon: Database },
 ] as const
 
@@ -264,6 +267,7 @@ export default function ObservabilityPage() {
       {activeTab === 'experiments' && <ExperimentsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'tool-usage' && <ToolUsagePanel />}
+      {activeTab === 'eval-scores' && <EvalScoresPanel />}
       {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
     </div>
   )
@@ -339,6 +343,104 @@ function ToolUsagePanel() {
                     <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[220px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.call_count.toLocaleString()}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.trace_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/* ── Quality & Evals Panel (F7) ──────────────────────────────────
+   MLflow-3 assessments (LLM-judge + human) rolled up per experiment from
+   agent_eval_scores: how each agent's traces score on safety, relevance,
+   groundedness, etc. Same experiment grain as tool usage. */
+function pctLabel(v: number | null | undefined): string {
+  return v == null ? '—' : `${(v * 100).toFixed(0)}%`
+}
+function passRateClass(v: number | null | undefined): string {
+  if (v == null) return 'text-gray-400 dark:text-gray-500'
+  if (v >= 0.9) return 'text-green-600 dark:text-green-400'
+  if (v >= 0.7) return 'text-amber-600 dark:text-amber-400'
+  return 'text-red-600 dark:text-red-400'
+}
+
+function EvalScoresPanel() {
+  const { data, isLoading } = useAgentEvalScores()
+  const sort = useSort('assessment_count', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(15)
+  const rows = data?.rows || []
+  const sorted = useMemo(() => sortRows(rows, sort.sort, (r: any, k) => {
+    if (k === 'assessment_count' || k === 'pass_count' || k === 'fail_count') return Number(r[k] || 0)
+    if (k === 'pass_rate') return r[k] == null ? -1 : Number(r[k])
+    return (r[k] || '').toString().toLowerCase()
+  }), [rows, sort.sort])
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+
+  if (isLoading) return <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
+  if (rows.length === 0) {
+    return (
+      <Card><CardContent className="py-12 text-center text-gray-400 dark:text-gray-500">
+        No eval scores yet — agents need MLflow-3 assessments (LLM-judge or human labels) attached to their traces,
+        and the discovery workflow must have synced them. Sourced from the <code>assessments</code> on Databricks-native
+        <code> trace_logs</code> tables.
+      </CardContent></Card>
+    )
+  }
+  const t = data!.totals
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <KpiCard title="Experiments" value={t.experiments ?? 0} format="number" />
+        <KpiCard title="Scorers" value={t.scorers ?? 0} format="number" />
+        <KpiCard title="Assessments" value={t.assessments ?? 0} format="number" />
+        <KpiCard title="Overall Pass Rate" value={pctLabel(t.pass_rate)} />
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Quality & Eval Scores</CardTitle>
+          <p className="text-[11px] text-gray-400 dark:text-gray-500">
+            MLflow-3 assessments (LLM-judge & human) per scorer, rolled up by <strong>experiment</strong> — the app has no
+            experiment→agent mapping yet. Pass rate covers yes/no verdicts only; scorers with non-binary feedback show “—”.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <SortableHeader label="Scorer" sortKey="scorer_name" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Source" sortKey="source_type" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Experiment" sortKey="experiment_name" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Assessments" sortKey="assessment_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Pass" sortKey="pass_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Fail" sortKey="fail_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Pass Rate" sortKey="pass_rate" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Last Seen" sortKey="last_seen" current={sort.sort} onToggle={sort.toggle} align="right" />
+                </tr>
+              </thead>
+              <tbody>
+                {paged.map((r: any, i: number) => (
+                  <tr key={`${r.experiment_id}-${r.scorer_name}-${r.source_type}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                    <td className="py-1.5 font-medium truncate max-w-[220px]" title={r.scorer_name}>{r.scorer_name}</td>
+                    <td className="py-1.5">
+                      <Badge variant={r.source_type === 'HUMAN' ? 'info' : 'default'} className="text-xs">
+                        {r.source_type === 'HUMAN' ? 'Human' : r.source_type === 'LLM_JUDGE' ? 'LLM judge' : (r.source_type || '—')}
+                      </Badge>
+                    </td>
+                    <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[200px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
+                    <td className="py-1.5 text-right tabular-nums">{r.assessment_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right tabular-nums text-green-600 dark:text-green-400">{r.pass_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right tabular-nums text-red-600 dark:text-red-400">{r.fail_count.toLocaleString()}</td>
+                    <td className={`py-1.5 text-right tabular-nums font-medium ${passRateClass(r.pass_rate)}`}>{pctLabel(r.pass_rate)}</td>
                     <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
                   </tr>
                 ))}

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -361,12 +361,15 @@ function ToolUsagePanel() {
    agent_eval_scores: how each agent's traces score on safety, relevance,
    groundedness, etc. Same experiment grain as tool usage. */
 function pctLabel(v: number | null | undefined): string {
-  return v == null ? '—' : `${(v * 100).toFixed(0)}%`
+  return v == null ? '—' : `${Math.round(v * 100)}%`
 }
 function passRateClass(v: number | null | undefined): string {
   if (v == null) return 'text-gray-400 dark:text-gray-500'
-  if (v >= 0.9) return 'text-green-600 dark:text-green-400'
-  if (v >= 0.7) return 'text-amber-600 dark:text-amber-400'
+  // Threshold on the same rounded percentage the label shows, so colour and
+  // number never disagree (e.g. 0.896 → "90%" reads green, not amber).
+  const pct = Math.round(v * 100)
+  if (pct >= 90) return 'text-green-600 dark:text-green-400'
+  if (pct >= 70) return 'text-amber-600 dark:text-amber-400'
   return 'text-red-600 dark:text-red-400'
 }
 
@@ -378,7 +381,9 @@ function EvalScoresPanel() {
   const rows = data?.rows || []
   const sorted = useMemo(() => sortRows(rows, sort.sort, (r: any, k) => {
     if (k === 'assessment_count' || k === 'pass_count' || k === 'fail_count') return Number(r[k] || 0)
-    if (k === 'pass_rate') return r[k] == null ? -1 : Number(r[k])
+    // Return null (not a sentinel) so sortRows pushes ungraded scorers to the
+    // bottom in both directions, instead of ranking them below a genuine 0%.
+    if (k === 'pass_rate') return r[k] == null ? null : Number(r[k])
     return (r[k] || '').toString().toLowerCase()
   }), [rows, sort.sort])
   const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -682,6 +682,13 @@ with obs_conn.cursor() as cur:
             last_seen TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
         "CREATE INDEX IF NOT EXISTS idx_atu_exp ON agent_tool_usage (experiment_id)",
+        """CREATE TABLE IF NOT EXISTS agent_eval_scores (
+            experiment_id TEXT, scorer_name TEXT NOT NULL, source_type TEXT,
+            assessment_count BIGINT DEFAULT 0, pass_count BIGINT DEFAULT 0,
+            fail_count BIGINT DEFAULT 0, pass_rate DOUBLE PRECISION,
+            last_seen TEXT,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
+        "CREATE INDEX IF NOT EXISTS idx_aes_exp ON agent_eval_scores (experiment_id)",
     ]:
         # Each statement in its own savepoint — protects against the case
         # where the workflow runs as a non-owner of pre-existing tables (the
@@ -1170,6 +1177,36 @@ try:
 except Exception as exc:
     obs_conn.rollback()
     print(f"  ⚠️  agent_tool_usage sync failed: {exc}")
+
+# COMMAND ----------
+
+# Sync agent_eval_scores (F7 — MLflow-3 assessment rollup from 07_discover_uc_otel_traces).
+EVAL_SCORES_DELTA = f"{CATALOG}.{SCHEMA}.agent_eval_scores"
+aes_count = 0
+print(f"▸ Syncing {EVAL_SCORES_DELTA} → agent_eval_scores ...")
+try:
+    # Read first, then truncate+insert in ONE transaction (single commit): a failed
+    # insert rolls back the truncate rather than leaving the table empty.
+    aes_rows = spark.read.table(EVAL_SCORES_DELTA).collect()
+    values = [(r.experiment_id, r.scorer_name, r.source_type,
+               int(r.assessment_count or 0), int(r.pass_count or 0), int(r.fail_count or 0),
+               float(r.pass_rate) if r.pass_rate is not None else None,
+               r.last_seen, now) for r in aes_rows]
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE agent_eval_scores")
+        if values:
+            execute_values(cur,
+                """INSERT INTO agent_eval_scores
+                   (experiment_id, scorer_name, source_type, assessment_count,
+                    pass_count, fail_count, pass_rate, last_seen, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    obs_conn.commit()
+    aes_count = len(values)
+    print(f"  ✅ {aes_count} agent eval-score rows synced")
+except Exception as exc:
+    obs_conn.rollback()
+    print(f"  ⚠️  agent_eval_scores sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -43,7 +43,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
-    StructType, StructField, StringType, LongType, TimestampType,
+    StructType, StructField, StringType, LongType, TimestampType, DoubleType,
 )
 
 spark = SparkSession.builder.getOrCreate()
@@ -79,10 +79,12 @@ if not CATALOG or not SCHEMA:
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces_uc_otel"
 DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details_uc_otel"
 TOOL_USAGE_TABLE = f"{CATALOG}.{SCHEMA}.agent_tool_usage"
+EVAL_SCORES_TABLE = f"{CATALOG}.{SCHEMA}.agent_eval_scores"
 
 print(f"Trace summary target: {TRACES_TABLE}")
 print(f"Trace detail target:  {DETAILS_TABLE}")
 print(f"Tool usage target:    {TOOL_USAGE_TABLE}")
+print(f"Eval scores target:   {EVAL_SCORES_TABLE}")
 print(f"Retention: {RETENTION_DAYS} days")
 
 # COMMAND ----------
@@ -134,6 +136,23 @@ TOOL_USAGE_SCHEMA = StructType([
     StructField("trace_count",   LongType(),   True),
     StructField("last_seen",     StringType(), True),
     StructField("discovered_at", TimestampType(), False),
+])
+
+# Agent eval scores (F7): MLflow-3 online-eval / labeled assessments rolled up per
+# experiment. Each trace's `assessments` array holds one entry per scorer
+# (LLM judge or human). One row per (experiment_id, scorer_name, source_type)
+# with pass/fail counts + pass_rate for yes/no verdicts. Same EXPERIMENT grain
+# as tool usage (no experiment→discovered-agent mapping yet).
+EVAL_SCORES_SCHEMA = StructType([
+    StructField("experiment_id",    StringType(), True),
+    StructField("scorer_name",      StringType(), False),   # e.g. safety, relevance_to_query
+    StructField("source_type",      StringType(), True),    # LLM_JUDGE | HUMAN | CODE
+    StructField("assessment_count", LongType(),   True),
+    StructField("pass_count",       LongType(),   True),
+    StructField("fail_count",       LongType(),   True),
+    StructField("pass_rate",        DoubleType(), True),     # pass/(pass+fail); null if no yes/no verdicts
+    StructField("last_seen",        StringType(), True),
+    StructField("discovered_at",    TimestampType(), False),
 ])
 
 # COMMAND ----------
@@ -573,11 +592,78 @@ else:
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## Agent eval scores (F7 — MLflow-3 assessments → per-experiment rollup)
+# MAGIC
+# MAGIC Explodes the `assessments` array from `trace_logs_*` and keeps entries that
+# MAGIC carry a `feedback.value` (a judge/human verdict; pure `expectation` labels are
+# MAGIC excluded). Rolls up per (experiment, scorer, source_type) with pass/fail counts
+# MAGIC (yes/true/pass vs no/false/fail) and pass_rate. Fail-open per table. Same
+# MAGIC caveat as tool usage: EXPERIMENT grain (no experiment→agent mapping yet).
+
+# COMMAND ----------
+
+eval_scores_rows = []
+for cat, sch, tbl in trace_log_tables:
+    full = f"`{cat}`.`{sch}`.`{tbl}`"
+    label = f"{cat}.{sch}.{tbl}"
+    try:
+        # Cap to the same recent-N window as the other trace_logs loops so the
+        # explode stays bounded and counts line up with the Traces tab.
+        agg = spark.sql(f"""
+            WITH src AS (
+                SELECT trace_id, request_time, trace_location, assessments
+                FROM {full}
+                WHERE request_time >= TIMESTAMP '{RETENTION_CUTOFF_TS.strftime('%Y-%m-%d %H:%M:%S')}'
+                  AND assessments IS NOT NULL
+                ORDER BY request_time DESC
+                LIMIT {MAX_TRACES_PER_TABLE}
+            )
+            SELECT trace_location.mlflow_experiment.experiment_id            AS experiment_id,
+                   a.name                                                    AS scorer_name,
+                   a.source.source_type                                      AS source_type,
+                   COUNT(*)                                                  AS assessment_count,
+                   SUM(CASE WHEN lower(trim(BOTH '"' FROM a.feedback.value))
+                            IN ('yes','true','pass') THEN 1 ELSE 0 END)      AS pass_count,
+                   SUM(CASE WHEN lower(trim(BOTH '"' FROM a.feedback.value))
+                            IN ('no','false','fail') THEN 1 ELSE 0 END)      AS fail_count,
+                   CAST(MAX(a.create_time) AS STRING)                        AS last_seen
+            FROM src LATERAL VIEW explode(assessments) t AS a
+            WHERE a.feedback.value IS NOT NULL
+              AND a.name IS NOT NULL
+            GROUP BY 1, 2, 3
+        """).collect()
+        for r in agg:
+            pc = int(r["pass_count"] or 0)
+            fc = int(r["fail_count"] or 0)
+            # pass_rate only meaningful for yes/no verdicts; null when a scorer
+            # emits neither (e.g. numeric-only feedback) so the UI can hide it.
+            pass_rate = (pc / (pc + fc)) if (pc + fc) > 0 else None
+            eval_scores_rows.append((r["experiment_id"], r["scorer_name"], r["source_type"],
+                                     int(r["assessment_count"] or 0), pc, fc, pass_rate,
+                                     r["last_seen"], NOW))
+        print(f"  ✅ eval-scores {label}: {len(agg)} (scorer,source) rows")
+    except Exception as exc:
+        if _classify_perm_error(str(exc)):
+            per_table_stats.append({"table": label, "shape": "eval_scores", "skipped": "no UC grants"})
+        else:
+            per_table_stats.append({"table": label, "shape": "eval_scores", "error": str(exc)[:200]})
+
+if eval_scores_rows:
+    spark.createDataFrame(eval_scores_rows, EVAL_SCORES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(EVAL_SCORES_TABLE)
+    print(f"✅ Wrote {len(eval_scores_rows)} eval-score rows to {EVAL_SCORES_TABLE}")
+else:
+    spark.createDataFrame([], EVAL_SCORES_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(EVAL_SCORES_TABLE)
+    print(f"ℹ️  No eval-score rows — empty {EVAL_SCORES_TABLE}")
+
+# COMMAND ----------
+
 result = {
     "status": "success",
     "otel_tables_found": len(otel_tables),
     "trace_log_tables_found": len(trace_log_tables),
     "tool_usage_rows": len(tool_usage_rows),
+    "eval_scores_rows": len(eval_scores_rows),
     "traces": len(all_trace_rows),
     "details": len(all_detail_rows),
     "retention_days": RETENTION_DAYS,

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -90,6 +90,7 @@ EXPECTED = [
     "uag_guardrail_daily",           # only populated when endpoints have UAG v2 guardrails active
     "uag_usage_timeseries_daily",    # daily UAG v2 usage series; empty when no v2 traffic
     "agent_tool_usage",              # TOOL/RETRIEVER span rollup; empty when no traced agents
+    "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were


### PR DESCRIPTION
## What

Adds agent **quality** signal (not just gateway usage) to Observability: a new **Quality & Evals** tab that surfaces MLflow-3 online-eval / human assessments per agent.

## Why this source

Probed the alternatives first: `system.ai_gateway` has only `usage` (no traces/assessments), and there is **no account-level trace or assessment table** anywhere in `system.*`. MLflow-3 assessments ride on the UC `trace_logs_*` tables' `assessments` array — which is **metastore-wide** via UC (every workspace on the metastore), the same reach W2.1 already uses. So this is as cross-workspace as agent traces get on Databricks today.

## Pipeline

- **`07_discover_uc_otel_traces`** — new `agent_eval_scores` Delta table: explode the `assessments` array, keep entries with a `feedback` verdict (drops pure `expectation` labels), roll up per `(experiment, scorer, source_type)` with pass/fail counts + `pass_rate` (yes/true/pass vs no/false/fail; null for non-binary feedback). Fail-open per table, capped to the same recent-N window as the sibling loops.
- **`02_sync_to_lakebase`** — mirror `agent_eval_scores` (savepoint DDL + read-first truncate/insert, matching `agent_tool_usage`).
- **`10_smoke_check`** — added to EXPECTED.
- **Backend** — `get_agent_eval_scores()` (totals from an unbounded aggregate; shared `_experiment_names` helper) + `GET /mlflow/agent-eval-scores`.
- **Frontend** — "Quality & Evals" tab: KPIs (experiments, scorers, assessments, overall pass rate) + sortable/paginated per-scorer table with color-coded pass rates and LLM-judge/human badges.

## Validation

- Query validated live on fevm's `dbdemos_ai_agent`: 70/73 traces assessed (safety 67/70, relevance 46/70, groundedness 10/10), all LLM_JUDGE.
- Reviewed with Isaac Review; 4 fixes applied (unbounded totals, null-sort, shared helper, color/label), 1 refuted with evidence.

**Known limitation:** experiment grain (no experiment→agent mapping yet); re-scored/overridden assessments would both count (no `valid` flag in the schema).

This pull request and its description were written by Isaac.