### PR TITLE
feat(ai-gateway): fallback-routing reliability (smart-routing failover)

### DIFF
--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -216,6 +216,13 @@ def throttling():
     return gateway_service.get_throttling()
 
 
+@router.get("/fallback-routing")
+def fallback_routing():
+    """Smart-routing fallback per endpoint from Unity AI Gateway usage — how often
+    routing fell back to a backup model, recovery rate, and backup destinations."""
+    return gateway_service.get_fallback_routing()
+
+
 @router.get("/inference-logs")
 def inference_logs(
     limit: int = Query(default=50, le=500),

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -850,6 +850,61 @@ def get_throttling() -> Dict[str, Any]:
     }
 
 
+def get_fallback_routing() -> Dict[str, Any]:
+    """Smart-routing fallback per endpoint from `uag_fallback_routing_daily`: how
+    often the AI Gateway had to fall back to a backup model (>1 routing attempt),
+    how many recovered (final attempt < 400), and which backup destinations were
+    used. Reliability signal for AI Gateway smart-routing. Degrades to empty when
+    the table is unsynced or no endpoint fell back.
+    """
+    from backend.database import execute_query, execute_one
+    empty: Dict[str, Any] = {"as_of": None, "totals": {}, "endpoints": []}
+    try:
+        agg = execute_one(
+            """SELECT COUNT(*) AS endpoints,
+                      COALESCE(SUM(fallback_requests), 0)  AS fallback_requests,
+                      COALESCE(SUM(fallback_recovered), 0) AS fallback_recovered,
+                      MAX(max_event_time) AS as_of
+               FROM uag_fallback_routing_daily"""
+        )
+    except Exception as exc:
+        logger.warning("uag_fallback_routing_daily not available: %s", exc)
+        return empty
+    agg = dict(agg) if agg else {}
+    if _row_int(agg, "endpoints") == 0:
+        return empty
+
+    rows = execute_query(
+        """SELECT endpoint_name, total_requests, fallback_requests,
+                  fallback_recovered, fallback_destinations
+           FROM uag_fallback_routing_daily
+           ORDER BY fallback_requests DESC LIMIT 200"""
+    )
+    return {
+        "as_of": agg.get("as_of"),
+        "totals": {
+            "endpoints": _row_int(agg, "endpoints"),
+            "fallback_requests": _row_int(agg, "fallback_requests"),
+            "fallback_recovered": _row_int(agg, "fallback_recovered"),
+        },
+        "endpoints": [
+            {
+                "endpoint_name": r.get("endpoint_name", ""),
+                "total_requests": _row_int(r, "total_requests"),
+                "fallback_requests": _row_int(r, "fallback_requests"),
+                "fallback_recovered": _row_int(r, "fallback_recovered"),
+                "fallback_destinations": r.get("fallback_destinations") or "",
+                # share of THIS endpoint's fallbacks that recovered (null if none)
+                "recovery_rate": (
+                    _row_int(r, "fallback_recovered") / _row_int(r, "fallback_requests")
+                    if _row_int(r, "fallback_requests") > 0 else None
+                ),
+            }
+            for r in rows
+        ],
+    }
+
+
 def get_uag_v2_timeseries() -> Dict[str, Any]:
     """Daily UAG v2 usage series (requests + tokens) from `uag_usage_timeseries_daily`
     for trend charts on the v2 tab. Degrades to empty when unsynced / no v2 traffic."""

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -769,6 +769,31 @@ export function useThrottling() {
   })
 }
 
