### PR TITLE
chore(genie): rename user-facing "Genie Space" label to "Genie Agent" (W2.2)

### DIFF
--- a/control-plane-app/backend/services/discovery_service.py
+++ b/control-plane-app/backend/services/discovery_service.py
@@ -795,7 +795,7 @@ def _discover_genie_from_audit_logs() -> List[Dict[str, Any]]:
         if last_active:
             last_active_str = last_active.isoformat() if hasattr(last_active, "isoformat") else str(last_active)
 
-        name = display_name or f"Genie Space {space_id[:8]}…"
+        name = display_name or f"Genie Agent {space_id[:8]}…"
 
         config_dict: Dict[str, Any] = {
             "space_id": space_id,

--- a/control-plane-app/frontend/src/pages/Agents.tsx
+++ b/control-plane-app/frontend/src/pages/Agents.tsx
@@ -203,7 +203,7 @@ function OverviewTab() {
       custom_app: 'Custom Agent (App)',
       custom_llm: 'Custom LLM',
       external_agent: 'External Agent',
-      genie_space: 'Genie Space',
+      genie_space: 'Genie Agent',
       information_extraction: 'Information Extraction',
       knowledge_assistant: 'Knowledge Assistant',
       multi_agent_supervisor: 'Multi-Agent Supervisor',

--- a/control-plane-app/frontend/src/pages/OperationsRT.tsx
+++ b/control-plane-app/frontend/src/pages/OperationsRT.tsx
@@ -54,7 +54,7 @@ const typeLabels: Record<string, string> = {
   custom_agent: 'Custom Agent',
   custom_app: 'Databricks App',
   external_agent: 'External Model',
-  genie_space: 'Genie Space',
+  genie_space: 'Genie Agent',
 }
 
 /* ── state badge variant ──────────────────────────────────────── */


### PR DESCRIPTION
## What

Renames the user-facing **"Genie Space" → "Genie Agent"** label (Databricks' DAIS 2026 repositioning). The internal `genie_space` type key is unchanged — it's woven through the backend `deployment_type`, permissions, topology configs, and Lakebase, so renaming the key would be a large, risky change for no user benefit.

## Changed
- `Agents.tsx` / `OperationsRT.tsx` — agent-type label map `genie_space` → "Genie Agent".
- `discovery_service.py` — user-facing fallback name `"Genie Space <id>"` → `"Genie Agent <id>"`.

## Left as-is (intentional)
- The "Ask Genie" assistant copy in `AskGenieOverlay` — its "open in new tab" links to the Databricks workspace page, which Databricks' own UI still labels a *space*; renaming would mismatch the external page.
- Internal docstrings/comments describing the discovery source.

## Verified
Genie discovery unaffected on fevm — **8,199 `genie_space` agents** synced fresh via `w.genie.list_spaces()` + the audit-log cross-workspace path.

## Companion note (W2.3)
The sibling quick win "surface new hosted models in the picker" needs **no code** — the Playground/models views list serving endpoints dynamically, and fevm already shows `databricks-claude-sonnet-5`, `opus-4-8`, `gemini-3-5-flash`, `gpt-5-5`, etc. automatically.

This pull request and its description were written by Isaac.