### PR TITLE
feat(observability): AI audit trail from system.access.audit (#8)

### DIFF
--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -43,6 +43,13 @@ async def agent_eval_scores():
     return mlflow_service.get_agent_eval_scores()
 
 
+@router.get("/ai-audit")
+async def ai_audit():
+    """Governed AI audit trail from system.access.audit (AI services only) —
+    per-(service, action) activity summary + a recent-event feed."""
+    return mlflow_service.get_ai_audit()
+
+
 @router.get("/experiments")
 async def list_experiments(
     request: Request,

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -373,6 +373,62 @@ def get_agent_eval_scores() -> Dict[str, Any]:
     return {"totals": totals, "rows": out}
 
 
+def get_ai_audit() -> Dict[str, Any]:
+    """Governed AI audit trail from `ai_audit_summary` + `ai_audit_recent`
+    (produced by 07_discover_uc_otel_traces from system.access.audit, restricted
+    to AI service_names). Returns a per-(service, action) summary + a recent-event
+    feed. Account-wide (audit is account-level). Degrades to empty when the tables
+    are unsynced or audit wasn't readable at the discovery principal's scope.
+    """
+    empty: Dict[str, Any] = {"totals": {}, "summary": [], "recent": []}
+    try:
+        summary = execute_query(
+            """SELECT service_name, action_name, event_count, actor_count,
+                      error_count, workspace_count, last_seen
+               FROM ai_audit_summary ORDER BY event_count DESC LIMIT 500"""
+        )
+    except Exception as exc:
+        logger.warning("ai_audit_summary not available: %s", exc)
+        return empty
+    if not summary:
+        return empty
+
+    try:
+        recent = execute_query(
+            """SELECT event_time, service_name, action_name, actor, status_code,
+                      workspace_id, source_ip
+               FROM ai_audit_recent ORDER BY event_time DESC LIMIT 500"""
+        )
+    except Exception:
+        recent = []
+
+    def _i(r, k):
+        return int(r.get(k) or 0)
+
+    summary_out = [
+        {
+            "service_name": r.get("service_name", ""),
+            "action_name": r.get("action_name", ""),
+            "event_count": _i(r, "event_count"),
+            "actor_count": _i(r, "actor_count"),
+            "error_count": _i(r, "error_count"),
+            "workspace_count": _i(r, "workspace_count"),
+            "last_seen": r.get("last_seen") or "",
+        }
+        for r in summary
+    ]
+    return {
+        "totals": {
+            "services": len({r["service_name"] for r in summary_out if r["service_name"]}),
+            "actions": len(summary_out),
+            "events": sum(r["event_count"] for r in summary_out),
+            "errors": sum(r["error_count"] for r in summary_out),
+        },
+        "summary": summary_out,
+        "recent": [dict(r) for r in recent],
+    }
+
+
 def search_experiments_system_tables(max_results: int = 5000) -> List[Dict[str, Any]]:
     """Query system.mlflow.experiments_latest for cross-workspace experiments.
 

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -394,10 +394,12 @@ def get_ai_audit() -> Dict[str, Any]:
         return empty
 
     try:
+        # LIMIT matches the frontend render cap (200) — no over-fetch. source_ip
+        # is intentionally not selected (account-wide PII with no UI consumer).
         recent = execute_query(
             """SELECT event_time, service_name, action_name, actor, status_code,
-                      workspace_id, source_ip
-               FROM ai_audit_recent ORDER BY event_time DESC LIMIT 500"""
+                      workspace_id
+               FROM ai_audit_recent ORDER BY event_time DESC LIMIT 200"""
         )
     except Exception:
         recent = []
@@ -417,13 +419,31 @@ def get_ai_audit() -> Dict[str, Any]:
         }
         for r in summary
     ]
