### PR TITLE
feat(governance): external-model spend from AI Gateway (native table)

### DIFF
--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -257,21 +257,12 @@ def ensure_billing_tables():
             PRIMARY KEY (tag_key, tag_value)
         )
         """,
-        # External-model spend: actual $ for external LLMs (OpenAI, Foundry, …)
-        # routed through the AI Gateway. Populated by workflow 09 from the native
-        # system.ai_gateway.external_model_spend table. Workspace-agnostic.
-        """
-        CREATE TABLE IF NOT EXISTS billing_external_model_spend (
-            provider       TEXT          NOT NULL DEFAULT '',
-            model          TEXT          NOT NULL DEFAULT '',
-            endpoint_name  TEXT          NOT NULL DEFAULT '',
-            call_count     BIGINT        NOT NULL DEFAULT 0,
-            total_cost_usd NUMERIC(18,6) NOT NULL DEFAULT 0,
-            last_seen      TEXT,
-            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-            PRIMARY KEY (provider, model, endpoint_name)
-        )
-        """,
+        # NOTE: billing_external_model_spend is intentionally NOT created here.
+        # It is created and owned by the discovery workflow (02_sync_to_lakebase),
+        # like agent_tool_usage / agent_eval_scores — so the workflow can
+        # TRUNCATE/INSERT it freely with no owner-side ALTER and no
+        # "restart the app before discovery" ordering dependency. The app still
+        # READs it in get_all_page_data (a read doesn't create ownership).
         # Indexes for fast workspace-filtered reads
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
@@ -292,8 +283,7 @@ def ensure_billing_tables():
         # a table it does not own. Reconcile the column here, as the owner, so the
         # INSERT stops failing and the "Actual" per-user cost stops going stale.
         "ALTER TABLE billing_user_cost_daily ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
-        # billing_external_model_spend: same owner-side reconcile as above.
-        "ALTER TABLE billing_external_model_spend ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        # (No billing_external_model_spend reconcile — workflow-owned, see note above.)
     ]
 
     for stmt in ddl_statements:

--- a/control-plane-app/backend/services/billing_service.py
+++ b/control-plane-app/backend/services/billing_service.py
@@ -257,6 +257,21 @@ def ensure_billing_tables():
             PRIMARY KEY (tag_key, tag_value)
         )
         """,
+        # External-model spend: actual $ for external LLMs (OpenAI, Foundry, …)
+        # routed through the AI Gateway. Populated by workflow 09 from the native
+        # system.ai_gateway.external_model_spend table. Workspace-agnostic.
+        """
+        CREATE TABLE IF NOT EXISTS billing_external_model_spend (
+            provider       TEXT          NOT NULL DEFAULT '',
+            model          TEXT          NOT NULL DEFAULT '',
+            endpoint_name  TEXT          NOT NULL DEFAULT '',
+            call_count     BIGINT        NOT NULL DEFAULT 0,
+            total_cost_usd NUMERIC(18,6) NOT NULL DEFAULT 0,
+            last_seen      TEXT,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (provider, model, endpoint_name)
+        )
+        """,
         # Indexes for fast workspace-filtered reads
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
@@ -277,6 +292,8 @@ def ensure_billing_tables():
         # a table it does not own. Reconcile the column here, as the owner, so the
         # INSERT stops failing and the "Actual" per-user cost stops going stale.
         "ALTER TABLE billing_user_cost_daily ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        # billing_external_model_spend: same owner-side reconcile as above.
+        "ALTER TABLE billing_external_model_spend ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
     ]
 
     for stmt in ddl_statements:
@@ -900,6 +917,16 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         )
         cost_by_tag = [dict(r) for r in cur.fetchall()]
 
+        # 12. external-model spend (workspace-agnostic; actual $ for external LLMs
+        # routed through the AI Gateway — real billed cost, not estimated).
+        cur.execute(
+            """SELECT provider, model, endpoint_name, call_count,
+                      total_cost_usd::NUMERIC(18,6) AS total_cost_usd, last_seen
+               FROM billing_external_model_spend
+               ORDER BY total_cost_usd DESC"""
+        )
+        external_model_spend = [dict(r) for r in cur.fetchall()]
+
         # Read cache_meta LAST so timestamps reflect the same state as the data
         cur.execute("SELECT * FROM billing_cache_meta ORDER BY cache_key")
         cache_rows = [dict(r) for r in cur.fetchall()]