+export interface FallbackRouting {
+  as_of: string | null
+  totals: Partial<{ endpoints: number; fallback_requests: number; fallback_recovered: number }>
+  endpoints: Array<{
+    endpoint_name: string
+    total_requests: number
+    fallback_requests: number
+    fallback_recovered: number
+    fallback_destinations: string
+    recovery_rate: number | null
+  }>
+}
+
+/** Per-endpoint smart-routing fallback (backup-model routing) from Unity AI Gateway usage. */
+export function useFallbackRouting() {
+  return useQuery({
+    queryKey: ['gateway', 'fallback-routing'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/fallback-routing')
+      return data as FallbackRouting
+    },
+    staleTime: GW_STALE,
+  })
+}
+
 export interface UagCodingAgents {
   as_of: string | null
   agents: Array<{

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -17,6 +17,7 @@ import {
   useUagMcpTools,
   useGuardrailCoverage,
   useThrottling,
+  useFallbackRouting,
   type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
@@ -355,6 +356,7 @@ function UagV2Section() {
       <UagMcpToolsCard />
       <GuardrailCoverageCard />
       <ThrottlingCard />
+      <FallbackRoutingCard />
     </div>
   )
 }
@@ -561,6 +563,70 @@ function ThrottlingCard() {
                   <td className="py-1.5 text-right tabular-nums text-red-600 dark:text-red-400">{e.throttled_count.toLocaleString()}</td>
                   <td className="py-1.5 text-right tabular-nums text-amber-600 dark:text-amber-400">{e.server_error_count.toLocaleString()}</td>
                   <td className="py-1.5 text-right tabular-nums font-medium">{pct(e.throttle_rate)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+      </CardContent>
+    </Card>
+  )
+}
+
+/* Fallback routing — smart-routing backup-model fallbacks from routing_information.attempts[]. */
+function FallbackRoutingCard() {
+  const { data, isLoading } = useFallbackRouting()
+  const sort = useSort('fallback_requests', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const endpoints = data?.endpoints || []
+  const sorted = useMemo(() => sortRows(endpoints, sort.sort, (e: any, k) => {
+    if (k === 'endpoint_name' || k === 'fallback_destinations') return (e[k] || '').toLowerCase()
+    if (k === 'recovery_rate') return e.recovery_rate == null ? null : Number(e.recovery_rate)
+    return Number(e[k] || 0)
+  }), [endpoints, sort.sort])
+  if (isLoading || endpoints.length === 0) return null
+  const affected = data!.totals.endpoints ?? endpoints.length
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+  const pct = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(1)}%`)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          Fallback Routing
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+            {affected} endpoint{affected === 1 ? '' : 's'} fell back
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">
+          Requests where AI Gateway smart-routing failed over to a backup model (a primary attempt failed, then a FALLBACK attempt ran).
+          Recovery = share of an endpoint's fallbacks whose final attempt succeeded. Only endpoints that fell back are shown.
+          {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <SortableHeader label="Endpoint" sortKey="endpoint_name" current={sort.sort} onToggle={sort.toggle} />
+                <SortableHeader label="Fallbacks" sortKey="fallback_requests" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Recovered" sortKey="fallback_recovered" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Recovery Rate" sortKey="recovery_rate" current={sort.sort} onToggle={sort.toggle} align="right" />
+                <SortableHeader label="Backup Model(s)" sortKey="fallback_destinations" current={sort.sort} onToggle={sort.toggle} />
+              </tr>
+            </thead>
+            <tbody>
+              {paged.map((e: any, i: number) => (
+                <tr key={`${e.endpoint_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                  <td className="py-1.5 font-mono text-xs truncate max-w-[220px]" title={e.endpoint_name}>{e.endpoint_name}</td>
+                  <td className="py-1.5 text-right tabular-nums">{e.fallback_requests.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums text-green-600 dark:text-green-400">{e.fallback_recovered.toLocaleString()}</td>
+                  <td className="py-1.5 text-right tabular-nums font-medium">{pct(e.recovery_rate)}</td>
+                  <td className="py-1.5 text-gray-600 dark:text-gray-400 text-xs truncate max-w-[240px]" title={e.fallback_destinations}>{e.fallback_destinations || '—'}</td>
                 </tr>
               ))}
             </tbody>

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -1943,6 +1943,43 @@ except Exception as exc:
     uag_conn.rollback()
     print(f"  ⚠️  uag_throttling_daily sync failed: {exc}")
 
+# Sync uag_fallback_routing_daily (smart-routing fallback per endpoint).
+UAG_FALLBACK_TABLE = f"{CATALOG}.{SCHEMA}.uag_fallback_routing_daily"
+uag_fb_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_fallback_routing_daily (
+            endpoint_name         TEXT NOT NULL,
+            total_requests        BIGINT DEFAULT 0,
+            fallback_requests     BIGINT DEFAULT 0,
+            fallback_recovered    BIGINT DEFAULT 0,
+            fallback_destinations TEXT,
+            max_event_time        TEXT,
+            last_synced           TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (endpoint_name))""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_ufb_ep ON uag_fallback_routing_daily (endpoint_name)")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_FALLBACK_TABLE} → uag_fallback_routing_daily ...")
+try:
+    fb_rows = spark.read.table(UAG_FALLBACK_TABLE).collect()
+    values = [(r.endpoint_name, int(r.total_requests or 0), int(r.fallback_requests or 0),
+               int(r.fallback_recovered or 0), r.fallback_destinations, r.max_event_time, now) for r in fb_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_fallback_routing_daily")
+        if values:
+            execute_values(cur,
+                """INSERT INTO uag_fallback_routing_daily
+                   (endpoint_name, total_requests, fallback_requests, fallback_recovered,
+                    fallback_destinations, max_event_time, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    uag_conn.commit()
+    uag_fb_count = len(values)
+    print(f"  ✅ {uag_fb_count} fallback-routing rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  uag_fallback_routing_daily sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -94,6 +94,7 @@ EXPECTED = [
     "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
+    "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP

--- a/workflows/11_discover_ai_gateway_usage.py
+++ b/workflows/11_discover_ai_gateway_usage.py
@@ -58,7 +58,8 @@ UAG_GUARDRAIL_TABLE = f"{CATALOG}.{SCHEMA}.uag_guardrail_daily"
 UAG_TIMESERIES_TABLE = f"{CATALOG}.{SCHEMA}.uag_usage_timeseries_daily"
 UAG_CODING_AGENT_TABLE = f"{CATALOG}.{SCHEMA}.uag_coding_agent_usage"
 UAG_THROTTLING_TABLE = f"{CATALOG}.{SCHEMA}.uag_throttling_daily"
-print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE}, {UAG_THROTTLING_TABLE} | retention {RETENTION_DAYS}d")
+UAG_FALLBACK_TABLE = f"{CATALOG}.{SCHEMA}.uag_fallback_routing_daily"
+print(f"Target tables: {UAG_TABLE}, {UAG_BREAKDOWN_TABLE}, {UAG_MCP_TOOL_TABLE}, {UAG_GUARDRAIL_TABLE}, {UAG_TIMESERIES_TABLE}, {UAG_THROTTLING_TABLE}, {UAG_FALLBACK_TABLE} | retention {RETENTION_DAYS}d")
 
 # COMMAND ----------
 
@@ -150,6 +151,21 @@ UAG_THROTTLING_SCHEMA = StructType([
     StructField("total_requests", LongType(), True),
     StructField("throttled_count", LongType(), True),   # HTTP 429
     StructField("server_error_count", LongType(), True),  # HTTP 5xx
+    StructField("max_event_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Fallback routing, one row per endpoint: how often smart-routing had to fall
+# back to a backup model (routing_information.attempts has >1 entry, i.e. the
+# primary attempt failed and a FALLBACK attempt followed), how many of those
+# ultimately recovered (final attempt < 400), and which backup destinations were
+# used. Reliability signal for AI Gateway smart-routing.
+UAG_FALLBACK_SCHEMA = StructType([
+    StructField("endpoint_name", StringType(), False),
+    StructField("total_requests", LongType(), True),
+    StructField("fallback_requests", LongType(), True),
+    StructField("fallback_recovered", LongType(), True),
+    StructField("fallback_destinations", StringType(), True),
     StructField("max_event_time", StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
@@ -514,10 +530,53 @@ print(f"✅ Wrote {len(th_rows_raw)} rows to {UAG_THROTTLING_TABLE}")
 
 # COMMAND ----------
 
+# Fallback routing per endpoint: how often smart-routing fell back to a backup
+# model (routing_information.attempts has >1 entry), how many recovered (final
+# attempt < 400), and which backup destinations were used.
+print("▸ Querying ai_gateway.usage fallback routing by endpoint …")
+try:
+    fb_rows_raw = _execute_sql(f"""
+        SELECT endpoint_name,
+               COUNT(*)                                                       AS total_requests,
+               SUM(CASE WHEN size(routing_information.attempts) > 1
+                        THEN 1 ELSE 0 END)                                     AS fallback_requests,
+               SUM(CASE WHEN size(routing_information.attempts) > 1
+                         AND element_at(routing_information.attempts, -1).status_code < 400
+                        THEN 1 ELSE 0 END)                                     AS fallback_recovered,
+               concat_ws(', ', array_sort(array_distinct(flatten(collect_list(
+                   CASE WHEN size(routing_information.attempts) > 1
+                        THEN array(element_at(routing_information.attempts, -1).destination)
+                        END))))) AS fallback_destinations,
+               CAST(MAX(event_time) AS STRING)                                AS max_event_time
+        FROM system.ai_gateway.usage
+        WHERE event_time >= current_timestamp() - INTERVAL {RETENTION_DAYS} DAYS
+          AND routing_information IS NOT NULL
+          AND endpoint_name IS NOT NULL
+        GROUP BY endpoint_name
+        -- only endpoints that actually fell back (reliability signal, not a dump)
+        HAVING SUM(CASE WHEN size(routing_information.attempts) > 1 THEN 1 ELSE 0 END) > 0
+        ORDER BY fallback_requests DESC
+    """)
+    print(f"  ✅ {len(fb_rows_raw)} fallback-routing endpoint rows")
+except Exception as exc:
+    fb_rows_raw = []
+    print(f"  ⚠️  fallback routing query unavailable: {exc}")
+
+if fb_rows_raw:
+    rows = [(r.get("endpoint_name", ""), to_int(r.get("total_requests")), to_int(r.get("fallback_requests")),
+             to_int(r.get("fallback_recovered")), r.get("fallback_destinations"), r.get("max_event_time"), now)
+            for r in fb_rows_raw]
+    spark.createDataFrame(rows, UAG_FALLBACK_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_FALLBACK_TABLE)
+else:
+    spark.createDataFrame([], UAG_FALLBACK_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(UAG_FALLBACK_TABLE)
+print(f"✅ Wrote {len(fb_rows_raw)} rows to {UAG_FALLBACK_TABLE}")
+
+# COMMAND ----------
+
 result = {"status": "success", "uag_endpoint_rows": len(rows_raw), "uag_breakdown_rows": len(bd_rows),
           "uag_mcp_tool_rows": len(mcp_rows_raw), "uag_guardrail_rows": len(gr_rows_raw),
           "uag_timeseries_rows": len(ts_rows_raw), "uag_coding_agent_rows": len(ca_rows_raw),
-          "uag_throttling_rows": len(th_rows_raw),
+          "uag_throttling_rows": len(th_rows_raw), "uag_fallback_rows": len(fb_rows_raw),
           "retention_days": RETENTION_DAYS, "discovered_at": now.isoformat()}
 print(json.dumps(result, indent=2))
 dbutils.notebook.exit(json.dumps(result))


### PR DESCRIPTION
## What

Adds a **Fallback Routing** card to the AI Gateway v2 tab — how often smart-routing failed over to a backup model, per endpoint, from `routing_information.attempts[]` on `system.ai_gateway.usage`. Complements the throttling card: a 429 on the primary destination is what typically triggers the FALLBACK to the next-priority model.

## Pipeline (mirrors uag_throttling_daily)

- **`11_discover_ai_gateway_usage`** — new `uag_fallback_routing_daily`: per endpoint, `total_requests` + `fallback_requests` (attempts > 1) + `fallback_recovered` (final attempt < 400) + `fallback_destinations` (distinct backup models). `HAVING` keeps only endpoints that fell back. Fail-open.
- **`02_sync_to_lakebase`** — mirror (workflow-owned).
- **`10_smoke_check`** — added to EXPECTED.
- **`gateway_service.get_fallback_routing()`** + `GET /gateway/fallback-routing` — per-endpoint recovery rate; degrade-to-empty.
- **AIGateway v2 tab** — "Fallback Routing" card: "N endpoints fell back" badge + sortable/paginated table (fallbacks / recovered / recovery rate / backup models). Per-endpoint recovery rate (no misleading blended fleet %, per the throttling-card lesson).

## Validation

- Query validated on fevm (90d): solution-builder 8244 fallbacks (4078 recovered), demo-parser 161 (100% recovered), etc. Confirmed shape: 429 on primary → FALLBACK to next-priority model → 200.
- Invariant checked live: `recovered ≤ fallbacks` (0 violations → recovery rate ≤ 100%); `fallback_destinations` clean (≤114 chars, no nulls/dups).
- Reviewed with Isaac Review — no findings (division guards, hooks ordering, workflow ownership, contract all verified).

This pull request and its description were written by Isaac.