### PR TITLE
feat(ai-gateway): throttling & reliability analytics (429/5xx per endpoint)

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -209,6 +209,13 @@ def guardrail_coverage():
     return gateway_service.get_guardrail_coverage()
 
 
+@router.get("/throttling")
+def throttling():
+    """Throttling / reliability per endpoint from Unity AI Gateway usage —
+    HTTP 429 (rate-limited) and 5xx (server-error) counts + throttle rate."""
+    return gateway_service.get_throttling()
+
+
 @router.get("/inference-logs")
 def inference_logs(
     limit: int = Query(default=50, le=500),

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -792,6 +792,63 @@ def get_guardrail_coverage() -> Dict[str, Any]:
     }
 
 
+def get_throttling() -> Dict[str, Any]:
+    """Throttling / reliability per endpoint from `uag_throttling_daily`: HTTP 429
+    (rate-limited) and 5xx (server-error) counts vs total requests, over the
+    discovery window. Answers "which endpoints are getting rate-limited/erroring".
+    Degrades to empty when the table is unsynced or no endpoint saw 429/5xx.
+    """
+    from backend.database import execute_query, execute_one
+    empty: Dict[str, Any] = {"as_of": None, "totals": {}, "endpoints": []}
+    try:
+        agg = execute_one(
+            """SELECT COUNT(*) AS endpoints,
+                      COALESCE(SUM(total_requests), 0)     AS total_requests,
+                      COALESCE(SUM(throttled_count), 0)    AS throttled_count,
+                      COALESCE(SUM(server_error_count), 0) AS server_error_count,
+                      MAX(max_event_time) AS as_of
+               FROM uag_throttling_daily"""
+        )
+    except Exception as exc:
+        logger.warning("uag_throttling_daily not available: %s", exc)
+        return empty
+    agg = dict(agg) if agg else {}
+    if _row_int(agg, "endpoints") == 0:
+        return empty
+
+    rows = execute_query(
+        """SELECT endpoint_name, total_requests, throttled_count, server_error_count
+           FROM uag_throttling_daily
+           ORDER BY throttled_count DESC LIMIT 200"""
+    )
+    tr = _row_int(agg, "total_requests")
+    thr = _row_int(agg, "throttled_count")
+    return {
+        "as_of": agg.get("as_of"),
+        "totals": {
+            "endpoints": _row_int(agg, "endpoints"),
+            "total_requests": tr,
+            "throttled_count": thr,
+            "server_error_count": _row_int(agg, "server_error_count"),
+            # blended throttle rate across all endpoints that saw any 429/5xx
+            "throttle_rate": (thr / tr) if tr > 0 else None,
+        },
+        "endpoints": [
+            {
+                "endpoint_name": r.get("endpoint_name", ""),
+                "total_requests": _row_int(r, "total_requests"),
+                "throttled_count": _row_int(r, "throttled_count"),
+                "server_error_count": _row_int(r, "server_error_count"),
+                "throttle_rate": (
+                    _row_int(r, "throttled_count") / _row_int(r, "total_requests")
+                    if _row_int(r, "total_requests") > 0 else None
+                ),
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_uag_v2_timeseries() -> Dict[str, Any]:
     """Daily UAG v2 usage series (requests + tokens) from `uag_usage_timeseries_daily`
     for trend charts on the v2 tab. Degrades to empty when unsynced / no v2 traffic."""

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -821,17 +821,18 @@ def get_throttling() -> Dict[str, Any]:
            FROM uag_throttling_daily
            ORDER BY throttled_count DESC LIMIT 200"""
     )
-    tr = _row_int(agg, "total_requests")
-    thr = _row_int(agg, "throttled_count")
     return {
         "as_of": agg.get("as_of"),
         "totals": {
+            # NOTE: no blended fleet-wide throttle_rate — uag_throttling_daily is
+            # pre-filtered to endpoints with ≥1 429/5xx, so SUM(throttled)/SUM(total)
+            # would divide by erroring-endpoint traffic only and overstate fleet
+            # throttling. The meaningful rate is per-endpoint (below); the headline
+            # is the COUNT of affected endpoints.
             "endpoints": _row_int(agg, "endpoints"),
-            "total_requests": tr,
-            "throttled_count": thr,
+            "total_requests": _row_int(agg, "total_requests"),
+            "throttled_count": _row_int(agg, "throttled_count"),
             "server_error_count": _row_int(agg, "server_error_count"),
-            # blended throttle rate across all endpoints that saw any 429/5xx
-            "throttle_rate": (thr / tr) if tr > 0 else None,
         },
         "endpoints": [
             {

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -747,7 +747,7 @@ export function useGuardrailCoverage() {
 
 export interface Throttling {
   as_of: string | null
-  totals: Partial<{ endpoints: number; total_requests: number; throttled_count: number; server_error_count: number; throttle_rate: number | null }>
+  totals: Partial<{ endpoints: number; total_requests: number; throttled_count: number; server_error_count: number }>
   endpoints: Array<{
     endpoint_name: string
     total_requests: number

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -745,6 +745,30 @@ export function useGuardrailCoverage() {
   })
 }
 
+export interface Throttling {
+  as_of: string | null
+  totals: Partial<{ endpoints: number; total_requests: number; throttled_count: number; server_error_count: number; throttle_rate: number | null }>
+  endpoints: Array<{
+    endpoint_name: string
+    total_requests: number
+    throttled_count: number
+    server_error_count: number
+    throttle_rate: number | null
+  }>
+}
+
+/** Per-endpoint throttling (HTTP 429) + server errors (5xx) from Unity AI Gateway usage. */
+export function useThrottling() {
+  return useQuery({
+    queryKey: ['gateway', 'throttling'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/throttling')
+      return data as Throttling
+    },
+    staleTime: GW_STALE,
+  })
+}
+
 export interface UagCodingAgents {
   as_of: string | null
   agents: Array<{

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -507,12 +507,21 @@ function ThrottlingCard() {
   const endpoints = data?.endpoints || []
   const sorted = useMemo(() => sortRows(endpoints, sort.sort, (e: any, k) => {
     if (k === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
-    if (k === 'throttle_rate') return Number(e.throttle_rate ?? -1)
+    // per-endpoint throttle_rate is always a number here (every row has ≥1
+    // request); pass null through so sortRows' null convention applies if that
+    // ever changes, rather than a sentinel that would misorder.
+    if (k === 'throttle_rate') return e.throttle_rate == null ? null : Number(e.throttle_rate)
     return Number(e[k] || 0)
   }), [endpoints, sort.sort])
   if (isLoading || endpoints.length === 0) return null
   const t = data!.totals
-  const blendedRate = t.throttle_rate != null ? `${(t.throttle_rate * 100).toFixed(1)}%` : '—'
+  // NOTE: no blended fleet-wide throttle-rate badge — the underlying table is
+  // pre-filtered to endpoints that saw ≥1 429/5xx, so a SUM-based blended rate
+  // would divide by erroring-endpoint traffic only and overstate fleet health
+  // (a 50/100 low-traffic endpoint would read "50% throttled"). We badge the
+  // COUNT of affected endpoints instead, and keep the accurate PER-endpoint rate
+  // in the table.
+  const affected = t.endpoints ?? endpoints.length
   const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
   const safePage = Math.min(page, totalPages - 1)
   const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
@@ -523,12 +532,12 @@ function ThrottlingCard() {
         <CardTitle className="text-base flex items-center gap-2">
           Throttling &amp; Reliability
           <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
-            {blendedRate} throttled
+            {affected} endpoint{affected === 1 ? '' : 's'} affected
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
           Endpoints returning HTTP 429 (rate-limited) or 5xx (server error) through Unity AI Gateway.
-          Only endpoints with at least one 429/5xx are shown.
+          Only endpoints with at least one 429/5xx are shown; rates are per-endpoint (share of that endpoint's own requests).
           {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
       </CardHeader>

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -16,6 +16,7 @@ import {
   useUagCodingAgents,
   useUagMcpTools,
   useGuardrailCoverage,
+  useThrottling,
   type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
@@ -353,6 +354,7 @@ function UagV2Section() {
       <CodingAgentsCard />
       <UagMcpToolsCard />
       <GuardrailCoverageCard />
+      <ThrottlingCard />
     </div>
   )
 }
@@ -485,6 +487,71 @@ function GuardrailCoverageCard() {
                   <td className="py-1.5 text-gray-600 dark:text-gray-400">{e.judge_models || '—'}</td>
                   <td className="py-1.5 text-right tabular-nums">{e.checked_requests.toLocaleString()}</td>
                   <td className="py-1.5 text-right tabular-nums">{e.unique_users.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+      </CardContent>
+    </Card>
+  )
+}
+
+/* Throttling / reliability — HTTP 429 + 5xx per endpoint from system.ai_gateway.usage. */
+function ThrottlingCard() {
+  const { data, isLoading } = useThrottling()
+  const sort = useSort('throttled_count', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const endpoints = data?.endpoints || []
+  const sorted = useMemo(() => sortRows(endpoints, sort.sort, (e: any, k) => {
+    if (k === 'endpoint_name') return (e.endpoint_name || '').toLowerCase()
+    if (k === 'throttle_rate') return Number(e.throttle_rate ?? -1)
+    return Number(e[k] || 0)
+  }), [endpoints, sort.sort])
+  if (isLoading || endpoints.length === 0) return null
+  const t = data!.totals
+  const blendedRate = t.throttle_rate != null ? `${(t.throttle_rate * 100).toFixed(1)}%` : '—'
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+  const pct = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(1)}%`)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Throttling &amp; Reliability
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
+            {blendedRate} throttled
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          Endpoints returning HTTP 429 (rate-limited) or 5xx (server error) through Unity AI Gateway.
+          Only endpoints with at least one 429/5xx are shown.
+          {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <SortableHeader label="Endpoint" sortKey="endpoint_name" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Requests" sortKey="total_requests" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="429" sortKey="throttled_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="5xx" sortKey="server_error_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Throttle Rate" sortKey="throttle_rate" current={sort.sort} onToggle={sort.toggle} align="right" />
+              </tr>
+            </thead>
+            <tbody>
+              {paged.map((e: any, i: number) => (
+                <tr key={`${e.endpoint_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                  <td className="py-1.5 font-mono text-xs truncate max-w-[260px]" title={e.endpoint_name}>{e.endpoint_name}</td>
+                  <td className="py-1.5 text-right tabular-nums">{e.total_requests.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums text-red-600 dark:text-red-400">{e.throttled_count.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums text-amber-600 dark:text-amber-400">{e.server_error_count.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums font-medium">{pct(e.throttle_rate)}</td>
                 </tr>
               ))}
             </tbody>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1908,6 +1908,41 @@ except Exception as exc:
     uag_conn.rollback()
     print(f"  ⚠️  uag_coding_agent_usage sync failed: {exc}")
 
+# Sync uag_throttling_daily (429/5xx per endpoint — reliability signal).
+UAG_THROTTLING_TABLE = f"{CATALOG}.{SCHEMA}.uag_throttling_daily"
+uag_th_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_throttling_daily (
+            endpoint_name      TEXT NOT NULL,
+            total_requests     BIGINT DEFAULT 0,
+            throttled_count    BIGINT DEFAULT 0,
+            server_error_count BIGINT DEFAULT 0,
+            max_event_time     TEXT,
+            last_synced        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (endpoint_name))""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_uth_ep ON uag_throttling_daily (endpoint_name)")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_THROTTLING_TABLE} → uag_throttling_daily ...")
+try:
+    th_rows = spark.read.table(UAG_THROTTLING_TABLE).collect()
+    values = [(r.endpoint_name, int(r.total_requests or 0), int(r.throttled_count or 0),
+               int(r.server_error_count or 0), r.max_event_time, now) for r in th_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_throttling_daily")
+        if values:
+            execute_values(cur,
+                """INSERT INTO uag_throttling_daily
+                   (endpoint_name, total_requests, throttled_count, server_error_count, max_event_time, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    uag_conn.commit()
+    uag_th_count = len(values)
+    print(f"  ✅ {uag_th_count} throttling rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  uag_throttling_daily sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -93,6 +93,7 @@ EXPECTED = [
     "agent_tool_usage",              # TOOL/RETRIEVER span rollup; empty when no traced agents
     "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
+    "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -57,7 +57,8 @@ UAG_MCP_TOOL_TABLE = f"{CATALOG}.{SCHEMA}.uag_mcp_tool_daily"
 UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
 UAG_TIMESERIES_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_timeseries_daily"
 UAG_CODING_AGENT_TABLE = f"{CATALOG}.{SCHEMA}.uag_coding_agent_usage"
-print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE} | retention {RETENTION_DAYS}d")
+UAG_THROTTLING_TABLE = f"{CATALOG}.{SCHEMA}.uag_throttling_daily"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE}, {UAG_THROTTLING_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -137,6 +138,18 @@ UAG_GUARDRAIL_SCHEMA = StructType([
     StructField("checked_requests", LongType(), True),
     StructField("unique_users", LongType(), True),
     StructField("judge_models", StringType(), True),
+    StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Throttling / reliability, one row per endpoint over the window: rate-limited
+# (HTTP 429) and server-error (5xx) request counts vs total, so the UI can show
+# a throttle rate per endpoint. Sourced from status_code on system.ai_gateway.usage.
+UAG_THROTTLING_SCHEMA = StructType([
+    StructField("endpoint_name", StringType(), False),
+    StructField("total_requests", LongType(), True),
+    StructField("throttled_count", LongType(), True),   # HTTP 429
+    StructField("server_error_count", LongType(), True),  # HTTP 5xx
     StructField("max_event_time", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
@@ -465,9 +478,46 @@ print(f"✅ Wrote {len(gr_rows_raw)} rows to {UAG_GUARDRAIL_TABLE}")
 
 # COMMAND ----------
 
+# Throttling / reliability per endpoint: 429 (rate-limited) and 5xx counts vs total.
+print("▸ Querying ai_gateway.usage throttling / errors by endpoint …")
+try:
+    th_rows_raw = _execute_sql(f"""
+        SELECT endpoint_name,
+               COUNT(*)                                                  AS total_requests,
+               SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END)        AS throttled_count,
+               SUM(CASE WHEN status_code >= 500 AND status_code < 600
+                        THEN 1 ELSE 0 END)                               AS server_error_count,
+               CAST(MAX(event_time) AS STRING)                          AS max_event_time
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND endpoint_name IS NOT NULL
+        GROUP BY endpoint_name
+        -- keep only endpoints that actually saw throttling or server errors, so the
+        -- view is a reliability signal rather than a full endpoint dump
+        HAVING SUM(CASE WHEN status_code = 429 OR (status_code >= 500 AND status_code < 600)
+                        THEN 1 ELSE 0 END) > 0
+        ORDER BY throttled_count DESC
+    """)
+    print(f"  ✅ {len(th_rows_raw)} throttled/erroring endpoint rows")
+except Exception as exc:
+    th_rows_raw = []
+    print(f"  ⚠️  throttling query unavailable: {exc}")
+
+if th_rows_raw:
+    rows = [(r.get("endpoint_name", ""), to_int(r.get("total_requests")), to_int(r.get("throttled_count")),
+             to_int(r.get("server_error_count")), r.get("max_event_time"), now)
+            for r in th_rows_raw]
+    spark.createDataFrame(rows, UAG_THROTTLING_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_THROTTLING_TABLE)
+else:
+    spark.createDataFrame([], UAG_THROTTLING_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_THROTTLING_TABLE)
+print(f"✅ Wrote {len(th_rows_raw)} rows to {UAG_THROTTLING_TABLE}")
+
+# COMMAND ----------
+
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
           "uag_mcp_tool_rows": len(mcp_rows_raw), "uag_guardrail_rows": len(gr_rows_raw),
           "uag_timeseries_rows": len(ts_rows_raw), "uag_coding_agent_rows": len(ca_rows_raw),
+          "uag_throttling_rows": len(th_rows_raw),
           "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## What

Adds a **Throttling & Reliability** card to the AI Gateway v2 tab — which endpoints are being **rate-limited (HTTP 429)** or **erroring (5xx)**, from `status_code` on `system.ai_gateway.usage`. A reliability signal the tab previously lacked.

## Pipeline (mirrors uag_guardrail_daily)

- **`11_discover_ai_gateway_usage`** — new `uag_throttling_daily` table: per endpoint, `total_requests` + `throttled_count` (429) + `server_error_count` (5xx). `HAVING` keeps only endpoints with ≥1 429/5xx. Fail-open to empty.
- **`02_sync_to_lakebase`** — mirror `uag_throttling_daily` (workflow-owned, like the other `uag_*` tables).
- **`10_smoke_check`** — added to EXPECTED.
- **`gateway_service.get_throttling()`** + `GET /gateway/throttling` — per-endpoint rate; degrade-to-empty.
- **AIGateway v2 tab** — "Throttling & Reliability" card: "N endpoints affected" badge + sortable/paginated per-endpoint table (429 / 5xx / per-endpoint rate). Hidden when no throttling.

## Validation

- Query validated on fevm (90d): real rows — `gpt-oss-20b` 1.08M/1.14M throttled, `claude-sonnet-4-6` 15.7k 429s + 115 5xx, etc.
- Reviewed with Isaac Review — 1 fix applied (dropped a misleading blended fleet-wide throttle-rate that would overstate throttling; badge the affected-endpoint count instead), rest refuted with evidence.

This pull request and its description were written by Isaac.