+
+    # Totals from an UNBOUNDED aggregate (not summed over the LIMIT-500 window
+    # above), so KPI cards stay accurate past 500 (service, action) combos —
+    # matching the get_agent_eval_scores pattern.
+    totals: Dict[str, Any] = {"services": 0, "actions": 0, "events": 0, "errors": 0}
+    try:
+        agg = execute_query(
+            """SELECT COUNT(DISTINCT service_name)   AS services,
+                      COUNT(*)                        AS actions,
+                      COALESCE(SUM(event_count), 0)   AS events,
+                      COALESCE(SUM(error_count), 0)   AS errors
+               FROM ai_audit_summary"""
+        )
+        a = agg[0] if agg else {}
+        totals = {
+            "services": int(a.get("services") or 0),
+            "actions": int(a.get("actions") or 0),
+            "events": int(a.get("events") or 0),
+            "errors": int(a.get("errors") or 0),
+        }
+    except Exception:
+        pass
+
     return {
-        "totals": {
-            "services": len({r["service_name"] for r in summary_out if r["service_name"]}),
-            "actions": len(summary_out),
-            "events": sum(r["event_count"] for r in summary_out),
-            "errors": sum(r["error_count"] for r in summary_out),
-        },
+        "totals": totals,
         "summary": summary_out,
         "recent": [dict(r) for r in recent],
     }

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -308,6 +308,39 @@ export function useAgentEvalScores() {
   })
 }
 