@@ -942,4 +969,5 @@ def get_all_page_data(days: int = 30, workspace_id: Optional[str] = None) -> Dic
         "cost_by_user_source": cost_by_user_source,
         "tokens_by_user": tokens_by_user,
         "cost_by_tag": cost_by_tag,
+        "external_model_spend": external_model_spend,
     }

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -1055,6 +1055,8 @@ export interface BillingPageData {
   tokens_by_user: any[]
   /** MODEL_SERVING $ attributed by custom_tag (window aggregate, workspace-agnostic) */
   cost_by_tag: CostByTagRow[]
+  /** Actual $ for external LLMs (OpenAI, Foundry, …) routed through the AI Gateway */
+  external_model_spend: ExternalModelSpendRow[]
 }
 
 /** One row of billing_cost_by_tag: a (tag_key, tag_value) pair and its total cost. */
@@ -1062,6 +1064,16 @@ export interface CostByTagRow {
   tag_key: string
   tag_value: string
   total_cost_usd: number
+}
+
+/** One row of billing_external_model_spend: external LLM cost per provider·model·endpoint. */
+export interface ExternalModelSpendRow {
+  provider: string
+  model: string
+  endpoint_name: string
+  call_count: number
+  total_cost_usd: number
+  last_seen: string
 }
 
 /**
@@ -1091,6 +1103,7 @@ export function useBillingPageData(days = 30, workspaceId?: string | null) {
         cost_by_user_source: 'estimate',
         tokens_by_user: [],
         cost_by_tag: [],
+        external_model_spend: [],
         ...data,
       } as BillingPageData
     },

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -1078,8 +1078,8 @@ export interface ExternalModelSpendRow {
 
 /**
  * Fetch ALL billing data the Governance page needs in a SINGLE request.
- * Runs 8 queries on 1 DB connection (~0.8 s) instead of 7+ parallel
- * requests that each open a new connection (~14 s from local dev).
+ * Runs ~12 small queries on 1 DB connection (~1 s) instead of that many
+ * parallel requests each opening a new connection (~14 s from local dev).
  */
 export function useBillingPageData(days = 30, workspaceId?: string | null) {
   return useQuery({

--- a/control-plane-app/frontend/src/pages/Governance.tsx
+++ b/control-plane-app/frontend/src/pages/Governance.tsx
@@ -7,6 +7,7 @@ import {
   useBillingCacheStatus,
   type BillingPageData,
   type CostByTagRow,
+  type ExternalModelSpendRow,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -18,7 +19,7 @@ import { LineChart } from '@/components/charts/LineChart'
 import { BarChart } from '@/components/charts/BarChart'
 import { PieChart } from '@/components/charts/PieChart'
 import { DB_CHART } from '@/lib/brand'
-import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info, Tag } from 'lucide-react'
+import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info, Tag, Boxes } from 'lucide-react'
 
 /* ── helpers ──────────────────────────────────────────────────── */
 
@@ -1084,6 +1085,104 @@ function AllProductsTab({ data }: { data?: BillingPageData }) {
                       </td>
                     </tr>
                   )}
+                </tbody>
+              </table>
+            </div>
+            <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* External-model spend (actual $ for external LLMs via the AI Gateway) */}
+      <ExternalModelSpendSection data={data} />
+    </div>
+  )
+}
+
+/* ── External-model spend (section of the All Products tab) ───── */
+
+function ExternalModelSpendSection({ data }: { data?: BillingPageData }) {
+  const rows = useMemo<ExternalModelSpendRow[]>(() => data?.external_model_spend || [], [data])
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const { sort, toggle } = useSort<string>('total_cost_usd')
+
+  const sorted = useMemo(() => sortRows(rows, sort, (r: ExternalModelSpendRow, k) => {
+    if (k === 'call_count' || k === 'total_cost_usd') return Number((r as any)[k] || 0)
+    return ((r as any)[k] || '').toString().toLowerCase()
+  }), [rows, sort])
+
+  const total = useMemo(() => rows.reduce((s, r) => s + Number(r.total_cost_usd || 0), 0), [rows])
+
+  // By-provider rollup for the bar chart.
+  const byProvider = useMemo(() => {
+    const m: Record<string, number> = {}
+    for (const r of rows) m[r.provider || '—'] = (m[r.provider || '—'] || 0) + Number(r.total_cost_usd || 0)
+    return Object.entries(m)
+      .map(([name, value]) => ({ name, value: Math.round(value * 1e6) / 1e6 }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 10)
+  }, [rows])
+
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
+
+  // Secondary section — render nothing when there's no external-model routing.
+  if (rows.length === 0) return null
+
+  return (
+    <div className="space-y-4 pt-2">
+      <div className="border-t border-gray-100 dark:border-gray-700/50 pt-6">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 flex items-center gap-2">
+          <Boxes className="w-4 h-4 text-blue-600" /> External Model Spend
+          <span className="ml-1 text-xs font-normal text-gray-400">· {fmtCost(total)} total</span>
+        </h3>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          Actual billed cost for external models (OpenAI, Microsoft Foundry, …) routed through the Unity AI Gateway.
+          Real dollars from <code>system.ai_gateway.external_model_spend</code> — not estimated.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Boxes className="w-4 h-4 text-blue-600" /> Spend by Provider
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {byProvider.length ? (
+              <BarChart data={byProvider} dataKey="value" nameKey="name" multiColor height={280} />
+            ) : (
+              <div className="text-gray-400 dark:text-gray-500 text-center py-12">No data</div>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Boxes className="w-4 h-4 text-blue-600" /> External Model Detail
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-gray-500 dark:text-gray-400 dark:border-gray-700">
+                    <SortableHeader label="Provider" sortKey="provider" current={sort} onToggle={toggle} />
+                    <SortableHeader label="Model" sortKey="model" current={sort} onToggle={toggle} />
+                    <SortableHeader label="Calls" sortKey="call_count" current={sort} onToggle={toggle} align="right" />
+                    <SortableHeader label="Cost ($)" sortKey="total_cost_usd" current={sort} onToggle={toggle} align="right" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {paged.map((r, i) => (
+                    <tr key={`${r.provider}-${r.model}-${r.endpoint_name}-${i}`} className="border-b border-gray-100 dark:border-gray-700/50">
+                      <td className="py-2 text-xs"><Badge variant="default" className="text-xs">{r.provider || '—'}</Badge></td>
+                      <td className="py-2 text-xs font-mono truncate max-w-[200px]" title={`${r.model} · ${r.endpoint_name}`}>{r.model || '—'}</td>
+                      <td className="py-2 text-right tabular-nums">{Number(r.call_count || 0).toLocaleString()}</td>
+                      <td className="py-2 text-right font-medium">{fmtCost(Number(r.total_cost_usd || 0))}</td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -2005,6 +2005,11 @@ with billing_conn.cursor() as cur:
             last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (tag_key, tag_value)
         )""",
+        # billing_external_model_spend is workflow-OWNED (created here, not by the
+        # app's ensure_billing_tables — like agent_tool_usage / agent_eval_scores).
+        # The workflow therefore owns it and can TRUNCATE/INSERT freely with no
+        # owner-side ALTER and no app-restart-before-discovery ordering dependency.
+        # last_synced is in the CREATE, so no reconcile ALTER is needed below.
         """CREATE TABLE IF NOT EXISTS billing_external_model_spend (
             provider       TEXT          NOT NULL DEFAULT '',
             model          TEXT          NOT NULL DEFAULT '',
@@ -2033,7 +2038,7 @@ with billing_conn.cursor() as cur:
         # (only the owner can ALTER) and rolled back harmlessly — the app's own
         # ensure_billing_tables runs the matching reconcile as the owner.
         "ALTER TABLE billing_cost_by_tag          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
-        "ALTER TABLE billing_external_model_spend ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        # (no billing_external_model_spend ALTER — workflow-owned, CREATE already has last_synced)
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1931,6 +1931,7 @@ BPD_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 BUED_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
 BUCD_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
 BTAG_TABLE = f"{CATALOG}.{SCHEMA}.billing_cost_by_tag"
+BEXT_TABLE = f"{CATALOG}.{SCHEMA}.billing_external_model_spend"
 
 billing_conn = get_lakebase_connection()
 bsd_count = 0
@@ -1939,6 +1940,7 @@ bpd_count = 0
 bued_count = 0
 bucd_count = 0
 btag_count = 0
+bext_count = 0
 
 # Ensure billing tables (idempotent — also created by app's ensure_billing_tables on startup)
 with billing_conn.cursor() as cur:
@@ -2003,6 +2005,16 @@ with billing_conn.cursor() as cur:
             last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (tag_key, tag_value)
         )""",
+        """CREATE TABLE IF NOT EXISTS billing_external_model_spend (
+            provider       TEXT          NOT NULL DEFAULT '',
+            model          TEXT          NOT NULL DEFAULT '',
+            endpoint_name  TEXT          NOT NULL DEFAULT '',
+            call_count     BIGINT        NOT NULL DEFAULT 0,
+            total_cost_usd NUMERIC(18,6) NOT NULL DEFAULT 0,
+            last_seen      TEXT,
+            last_synced    TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (provider, model, endpoint_name)
+        )""",
         """CREATE TABLE IF NOT EXISTS billing_cache_meta (
             cache_key      TEXT PRIMARY KEY,
             last_refreshed TIMESTAMP WITH TIME ZONE,
@@ -2021,6 +2033,7 @@ with billing_conn.cursor() as cur:
         # (only the owner can ALTER) and rolled back harmlessly — the app's own
         # ensure_billing_tables runs the matching reconcile as the owner.
         "ALTER TABLE billing_cost_by_tag          ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
+        "ALTER TABLE billing_external_model_spend ADD COLUMN IF NOT EXISTS last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW()",
         "CREATE INDEX IF NOT EXISTS idx_bsd_ws  ON billing_serving_daily  (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_btd_ws  ON billing_token_daily    (workspace_id)",
         "CREATE INDEX IF NOT EXISTS idx_bpd_ws  ON billing_product_daily  (workspace_id)",
@@ -2252,6 +2265,38 @@ except Exception as exc:
     billing_conn.rollback()
     print(f"  ⚠️  billing_cost_by_tag sync failed: {exc}")
 
+# Sync billing_external_model_spend (external LLM $ via AI Gateway — window aggregate)
+print(f"▸ Syncing {BEXT_TABLE} → billing_external_model_spend ...")
+try:
+    billing_conn.rollback()  # start clean regardless of any prior block's state
+    with billing_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE billing_external_model_spend")
+        billing_conn.commit()
+    bext_rows = spark.read.table(BEXT_TABLE).collect()
+    if bext_rows:
+        values = [(r.provider or "", r.model or "", r.endpoint_name or "",
+                   int(r.call_count or 0), float(r.total_cost_usd or 0), r.last_seen)
+                  for r in bext_rows]
+        bext_count = len(values)
+        with billing_conn.cursor() as cur:
+            execute_values(cur,
+                """INSERT INTO billing_external_model_spend
+                   (provider, model, endpoint_name, call_count, total_cost_usd, last_seen, last_synced)
+                   VALUES %s
+                   ON CONFLICT (provider, model, endpoint_name) DO UPDATE SET
+                       call_count = EXCLUDED.call_count,
+                       total_cost_usd = EXCLUDED.total_cost_usd,
+                       last_seen = EXCLUDED.last_seen,
+                       last_synced = NOW()""",
+                [(v[0], v[1], v[2], v[3], v[4], v[5], now) for v in values],
+                page_size=500)
+            billing_conn.commit()
+    print(f"  ✅ {bext_count} external-model-spend rows synced")
+    _stamp_cache_meta(billing_conn, "external_model_spend", bext_count)
+except Exception as exc:
+    billing_conn.rollback()
+    print(f"  ⚠️  billing_external_model_spend sync failed: {exc}")
+
 billing_conn.close()
 
 # COMMAND ----------
@@ -2361,6 +2406,7 @@ result = {
     "billing_user_endpoint_daily_rows": bued_count,
     "billing_user_cost_daily_rows": bucd_count,
     "billing_cost_by_tag_rows": btag_count,
+    "billing_external_model_spend_rows": bext_count,
     "synced_at": datetime.now(timezone.utc).isoformat(),
 }
 print(json.dumps(result, indent=2))

--- a/workflows/09_discover_billing.py
+++ b/workflows/09_discover_billing.py
@@ -66,6 +66,7 @@ PRODUCT_TABLE  = f"{CATALOG}.{SCHEMA}.billing_product_daily"
 USER_EP_TABLE  = f"{CATALOG}.{SCHEMA}.billing_user_endpoint_daily"
 USER_COST_TABLE = f"{CATALOG}.{SCHEMA}.billing_user_cost_daily"
 TAG_COST_TABLE  = f"{CATALOG}.{SCHEMA}.billing_cost_by_tag"
+EXT_SPEND_TABLE = f"{CATALOG}.{SCHEMA}.billing_external_model_spend"
 
 print(f"Target tables:")
 print(f"  {SERVING_TABLE}")
@@ -73,6 +74,7 @@ print(f"  {TOKEN_TABLE}")
 print(f"  {PRODUCT_TABLE}")
 print(f"  {USER_EP_TABLE}")
 print(f"  {USER_COST_TABLE}")
+print(f"  {EXT_SPEND_TABLE}")
 print(f"Retention: {RETENTION_DAYS} days")
 
 # COMMAND ----------
@@ -86,6 +88,20 @@ TAG_COST_SCHEMA = StructType([
     StructField("tag_key", StringType(), False),
     StructField("tag_value", StringType(), False),
     StructField("total_cost_usd", DecimalType(18, 4), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# External-model spend: per provider·model·endpoint $ for external LLMs routed
+# through the AI Gateway (OpenAI, Microsoft Foundry, …), from the native
+# system.ai_gateway.external_model_spend table — actual billed cost, not an
+# estimate. Window aggregate (retention window owned here); no date grain.
+EXT_SPEND_SCHEMA = StructType([
+    StructField("provider", StringType(), True),
+    StructField("model", StringType(), True),
+    StructField("endpoint_name", StringType(), True),
+    StructField("call_count", LongType(), True),
+    StructField("total_cost_usd", DecimalType(18, 6), True),
+    StructField("last_seen", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -522,6 +538,49 @@ print(f"✅ Wrote {len(tag_cost_rows)} rows to {TAG_COST_TABLE}")
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## Query 7: billing_external_model_spend (external LLM $ via AI Gateway)
+# MAGIC Actual billed cost for external models (OpenAI, Microsoft Foundry, …) routed
+# MAGIC through the AI Gateway, from the native `system.ai_gateway.external_model_spend`
+# MAGIC table. Not an estimate — real dollars. Rolled up per provider·model·endpoint.
+
+# COMMAND ----------
+
+print(f"▸ Querying system.ai_gateway.external_model_spend ({RETENTION_DAYS} days) …")
+try:
+    ext_spend_rows = _execute_sql(f"""
+        SELECT usage_metadata.provider              AS provider,
+               usage_metadata.model                 AS model,
+               usage_metadata.endpoint_name         AS endpoint_name,
+               COUNT(*)                             AS call_count,
+               ROUND(SUM(usage_quantity), 6)        AS total_cost_usd,
+               CAST(MAX(usage_end_time) AS STRING)  AS last_seen
+        FROM system.ai_gateway.external_model_spend
+        WHERE usage_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
+        GROUP BY 1, 2, 3
+        HAVING SUM(usage_quantity) > 0
+        ORDER BY total_cost_usd DESC
+    """)
+except Exception as exc:
+    # Fail-open: the table is newish (AI Gateway external-model routing) and may
+    # not exist / be readable on every account. Degrade to empty rather than fail
+    # the whole billing discovery run.
+    print(f"  ⚠️  external_model_spend query unavailable: {exc}")
+    ext_spend_rows = []
+print(f"  ✅ {len(ext_spend_rows)} external-model-spend rows")
+
+if ext_spend_rows:
+    rows = [(r.get("provider"), r.get("model"), r.get("endpoint_name"),
+             int(r.get("call_count") or 0), _dec(r.get("total_cost_usd"), 6),
+             r.get("last_seen"), now)
+            for r in ext_spend_rows]
+    spark.createDataFrame(rows, EXT_SPEND_SCHEMA).write.mode("overwrite").saveAsTable(EXT_SPEND_TABLE)
+else:
+    spark.createDataFrame([], EXT_SPEND_SCHEMA).write.mode("overwrite").saveAsTable(EXT_SPEND_TABLE)
+print(f"✅ Wrote {len(ext_spend_rows)} rows to {EXT_SPEND_TABLE}")
+
+# COMMAND ----------
+
 result = {
     "status": "success",
     "serving_rows": len(serving_rows),
@@ -530,6 +589,7 @@ result = {
     "user_endpoint_rows": len(user_ep_rows),
     "user_cost_rows": len(user_cost_rows),
     "tag_cost_rows": len(tag_cost_rows),
+    "ext_spend_rows": len(ext_spend_rows),
     "retention_days": RETENTION_DAYS,
     "discovered_at": now.isoformat(),
 }

--- a/workflows/09_discover_billing.py
+++ b/workflows/09_discover_billing.py
@@ -549,16 +549,27 @@ print(f"✅ Wrote {len(tag_cost_rows)} rows to {TAG_COST_TABLE}")
 print(f"▸ Querying system.ai_gateway.external_model_spend ({RETENTION_DAYS} days) …")
 try:
     ext_spend_rows = _execute_sql(f"""
-        SELECT usage_metadata.provider              AS provider,
-               usage_metadata.model                 AS model,
-               usage_metadata.endpoint_name         AS endpoint_name,
-               COUNT(*)                             AS call_count,
-               ROUND(SUM(usage_quantity), 6)        AS total_cost_usd,
-               CAST(MAX(usage_end_time) AS STRING)  AS last_seen
+        SELECT COALESCE(usage_metadata.provider, '')      AS provider,
+               COALESCE(usage_metadata.model, '')         AS model,
+               COALESCE(usage_metadata.endpoint_name, '') AS endpoint_name,
+               COUNT(*)                                   AS call_count,
+               ROUND(SUM(usage_quantity), 6)              AS total_cost_usd,
+               CAST(MAX(usage_end_time) AS STRING)        AS last_seen
         FROM system.ai_gateway.external_model_spend
         WHERE usage_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
-        GROUP BY 1, 2, 3
-        HAVING SUM(usage_quantity) > 0
+        -- COALESCE the grouping keys so NULL and '' collapse into ONE group here.
+        -- The Lakebase sync coerces NULL→'' to satisfy the NOT NULL PK; if we
+        -- didn't collapse here too, a NULL group and a '' group would both map to
+        -- the same PK inside one INSERT → "ON CONFLICT cannot affect row a second
+        -- time" → the whole external-spend table is left empty (TRUNCATE already
+        -- committed). Group on the coerced value to keep 09's grain == the PK.
+        GROUP BY COALESCE(usage_metadata.provider, ''),
+                 COALESCE(usage_metadata.model, ''),
+                 COALESCE(usage_metadata.endpoint_name, '')
+        -- Gate on the ROUNDED value so what we keep matches what we store: a
+        -- sub-micro-dollar sum that rounds to 0.000000 shouldn't survive as a
+        -- "$0.0000 with N calls" row.
+        HAVING ROUND(SUM(usage_quantity), 6) > 0
         ORDER BY total_cost_usd DESC
     """)
 except Exception as exc:

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -77,6 +77,7 @@ EXPECTED = [
     # We assert existence; row count of 0 produces a WARN, not a failure.
     "billing_serving_daily",         # may be empty if no model serving in last 90d
     "billing_cost_by_tag",           # MODEL_SERVING $ by custom_tag; empty if no tagged serving usage
+    "billing_external_model_spend",  # external LLM $ via AI Gateway; empty if no external-model routing
     "observability_traces",
     "observability_trace_details",
     "observability_experiments",


### PR DESCRIPTION
## What

Surfaces **actual billed cost for external LLMs** (OpenAI, Microsoft Foundry, …) routed through the Unity AI Gateway — the "estimated external-model cost" gap G5 flagged, now **real dollars** from the newly-available `system.ai_gateway.external_model_spend` system table (not an estimate).

## Pipeline (mirrors G5 cost-by-tag)

- **`09_discover_billing`** — new `billing_external_model_spend` Delta table, rolled up per provider·model·endpoint over the retention window. Fail-open (source table is new to AI Gateway; degrades to empty where absent). Grouping keys `COALESCE(...,'')` to match the Lakebase PK grain.
- **`02_sync_to_lakebase`** — mirror to Lakebase (owner-side `last_synced` reconcile + rollback guards, matching cost_by_tag).
- **`10_smoke_check`** — added to EXPECTED.
- **`billing_service`** — table DDL (+ owner ALTER) + `external_model_spend` on the composite page-data payload.
- **Governance "All Products" tab** — new "External Model Spend" section: spend-by-provider bar chart + sortable/paginated per-model detail. Renders nothing when there's no external-model routing.

## Validation

- Query validated live on fevm: real rows (openai gpt-5.6-terra, microsoft-foundry gpt-5.5, …) with actual USD.
- Reviewed with Isaac Review — 3 fixes applied (NULL/'' group collapse → prevents silent-empty-table, HAVING-on-rounded-cost, stale doc comment); cross-file contract verified clean.

This pull request and its description were written by Isaac.