+export interface AiAudit {
+  totals: Partial<{ services: number; actions: number; events: number; errors: number }>
+  summary: Array<{
+    service_name: string
+    action_name: string
+    event_count: number
+    actor_count: number
+    error_count: number
+    workspace_count: number
+    last_seen: string
+  }>
+  recent: Array<{
+    event_time: string
+    service_name: string
+    action_name: string
+    actor: string | null
+    status_code: number | null
+    workspace_id: string | null
+    source_ip: string | null
+  }>
+}
+
+/** Governed AI audit trail from system.access.audit (AI services only). */
+export function useAiAudit() {
+  return useQuery({
+    queryKey: ['mlflow', 'ai-audit'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/mlflow/ai-audit')
+      return data as AiAudit
+    },
+  })
+}
+
 export function useMlflowTraceDetail(requestId: string | null, workspaceId?: string | null) {
   return useQuery({
     queryKey: ['mlflow', 'trace-detail', requestId, workspaceId],

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -326,7 +326,6 @@ export interface AiAudit {
     actor: string | null
     status_code: number | null
     workspace_id: string | null
-    source_ip: string | null
   }>
 }
 

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -543,7 +543,7 @@ function AiAuditPanel() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Recent AI Audit Events</CardTitle>
-            <p className="text-[11px] text-gray-400 dark:text-gray-500">Most recent {recent.length.toLocaleString()} governed AI events (who did what, from where).</p>
+            <p className="text-[11px] text-gray-400 dark:text-gray-500">Most recent {Math.min(recent.length, 200).toLocaleString()} governed AI events (who did what).</p>
           </CardHeader>
           <CardContent>
             <div className="overflow-x-auto max-h-[420px] overflow-y-auto">

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -16,6 +16,7 @@ import {
   useGatewayLogTimeseries,
   useAgentToolUsage,
   useAgentEvalScores,
+  useAiAudit,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
 import { RefreshButton } from '@/components/RefreshButton'
@@ -66,6 +67,7 @@ import {
   Info,
   Wrench,
   ShieldCheck,
+  ScrollText,
 } from 'lucide-react'
 import { DB_RED_SHADES } from '@/lib/brand'
 
@@ -167,6 +169,7 @@ const tabs = [
   { id: 'runs', label: 'Evaluation Runs', icon: Activity },
   { id: 'tool-usage', label: 'Tool & Asset Usage', icon: Wrench },
   { id: 'eval-scores', label: 'Quality & Evals', icon: ShieldCheck },
+  { id: 'ai-audit', label: 'AI Audit', icon: ScrollText },
   { id: 'models', label: 'Model Registry', icon: Database },
 ] as const
 
@@ -268,6 +271,7 @@ export default function ObservabilityPage() {
       {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'tool-usage' && <ToolUsagePanel />}
       {activeTab === 'eval-scores' && <EvalScoresPanel />}
+      {activeTab === 'ai-audit' && <AiAuditPanel />}
       {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
     </div>
   )
@@ -455,6 +459,120 @@ function EvalScoresPanel() {
           <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/* ── AI Audit Panel (#8) ─────────────────────────────────────────
+   Governed AI activity from system.access.audit (AI services only): a
+   per-(service, action) summary rollup + a recent-event feed. Account-wide. */
+function AiAuditPanel() {
+  const { data, isLoading } = useAiAudit()
+  const sort = useSort('event_count', 'desc')
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(15)
+  const summary = data?.summary || []
+  const recent = data?.recent || []
+  const sorted = useMemo(() => sortRows(summary, sort.sort, (r: any, k) => {
+    if (k === 'service_name' || k === 'action_name') return (r[k] || '').toString().toLowerCase()
+    return Number(r[k] || 0)
+  }), [summary, sort.sort])
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
+  const safePage = Math.min(page, totalPages - 1)
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
+
+  if (isLoading) return <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
+  if (summary.length === 0) {
+    return (
+      <Card><CardContent className="py-12 text-center text-gray-400 dark:text-gray-500">
+        No AI audit activity found — either no AI-service audit events in the retention window, or
+        the discovery principal can't read <code>system.access.audit</code> (needs account-level audit access).
+      </CardContent></Card>
+    )
+  }
+  const t = data!.totals
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <KpiCard title="AI Services" value={t.services ?? 0} format="number" />
+        <KpiCard title="Distinct Actions" value={t.actions ?? 0} format="number" />
+        <KpiCard title="Audited Events" value={t.events ?? 0} format="number" />
+        <KpiCard title="Errors" value={t.errors ?? 0} format="number" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">AI Activity by Service &amp; Action</CardTitle>
+          <p className="text-[11px] text-gray-400 dark:text-gray-500">
+            Governed audit events from <code>system.access.audit</code> for AI services (agents, agent framework,
+            supervisor agents, MLflow, Genie, MCP, model registry, vector search). Account-wide.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                  <SortableHeader label="Service" sortKey="service_name" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Action" sortKey="action_name" current={sort.sort} onToggle={sort.toggle} />
+                  <SortableHeader label="Events" sortKey="event_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Actors" sortKey="actor_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Errors" sortKey="error_count" current={sort.sort} onToggle={sort.toggle} align="right" />
+                  <SortableHeader label="Last Seen" sortKey="last_seen" current={sort.sort} onToggle={sort.toggle} align="right" />
+                </tr>
+              </thead>
+              <tbody>
+                {paged.map((r: any, i: number) => (
+                  <tr key={`${r.service_name}-${r.action_name}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                    <td className="py-1.5"><Badge variant="default" className="text-xs">{r.service_name}</Badge></td>
+                    <td className="py-1.5 font-mono text-xs truncate max-w-[220px]" title={r.action_name}>{r.action_name || '—'}</td>
+                    <td className="py-1.5 text-right tabular-nums">{r.event_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right tabular-nums">{r.actor_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right tabular-nums text-red-600 dark:text-red-400">{r.error_count.toLocaleString()}</td>
+                    <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+        </CardContent>
+      </Card>
+
+      {recent.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Recent AI Audit Events</CardTitle>
+            <p className="text-[11px] text-gray-400 dark:text-gray-500">Most recent {recent.length.toLocaleString()} governed AI events (who did what, from where).</p>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto max-h-[420px] overflow-y-auto">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-white dark:bg-gray-900">
+                  <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                    <th className="py-1.5 font-medium">Time</th>
+                    <th className="py-1.5 font-medium">Service</th>
+                    <th className="py-1.5 font-medium">Action</th>
+                    <th className="py-1.5 font-medium">Actor</th>
+                    <th className="py-1.5 font-medium text-right">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recent.slice(0, 200).map((e, i) => (
+                    <tr key={`${e.event_time}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
+                      <td className="py-1.5 text-xs text-gray-500 dark:text-gray-400 tabular-nums whitespace-nowrap">{e.event_time ? e.event_time.slice(0, 19).replace('T', ' ') : '—'}</td>
+                      <td className="py-1.5 text-xs">{e.service_name}</td>
+                      <td className="py-1.5 font-mono text-xs truncate max-w-[200px]" title={e.action_name}>{e.action_name || '—'}</td>
+                      <td className="py-1.5 text-xs truncate max-w-[200px]" title={e.actor || ''}>{e.actor || '—'}</td>
+                      <td className={`py-1.5 text-right tabular-nums text-xs ${e.status_code != null && e.status_code >= 400 ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}>{e.status_code ?? '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -699,7 +699,7 @@ with obs_conn.cursor() as cur:
         "CREATE INDEX IF NOT EXISTS idx_aas_svc ON ai_audit_summary (service_name)",
         """CREATE TABLE IF NOT EXISTS ai_audit_recent (
             event_time TEXT, service_name TEXT, action_name TEXT, actor TEXT,
-            status_code BIGINT, workspace_id TEXT, source_ip TEXT,
+            status_code BIGINT, workspace_id TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
     ]:
         # Each statement in its own savepoint — protects against the case
@@ -1252,14 +1252,14 @@ try:
     aar_rows = spark.read.table(AI_AUDIT_RECENT_DELTA).collect()
     values = [(r.event_time, r.service_name, r.action_name, r.actor,
                int(r.status_code) if r.status_code is not None else None,
-               r.workspace_id, r.source_ip, now) for r in aar_rows]
+               r.workspace_id, now) for r in aar_rows]
     with obs_conn.cursor() as cur:
         cur.execute("TRUNCATE TABLE ai_audit_recent")
         if values:
             execute_values(cur,
                 """INSERT INTO ai_audit_recent
                    (event_time, service_name, action_name, actor, status_code,
-                    workspace_id, source_ip, last_synced)
+                    workspace_id, last_synced)
                    VALUES %s""",
                 values, page_size=500)
     obs_conn.commit()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -689,6 +689,18 @@ with obs_conn.cursor() as cur:
             last_seen TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
         "CREATE INDEX IF NOT EXISTS idx_aes_exp ON agent_eval_scores (experiment_id)",
+        """CREATE TABLE IF NOT EXISTS ai_audit_summary (
+            service_name TEXT NOT NULL, action_name TEXT NOT NULL,
+            event_count BIGINT DEFAULT 0, actor_count BIGINT DEFAULT 0,
+            error_count BIGINT DEFAULT 0, workspace_count BIGINT DEFAULT 0,
+            last_seen TEXT,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (service_name, action_name))""",
+        "CREATE INDEX IF NOT EXISTS idx_aas_svc ON ai_audit_summary (service_name)",
+        """CREATE TABLE IF NOT EXISTS ai_audit_recent (
+            event_time TEXT, service_name TEXT, action_name TEXT, actor TEXT,
+            status_code BIGINT, workspace_id TEXT, source_ip TEXT,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
     ]:
         # Each statement in its own savepoint — protects against the case
         # where the workflow runs as a non-owner of pre-existing tables (the
@@ -1207,6 +1219,55 @@ try:
 except Exception as exc:
     obs_conn.rollback()
     print(f"  ⚠️  agent_eval_scores sync failed: {exc}")
+
+# Sync ai_audit_summary (#8 — per service·action rollup from system.access.audit).
+AI_AUDIT_SUMMARY_DELTA = f"{CATALOG}.{SCHEMA}.ai_audit_summary"
+aas_count = 0
+print(f"▸ Syncing {AI_AUDIT_SUMMARY_DELTA} → ai_audit_summary ...")
+try:
+    aas_rows = spark.read.table(AI_AUDIT_SUMMARY_DELTA).collect()
+    values = [(r.service_name, r.action_name, int(r.event_count or 0), int(r.actor_count or 0),
+               int(r.error_count or 0), int(r.workspace_count or 0), r.last_seen, now) for r in aas_rows]
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE ai_audit_summary")
+        if values:
+            execute_values(cur,
+                """INSERT INTO ai_audit_summary
+                   (service_name, action_name, event_count, actor_count, error_count,
+                    workspace_count, last_seen, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    obs_conn.commit()
+    aas_count = len(values)
+    print(f"  ✅ {aas_count} AI audit-summary rows synced")
+except Exception as exc:
+    obs_conn.rollback()
+    print(f"  ⚠️  ai_audit_summary sync failed: {exc}")
+
+# Sync ai_audit_recent (#8 — capped recent-event feed).
+AI_AUDIT_RECENT_DELTA = f"{CATALOG}.{SCHEMA}.ai_audit_recent"
+aar_count = 0
+print(f"▸ Syncing {AI_AUDIT_RECENT_DELTA} → ai_audit_recent ...")
+try:
+    aar_rows = spark.read.table(AI_AUDIT_RECENT_DELTA).collect()
+    values = [(r.event_time, r.service_name, r.action_name, r.actor,
+               int(r.status_code) if r.status_code is not None else None,
+               r.workspace_id, r.source_ip, now) for r in aar_rows]
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE ai_audit_recent")
+        if values:
+            execute_values(cur,
+                """INSERT INTO ai_audit_recent
+                   (event_time, service_name, action_name, actor, status_code,
+                    workspace_id, source_ip, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    obs_conn.commit()
+    aar_count = len(values)
+    print(f"  ✅ {aar_count} AI audit-recent rows synced")
+except Exception as exc:
+    obs_conn.rollback()
+    print(f"  ⚠️  ai_audit_recent sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -183,7 +183,6 @@ AI_AUDIT_RECENT_SCHEMA = StructType([
     StructField("actor",         StringType(), True),
     StructField("status_code",   LongType(),   True),
     StructField("workspace_id",  StringType(), True),
-    StructField("source_ip",     StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -696,6 +695,11 @@ else:
 # MAGIC Two tables from the account-level audit log, restricted to AI service_names:
 # MAGIC a per-(service, action) SUMMARY rollup and a capped RECENT-events feed.
 # MAGIC Fail-open: audit may not be readable at the discovery principal's scope.
+# MAGIC
+# MAGIC NOTE: this is a NON-TRACE source (system.access.audit is account-level audit,
+# MAGIC not UC OTEL traces). It lives in this workflow as pragmatic co-location with
+# MAGIC the other agent-observability rollups (agent_tool_usage, agent_eval_scores)
+# MAGIC since the app has no dedicated audit workflow.
 
 # COMMAND ----------
 
@@ -726,23 +730,25 @@ try:
     ]
     print(f"  ✅ audit summary: {len(audit_summary_rows)} (service,action) rows")
 
-    # RECENT: capped feed of the most recent AI audit events for a live activity view.
+    # RECENT: capped feed of the most recent AI audit events for a live activity
+    # view. LIMIT matches the backend read cap (no over-fetch). source_ip is
+    # deliberately NOT selected — it's account-wide PII with no UI consumer.
     _recent = spark.sql(f"""
         SELECT CAST(event_time AS STRING) AS event_time, service_name,
                COALESCE(action_name, '')  AS action_name,
                user_identity.email        AS actor,
                response.status_code       AS status_code,
-               workspace_id, source_ip_address AS source_ip
+               workspace_id
         FROM system.access.audit
         WHERE event_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
           AND service_name IN ({_audit_svc_list})
         ORDER BY event_time DESC
-        LIMIT 2000
+        LIMIT 500
     """).collect()
     audit_recent_rows = [
         (r["event_time"], r["service_name"], r["action_name"], r["actor"],
          int(r["status_code"]) if r["status_code"] is not None else None,
-         r["workspace_id"], r["source_ip"], NOW)
+         r["workspace_id"], NOW)
         for r in _recent
     ]
     print(f"  ✅ audit recent: {len(audit_recent_rows)} events")

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -80,11 +80,14 @@ TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces_uc_otel"
 DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details_uc_otel"
 TOOL_USAGE_TABLE = f"{CATALOG}.{SCHEMA}.agent_tool_usage"
 EVAL_SCORES_TABLE = f"{CATALOG}.{SCHEMA}.agent_eval_scores"
+AI_AUDIT_SUMMARY_TABLE = f"{CATALOG}.{SCHEMA}.ai_audit_summary"
+AI_AUDIT_RECENT_TABLE = f"{CATALOG}.{SCHEMA}.ai_audit_recent"
 
 print(f"Trace summary target: {TRACES_TABLE}")
 print(f"Trace detail target:  {DETAILS_TABLE}")
 print(f"Tool usage target:    {TOOL_USAGE_TABLE}")
 print(f"Eval scores target:   {EVAL_SCORES_TABLE}")
+print(f"AI audit targets:     {AI_AUDIT_SUMMARY_TABLE}, {AI_AUDIT_RECENT_TABLE}")
 print(f"Retention: {RETENTION_DAYS} days")
 
 # COMMAND ----------
@@ -153,6 +156,35 @@ EVAL_SCORES_SCHEMA = StructType([
     StructField("pass_rate",        DoubleType(), True),     # pass/(pass+fail); null if no yes/no verdicts
     StructField("last_seen",        StringType(), True),
     StructField("discovered_at",    TimestampType(), False),
+])
+
+# AI audit trail (#8) — governed AI activity from system.access.audit, restricted
+# to AI-related service_names. Two tables: a per-(service, action) SUMMARY rollup
+# and a capped RECENT-events feed. Metastore/account-wide (audit is account-level).
+AI_AUDIT_SERVICES = [
+    "agents", "agentFramework", "agentEvaluation", "supervisorAgent", "supervisor_agent",
+    "mlflowExperiment", "mlflowTrace", "mlflowAcledArtifact", "modelRegistry",
+    "genie", "genieChat", "aibiGenie", "mcpService", "vectorSearch",
+]
+AI_AUDIT_SUMMARY_SCHEMA = StructType([
+    StructField("service_name",  StringType(), False),
+    StructField("action_name",   StringType(), False),
+    StructField("event_count",   LongType(),   True),
+    StructField("actor_count",   LongType(),   True),
+    StructField("error_count",   LongType(),   True),   # response.status_code >= 400
+    StructField("workspace_count", LongType(), True),
+    StructField("last_seen",     StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+AI_AUDIT_RECENT_SCHEMA = StructType([
+    StructField("event_time",    StringType(), True),
+    StructField("service_name",  StringType(), True),
+    StructField("action_name",   StringType(), True),
+    StructField("actor",         StringType(), True),
+    StructField("status_code",   LongType(),   True),
+    StructField("workspace_id",  StringType(), True),
+    StructField("source_ip",     StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
 ])
 
 # COMMAND ----------
@@ -658,12 +690,84 @@ else:
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC ## AI audit trail (#8 — governed AI activity from system.access.audit)
+# MAGIC
+# MAGIC Two tables from the account-level audit log, restricted to AI service_names:
+# MAGIC a per-(service, action) SUMMARY rollup and a capped RECENT-events feed.
+# MAGIC Fail-open: audit may not be readable at the discovery principal's scope.
+
+# COMMAND ----------
+
+_audit_svc_list = ", ".join(f"'{s}'" for s in AI_AUDIT_SERVICES)
+audit_summary_rows = []
+audit_recent_rows = []
+try:
+    # SUMMARY: per (service, action) over the window. audit is date-partitioned on
+    # event_date, so filter on it (not event_time) for partition pruning.
+    _sum = spark.sql(f"""
+        SELECT service_name,
+               COALESCE(action_name, '')                                 AS action_name,
+               COUNT(*)                                                   AS event_count,
+               COUNT(DISTINCT user_identity.email)                        AS actor_count,
+               SUM(CASE WHEN response.status_code >= 400 THEN 1 ELSE 0 END) AS error_count,
+               COUNT(DISTINCT workspace_id)                               AS workspace_count,
+               CAST(MAX(event_time) AS STRING)                            AS last_seen
+        FROM system.access.audit
+        WHERE event_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
+          AND service_name IN ({_audit_svc_list})
+        GROUP BY service_name, COALESCE(action_name, '')
+        ORDER BY event_count DESC
+    """).collect()
+    audit_summary_rows = [
+        (r["service_name"], r["action_name"], int(r["event_count"] or 0), int(r["actor_count"] or 0),
+         int(r["error_count"] or 0), int(r["workspace_count"] or 0), r["last_seen"], NOW)
+        for r in _sum
+    ]
+    print(f"  ✅ audit summary: {len(audit_summary_rows)} (service,action) rows")
+
+    # RECENT: capped feed of the most recent AI audit events for a live activity view.
+    _recent = spark.sql(f"""
+        SELECT CAST(event_time AS STRING) AS event_time, service_name,
+               COALESCE(action_name, '')  AS action_name,
+               user_identity.email        AS actor,
+               response.status_code       AS status_code,
+               workspace_id, source_ip_address AS source_ip
+        FROM system.access.audit
+        WHERE event_date >= current_date() - INTERVAL {RETENTION_DAYS} DAYS
+          AND service_name IN ({_audit_svc_list})
+        ORDER BY event_time DESC
+        LIMIT 2000
+    """).collect()
+    audit_recent_rows = [
+        (r["event_time"], r["service_name"], r["action_name"], r["actor"],
+         int(r["status_code"]) if r["status_code"] is not None else None,
+         r["workspace_id"], r["source_ip"], NOW)
+        for r in _recent
+    ]
+    print(f"  ✅ audit recent: {len(audit_recent_rows)} events")
+except Exception as exc:
+    if _classify_perm_error(str(exc)):
+        per_table_stats.append({"table": "system.access.audit", "shape": "ai_audit", "skipped": "no audit grants"})
+        print("  ℹ️  system.access.audit not readable at this scope — skipping AI audit trail")
+    else:
+        per_table_stats.append({"table": "system.access.audit", "shape": "ai_audit", "error": str(exc)[:200]})
+        print(f"  ⚠️  AI audit query failed: {exc}")
+
+spark.createDataFrame(audit_summary_rows, AI_AUDIT_SUMMARY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(AI_AUDIT_SUMMARY_TABLE)
+spark.createDataFrame(audit_recent_rows, AI_AUDIT_RECENT_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(AI_AUDIT_RECENT_TABLE)
+print(f"✅ Wrote {len(audit_summary_rows)} summary + {len(audit_recent_rows)} recent rows to AI audit tables")
+
+# COMMAND ----------
+
 result = {
     "status": "success",
     "otel_tables_found": len(otel_tables),
     "trace_log_tables_found": len(trace_log_tables),
     "tool_usage_rows": len(tool_usage_rows),
     "eval_scores_rows": len(eval_scores_rows),
+    "ai_audit_summary_rows": len(audit_summary_rows),
+    "ai_audit_recent_rows": len(audit_recent_rows),
     "traces": len(all_trace_rows),
     "details": len(all_detail_rows),
     "retention_days": RETENTION_DAYS,

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -92,6 +92,8 @@ EXPECTED = [
     "uag_usage_timeseries_daily",    # daily UAG v2 usage series; empty when no v2 traffic
     "agent_tool_usage",              # TOOL/RETRIEVER span rollup; empty when no traced agents
     "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
+    "ai_audit_summary",              # AI activity rollup from system.access.audit; empty if audit unreadable
+    "ai_audit_recent",               # recent AI audit events; empty if audit unreadable
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks


### PR DESCRIPTION
## What

Adds an **AI Audit** tab to Observability — a governed activity trail for AI services, from `system.access.audit` (account-level). Realizes the Unity AI Gateway "audit logging" capability the app previously didn't surface.

## Pipeline

- **`07_discover_uc_otel_traces`** — two new tables (restricted to AI `service_name`s: agents, agentFramework, supervisorAgent, agentEvaluation, mlflow*, genie*, mcpService, modelRegistry, vectorSearch):
  - `ai_audit_summary` — per (service, action): event / actor / error / workspace counts.
  - `ai_audit_recent` — capped recent-event feed (time / service / action / actor / status / workspace).
  Filters on `event_date` (partition prune). Fail-open (empty tables written if the discovery principal can't read audit).
- **`02_sync_to_lakebase`** — mirror both (workflow-owned).
- **`10_smoke_check`** — both added to EXPECTED.
- **`mlflow_service.get_ai_audit()`** + `GET /mlflow/ai-audit` — summary + recent + unbounded totals; degrade-to-empty.
- **Observability "AI Audit" tab** — KPIs (services / actions / events / errors) + activity-by-service·action table + recent-events feed.

## Validation

- Queries validated on fevm (90d): millions of AI audit events — aibiGenie genieGetSpace 5.8M, vectorSearch queryVectorIndex 5.6M, mlflowTrace readTraceData 3.2M, actor/error counts resolving.
- Reviewed with Isaac Review — fixes applied: dropped `source_ip` (new PII, no UI consumer), totals from unbounded aggregate, aligned the 500→200 LIMIT chain, caption fix. Auth / injection / fail-open / contract verified clean.

**Note:** this workflow is named for UC traces but now also carries this non-trace audit source (pragmatic co-location with the other agent-observability rollups; the app has no dedicated audit workflow).

This pull request and its description were written by Isaac.