### PR TITLE
Release 0.1.3 — Unity Gateway budgets/inventory/model-services + Observability caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-26
+
+This release grows the **Unity Gateway** (v3) story and moves the app's read
+layer onto cached Lakebase tables where it was still doing live per-load calls.
+Two threads drove it: give native platform primitives (budgets, endpoints, UC
+model services) fleet-wide read-only visibility the per-object UIs don't, and
+stop the remaining Observability drill-downs from querying live on every click.
+
+### Added
+- **Budget status + consumption** (F5). Fleet-wide inventory of native account
+  budgets — cap thresholds, whether each *enforces* (BLOCK_USAGE) vs only *alerts*,
+  its filter, and AI-relevance — plus month-to-date spend vs cap (%-used), sortable
+  and paginated. Read-only: enforcement stays platform-side. New discovery task
+  `workflows/13_discover_budgets.py` → `uag_budget_status`; backend
+  `get_uag_budget_status()` and `GET /gateway/uag-budget-status`, degrading to empty
+  without account credentials.
+- **Account-wide endpoint inventory.** Read-only served-entity fleet view across
+  every workspace in the metastore from `system.serving.served_entities` — the view
+  the per-workspace serving API can't give. New `workflows/14_discover_endpoint_inventory.py`
+  → `serving_endpoints_inventory`, surfaced on the Unity Gateway tab.
+- **v3 Unity Gateway UC model services** (read-only). Metastore-wide list via the UC
+  REST API (workflow run-as a metastore admin — the list endpoint the app's OBO/SP
+  identities can't reach) plus live per-service grant reads. New
+  `workflows/15_discover_model_services.py` → `model_services_inventory`.
+- **Model Registry version cache.** Every version per registered model is cached to
+  Lakebase (`mlflow_model_versions`, from `04_discover_observability`) so the model
+  drill-down reads cache-first instead of a live REST search on each expand;
+  `GET /mlflow/models/{name}/versions` falls back to live only on a cold cache.
+- **MLflow trace-detail write-through.** SP-fetched trace details are persisted to
+  `observability_trace_details` on a cache miss, so repeat opens read from Lakebase.
+
+### Changed
+- **AI Gateway page reorganized and rebranded "Unity Gateway"**; Beta and version
+  labels removed (GA). v1 per-endpoint views consolidated into a **"Legacy AI
+  Gateway"** tab; Budgets moved next to Unity Gateway; Requests/Tokens-per-day charts
+  moved directly under the KPI cards.
+- **Tools → MCP Usage** is now sortable and paginated.
+- **Budget list is uncapped.** `GET /gateway/uag-budget-status` returns the full
+  budget list (totals already aggregate the whole table; the frontend paginates),
+  replacing the prior 500-row cap.
+
+### Removed
+- Pruned dead tabs: Observability **Gateway Requests** and **Quality & Evals**, and
+  Governance **Guardrails** (plus their now-unused panels and imports).
+
+### Fixed
+- `10_smoke_check_lakebase` `authenticate()` bug that crashed every run.
+- Budget month-to-date total now includes NULL-workspace (account-level) usage
+  instead of under-counting it.
+- Model-versions discovery orders by `last_updated_timestamp DESC` so the per-model
+  cap keeps the newest versions (with a retry-without-order_by fallback so an
+  unsupported order_by never silently zeroes a model); single quotes in the name
+  filter are escaped; and a transient full-enumeration failure no longer overwrites
+  the good `mlflow_model_versions` table with empty.
+
+### Security
+- **Trace-detail write-through is scoped to SP-authority fetches only.**
+  `observability_trace_details` is a shared cache served to every app user with no
+  per-user authorization recheck. Persisting a user-scoped (OBO) fetch could expose a
+  trace to users who lack access to it, so write-through now fires only when the fetch
+  used the app service principal — keeping the shared cache ⊆ SP-visible data, the
+  invariant the discovery workflow already maintains. Cross-workspace trace detail
+  (always OBO) stays live-per-request.
+
 ## [0.1.2] - 2026-06-02
 
 This release builds the Unity AI Gateway **v2** story and steps the app back from

--- a/control-plane-app/backend/api/gateway.py
+++ b/control-plane-app/backend/api/gateway.py
@@ -1,7 +1,7 @@
 """FastAPI routes for AI Gateway — powered by real Databricks APIs."""
 from fastapi import APIRouter, HTTPException, Query, Depends, Request
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from backend.config import settings
 from backend.services import gateway_service
 from backend.utils.auth import get_current_user, require_admin, require_account_admin, UserInfo
@@ -179,6 +179,57 @@ def uag_v2_usage():
     Breakdowns include requester_type, destination_model, api_type,
     service_type (model/MCP/provider) and route_action (routing outcomes)."""
     return gateway_service.get_uag_v2_usage()
+
+
+class ModelServiceGrant(BaseModel):
+    full_name: str
+    principal: str
+    add: List[str] = []
+    remove: List[str] = []
+
+
+@router.get("/model-services")
+def model_services(user: UserInfo = Depends(get_current_user)):
+    """v3 Unity Gateway UC model services (metastore-wide). Read via the caller's
+    OBO token so UC scopes what they can see."""
+    return gateway_service.list_model_services(user_token=user.token)
+
+
+@router.get("/model-services/grants")
+def model_service_grants(full_name: str = Query(...), user: UserInfo = Depends(get_current_user)):
+    """UC grants on one model service securable."""
+    return gateway_service.get_model_service_grants(full_name, user_token=user.token)
+
+
+@router.post("/model-services/grant")
+def model_service_grant(body: ModelServiceGrant, request: Request, user: UserInfo = Depends(require_admin)):
+    """Add/remove UC privileges on a model service. Admin-gated (workspace admin),
+    mirroring the app's v1 local permission writes: the write prefers the user's OBO
+    token (UC-enforced) but OBO can't carry the `unity-catalog` scope, so it falls
+    back to the app SP, which has MANAGE. The require_admin gate is the authorization
+    boundary; writes are SP-attributed in the audit trail."""
+    token = request.headers.get("x-forwarded-access-token", "") or user.token
+    return gateway_service.set_model_service_grant(
+        body.full_name, body.principal, body.add, body.remove, user_token=token,
+    )
+
+
+@router.get("/endpoint-inventory")
+def endpoint_inventory():
+    """Account-wide served-entity inventory (read-only) from
+    system.serving.served_entities — all serving endpoints across every workspace in
+    the metastore, not just the deploy workspace. Live management stays per-workspace."""
+    return gateway_service.get_endpoint_inventory()
+
+
+@router.get("/uag-budget-status")
+def uag_budget_status():
+    """Read-only budget configuration inventory from the account Budgets API
+    (/api/2.1/accounts/{id}/budgets): per-budget cap thresholds, enforce
+    (BLOCK_USAGE) vs alert-only, filter, and AI-relevance. Fleet-wide view;
+    enforcement stays platform-side. Empty when the workflow had no account
+    credentials to read the (account-scoped) API."""
+    return gateway_service.get_uag_budget_status()
 
 
 @router.get("/uag-mcp-tools")

--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -171,15 +171,16 @@ async def list_models(
     max_results: int = Query(500, le=10000),
     workspace_id: Optional[str] = Query(None, description="Workspace ID, 'all' for all workspaces"),
 ):
-    """Search Unity Catalog registered models, optionally cross-workspace."""
+    """UC registered models from the Lakebase cache (populated by the discovery
+    workflow). Reads the cache instead of a live REST search on every load; the
+    live search now only runs in the discovery workflow. Same row shape as before."""
     try:
-        token = _obo_token(request)
-        if workspace_id == "all" or workspace_id:
-            # Models are only available on the current workspace via REST
-            # Cross-workspace model registry not supported (no system table, OBO scope too narrow)
-            return mlflow_service.search_registered_models(max_results)
-        else:
-            return mlflow_service.search_registered_models(max_results)
+        rows = mlflow_service.get_cached_models(max_results)
+        if rows:
+            return rows
+        # Cold cache (workflow hasn't run yet): fall back to a one-off live search
+        # so the tab isn't empty before the first discovery run.
+        return mlflow_service.search_registered_models(max_results)
     except HTTPException:
         raise
     except Exception as e:

--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -175,12 +175,14 @@ async def list_models(
     workflow). Reads the cache instead of a live REST search on every load; the
     live search now only runs in the discovery workflow. Same row shape as before."""
     try:
-        rows = mlflow_service.get_cached_models(max_results)
-        if rows:
-            return rows
-        # Cold cache (workflow hasn't run yet): fall back to a one-off live search
-        # so the tab isn't empty before the first discovery run.
-        return mlflow_service.search_registered_models(max_results)
+        cached = mlflow_service.get_cached_models(max_results)
+        # None = cache table absent (never synced) → one-off live fallback so the
+        # tab isn't empty before the first discovery run. A real empty list (0
+        # models in the workspace) is returned as-is, so we don't hit the live API
+        # on every load.
+        if cached is None:
+            return mlflow_service.search_registered_models(max_results)
+        return cached
     except HTTPException:
         raise
     except Exception as e:

--- a/control-plane-app/backend/api/mlflow.py
+++ b/control-plane-app/backend/api/mlflow.py
@@ -191,9 +191,18 @@ async def list_models(
 
 @router.get("/models/{name:path}/versions")
 async def list_model_versions(name: str, max_results: int = Query(20, le=100)):
-    """Search versions for a registered model."""
+    """Versions for a registered model, from the Lakebase cache (populated by the
+    discovery workflow). Reads the cache instead of a live REST search on every
+    model expand; the live search now only runs in the discovery workflow.
+
+    Cache-first with a one-off live fallback only when the cache table is ABSENT
+    (never synced) — a real empty list (a model with no cached versions) is
+    returned as-is, so we don't hit the live API on every expand."""
     try:
-        return mlflow_service.search_model_versions(name, max_results)
+        cached = mlflow_service.get_cached_model_versions(name, max_results)
+        if cached is None:
+            return mlflow_service.search_model_versions(name, max_results)
+        return cached
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"MLflow API error: {e}")
 

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -684,6 +684,243 @@ def get_uag_v2_usage() -> Dict[str, Any]:
     }
 
 
+def get_uag_budget_status() -> Dict[str, Any]:
+    """Budget configuration inventory from `uag_budget_status` (sourced from the
+    account Budgets API, /api/2.1/accounts/{id}/budgets).
+
+    Read-only: surfaces each native budget's cap thresholds, whether it *enforces*
+    (BLOCK_USAGE) vs only *alerts* (email), its filter, and AI-relevance — the
+    fleet-wide view the native per-budget UI doesn't give. Enforcement stays
+    entirely platform-side; the app never creates or enforces budgets.
+
+    Returns {as_of, totals, budgets}. Degrades to empty when the table isn't
+    synced yet or the discovery workflow had no account-level credentials to
+    read the (account-scoped) Budgets API.
+
+    NOTE: consumption (% of cap used) is not populated yet — the account Budgets
+    API is config-only, so spend-vs-cap requires reproducing each budget's
+    tag/workspace filter against system.billing.usage (a separate validated pass).
+    """
+    from backend.database import execute_query
+    empty = {"as_of": None, "totals": {}, "budgets": []}
+    try:
+        # Totals aggregate the FULL table (not the limited list below), so KPIs
+        # stay correct on accounts with more budgets than the display cap.
+        agg = execute_query(
+            """SELECT count(*) AS budget_count,
+                      count(*) FILTER (WHERE enforce) AS enforcing_count,
+                      count(*) FILTER (WHERE alerting) AS alerting_count,
+                      count(*) FILTER (WHERE is_ai) AS ai_budget_count,
+                      count(*) FILTER (WHERE pct_used >= 100) AS over_cap_count,
+                      count(*) FILTER (WHERE pct_used >= 80 AND pct_used < 100) AS near_cap_count,
+                      max(discovered_at) AS max_discovered
+               FROM uag_budget_status"""
+        )
+        rows = execute_query(
+            """SELECT budget_id, display_name, enforce, alerting,
+                      min_threshold_usd, max_threshold_usd, time_period,
+                      filter_summary, is_ai, spent_usd, pct_used, discovered_at
+               FROM uag_budget_status
+               ORDER BY pct_used DESC NULLS LAST, max_threshold_usd DESC NULLS LAST LIMIT 500"""
+        )
+    except Exception as exc:
+        logger.warning("uag_budget_status not available: %s", exc)
+        return empty
+    if not agg or _row_int(agg[0], "budget_count") == 0:
+        return empty
+
+    a = agg[0]
+    as_of = str(a.get("max_discovered")) if a.get("max_discovered") else None
+
+    return {
+        "as_of": as_of,
+        "totals": {
+            "budget_count": _row_int(a, "budget_count"),
+            "enforcing_count": _row_int(a, "enforcing_count"),
+            "alerting_count": _row_int(a, "alerting_count"),
+            "ai_budget_count": _row_int(a, "ai_budget_count"),
+            "over_cap_count": _row_int(a, "over_cap_count"),
+            "near_cap_count": _row_int(a, "near_cap_count"),
+        },
+        "budgets": [
+            {
+                "budget_id": r.get("budget_id", ""),
+                "display_name": r.get("display_name", ""),
+                "enforce": bool(r.get("enforce")),
+                "alerting": bool(r.get("alerting")),
+                "min_threshold_usd": float(r.get("min_threshold_usd") or 0),
+                "max_threshold_usd": float(r.get("max_threshold_usd") or 0),
+                "time_period": r.get("time_period", ""),
+                "filter_summary": r.get("filter_summary", ""),
+                "is_ai": bool(r.get("is_ai")),
+                # spent/pct are None (n/a) when the budget's filter shape isn't computable
+                "spent_usd": float(r["spent_usd"]) if r.get("spent_usd") is not None else None,
+                "pct_used": float(r["pct_used"]) if r.get("pct_used") is not None else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+def get_endpoint_inventory() -> Dict[str, Any]:
+    """Account-wide served-entity inventory from `serving_endpoints_inventory`
+    (system.serving.served_entities). Read-only fleet view across ALL workspaces in
+    the metastore — the per-workspace serving API only sees the deploy workspace.
+    Live management (ACL/config edits) stays per-workspace. Degrades to empty if the
+    table isn't synced or served_entities wasn't readable at the discovery scope.
+    """
+    from backend.database import execute_query
+    empty = {"as_of": None, "totals": {}, "endpoints": []}
+    try:
+        agg = execute_query(
+            """SELECT count(*) AS served_entity_count,
+                      count(DISTINCT endpoint_id) AS endpoint_count,
+                      count(DISTINCT workspace_id) AS workspace_count,
+                      count(*) FILTER (WHERE entity_type = 'FOUNDATION_MODEL') AS foundation_count,
+                      count(*) FILTER (WHERE entity_type = 'CUSTOM_MODEL') AS custom_count,
+                      count(*) FILTER (WHERE entity_type = 'EXTERNAL_MODEL') AS external_count,
+                      max(discovered_at) AS max_discovered
+               FROM serving_endpoints_inventory"""
+        )
+        rows = execute_query(
+            """SELECT endpoint_name, workspace_id, entity_type, entity_name,
+                      entity_version, provider, task, created_by, change_time
+               FROM serving_endpoints_inventory
+               ORDER BY change_time DESC NULLS LAST LIMIT 2000"""
+        )
+    except Exception as exc:
+        logger.warning("serving_endpoints_inventory not available: %s", exc)
+        return empty
+    if not agg or _row_int(agg[0], "served_entity_count") == 0:
+        return empty
+    a = agg[0]
+    return {
+        "as_of": str(a.get("max_discovered")) if a.get("max_discovered") else None,
+        "totals": {
+            "served_entity_count": _row_int(a, "served_entity_count"),
+            "endpoint_count": _row_int(a, "endpoint_count"),
+            "workspace_count": _row_int(a, "workspace_count"),
+            "foundation_count": _row_int(a, "foundation_count"),
+            "custom_count": _row_int(a, "custom_count"),
+            "external_count": _row_int(a, "external_count"),
+        },
+        "endpoints": [
+            {
+                "endpoint_name": r.get("endpoint_name", ""),
+                "workspace_id": r.get("workspace_id", ""),
+                "entity_type": r.get("entity_type", ""),
+                "entity_name": r.get("entity_name", ""),
+                "entity_version": r.get("entity_version", ""),
+                "provider": r.get("provider", ""),
+                "task": r.get("task", ""),
+                "created_by": r.get("created_by", ""),
+                "change_time": str(r["change_time"]) if r.get("change_time") else None,
+            }
+            for r in rows
+        ],
+    }
+
+
+# ── Unity Gateway v3 — UC model services + grants (OBO, UC-enforced) ──
+
+def _uc_call(method: str, path: str, user_token: str = "", json_body: Optional[dict] = None):
+    """Call the workspace UC REST API. Uses the caller's OBO token when present
+    (so UC enforces the user's own privileges — MANAGE required to edit grants);
+    falls back to the app SP for reads when OBO isn't enabled."""
+    from backend.config import get_databricks_host, _sdk_auth_headers
+    host = get_databricks_host()
+    if user_token:
+        headers = {"Authorization": f"Bearer {user_token}"}
+    else:
+        headers = _sdk_auth_headers() or {}
+    headers["Content-Type"] = "application/json"
+    return httpx.request(method, f"{host}{path}", headers=headers, json=json_body, timeout=30)
+
+
+def _uc_get_json(path: str, user_token: str = "") -> Optional[dict]:
+    """GET a UC REST path, preferring the caller's OBO token but falling back to
+    the app SP when OBO is rejected (the v3 UC APIs currently 403 downscoped OBO
+    tokens; the app SP has the metastore read access, like the app's other UC
+    calls). Returns parsed JSON or None."""
+    for tok in ([user_token, ""] if user_token else [""]):
+        try:
+            resp = _uc_call("GET", path, tok)
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception as exc:
+            logger.warning("UC GET %s failed: %s", path, exc)
+    return None
+
+
+def list_model_services(user_token: str = "") -> Dict[str, Any]:
+    """v3 Unity Gateway UC model services from the `model_services_inventory`
+    Lakebase cache (populated by the discovery workflow, which enumerates
+    account-wide via its metastore-admin run-as — the list endpoint the app's
+    OBO/SP identities can't reliably reach). Grants are read/edited live
+    per-service (get_model_service_grants / set_model_service_grant)."""
+    from backend.database import execute_query
+    try:
+        rows = execute_query(
+            """SELECT full_name, owner, supported_api_types, create_time
+               FROM model_services_inventory ORDER BY full_name LIMIT 2000"""
+        )
+    except Exception as exc:
+        logger.warning("model_services_inventory not available: %s", exc)
+        return {"services": []}
+    return {
+        "services": [
+            {
+                "full_name": r.get("full_name", ""),
+                "owner": r.get("owner", ""),
+                "supported_api_types": (r.get("supported_api_types") or "").split(",") if r.get("supported_api_types") else [],
+                "create_time": r.get("create_time"),
+            }
+            for r in rows
+        ]
+    }
+
+
+def get_model_service_grants(full_name: str, user_token: str = "") -> Dict[str, Any]:
+    """UC grants on one model service (securable_type MODEL_SERVICE)."""
+    body = _uc_get_json(f"/api/2.1/unity-catalog/permissions/model_service/{full_name}", user_token)
+    if body is None:
+        return {"grants": [], "error": "grants not readable (insufficient privileges)"}
+    return {
+        "grants": [
+            {"principal": pa.get("principal", ""), "privileges": pa.get("privileges", [])}
+            for pa in body.get("privilege_assignments", [])
+        ]
+    }
+
+
+def set_model_service_grant(
+    full_name: str, principal: str, add: Optional[List[str]] = None,
+    remove: Optional[List[str]] = None, user_token: str = "",
+) -> Dict[str, Any]:
+    """Add/remove UC privileges for a principal on a model service. Prefers the
+    caller's OBO token (UC-enforced), but Apps OBO can't carry the required
+    `unity-catalog` scope today, so it falls back to the app SP (which has MANAGE).
+    The route gates this on require_admin; when the SP path is used the authorization
+    boundary is that admin gate, not per-user UC enforcement, and the write is
+    SP-attributed. NOTE: currently dormant — the UI is read-only (see
+    ideas/model-services-write-path.md for the planned user-MANAGE-checked design)."""
+    body = {"changes": [{"principal": principal, "add": add or [], "remove": remove or []}]}
+    path = f"/api/2.1/unity-catalog/permissions/model_service/{full_name}"
+    # OBO can't carry the `unity-catalog` scope (not grantable to Apps OBO), so fall
+    # back to the app SP — same pattern as v1 local permission writes. The route gates
+    # this on require_admin; UC still enforces the SP has MANAGE on the securable.
+    last = "no attempt"
+    for tok in ([user_token, ""] if user_token else [""]):
+        try:
+            resp = _uc_call("PATCH", path, tok, json_body=body)
+            if resp.status_code == 200:
+                return {"ok": True, "via": "obo" if tok else "sp"}
+            last = f"{resp.status_code}: {resp.text[:220]}"
+        except Exception as exc:
+            last = str(exc)[:220]
+    return {"ok": False, "error": last}
+
+
 def get_uag_mcp_tools() -> Dict[str, Any]:
     """Per-tool MCP activity from `uag_mcp_tool_daily` (sourced from
     system.ai_gateway.usage rows where service_type = MCP_SERVICE).

--- a/control-plane-app/backend/services/gateway_service.py
+++ b/control-plane-app/backend/services/gateway_service.py
@@ -697,9 +697,10 @@ def get_uag_budget_status() -> Dict[str, Any]:
     synced yet or the discovery workflow had no account-level credentials to
     read the (account-scoped) Budgets API.
 
-    NOTE: consumption (% of cap used) is not populated yet — the account Budgets
-    API is config-only, so spend-vs-cap requires reproducing each budget's
-    tag/workspace filter against system.billing.usage (a separate validated pass).
+    Consumption (spent_usd / pct_used) is populated by 13_discover_budgets, which
+    reproduces each budget's tag/workspace filter against system.billing.usage for
+    the supported filter shapes (account-wide / workspace-only / single-tag); other
+    shapes stay n/a. The full budget list is returned (no cap); the frontend paginates.
     """
     from backend.database import execute_query
     empty = {"as_of": None, "totals": {}, "budgets": []}
@@ -721,7 +722,7 @@ def get_uag_budget_status() -> Dict[str, Any]:
                       min_threshold_usd, max_threshold_usd, time_period,
                       filter_summary, is_ai, spent_usd, pct_used, discovered_at
                FROM uag_budget_status
-               ORDER BY pct_used DESC NULLS LAST, max_threshold_usd DESC NULLS LAST LIMIT 500"""
+               ORDER BY pct_used DESC NULLS LAST, max_threshold_usd DESC NULLS LAST"""
         )
     except Exception as exc:
         logger.warning("uag_budget_status not available: %s", exc)

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -1439,12 +1439,12 @@ def get_cached_models(limit: int = 1000) -> Optional[List[Dict[str, Any]]]:
         rows = execute_query(
             """SELECT name, workspace_id, user_id, last_updated_timestamp,
                       creation_timestamp, description, aliases, latest_versions
-               FROM model_registry ORDER BY last_updated_timestamp DESC NULLS LAST LIMIT %s""",
+               FROM mlflow_registered_models ORDER BY last_updated_timestamp DESC NULLS LAST LIMIT %s""",
             (limit,),
         )
     except Exception as exc:
         # Table missing / not yet created by the discovery sync → signal "unknown".
-        logger.warning("model_registry cache not available: %s", exc)
+        logger.warning("mlflow_registered_models cache not available: %s", exc)
         return None
     # psycopg2 returns JSONB as already-parsed Python objects; pass through.
     return rows

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -735,9 +735,11 @@ def search_model_versions(
     name: str, max_results: int = 20
 ) -> List[Dict[str, Any]]:
     """Search versions for a registered model."""
+    # Escape single quotes so a model name with an apostrophe can't break the filter.
+    name_esc = name.replace("'", "''")
     data = _get(
         "/api/2.0/mlflow/unity-catalog/model-versions/search",
-        {"filter": f"name='{name}'", "max_results": max_results},
+        {"filter": f"name='{name_esc}'", "max_results": max_results},
     )
     return data.get("model_versions", [])
 
@@ -1530,7 +1532,7 @@ def get_cached_model_versions(name: str, limit: int = 100) -> Optional[List[Dict
     try:
         rows = execute_query(
             """SELECT name, version, workspace_id, user_id, creation_timestamp,
-                      last_updated_timestamp, status, description, source, run_id
+                      last_updated_timestamp, status, description, source, run_id, aliases
                FROM mlflow_model_versions WHERE name = %s
                ORDER BY CASE WHEN version ~ '^[0-9]+$' THEN CAST(version AS BIGINT) END DESC NULLS LAST,
                         version DESC LIMIT %s""",

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -1423,6 +1423,27 @@ def get_cached_traces(
     )
 
 
+def get_cached_models(limit: int = 1000) -> List[Dict[str, Any]]:
+    """Read UC registered models from the Lakebase cache (populated by
+    04_discover_observability). Returns the same row shape the live
+    search_registered_models produced (name, user_id, last_updated_timestamp,
+    aliases, …) so the frontend is unchanged. aliases/latest_versions are stored
+    as JSONB → returned as parsed lists. Degrades to [] when unsynced.
+    """
+    try:
+        rows = execute_query(
+            """SELECT name, user_id, last_updated_timestamp, creation_timestamp,
+                      description, aliases, latest_versions
+               FROM model_registry ORDER BY last_updated_timestamp DESC NULLS LAST LIMIT %s""",
+            (limit,),
+        )
+    except Exception as exc:
+        logger.warning("model_registry cache not available: %s", exc)
+        return []
+    # psycopg2 returns JSONB as already-parsed Python objects; pass through.
+    return rows
+
+
 def get_cached_experiments(workspace_id: Optional[str] = None, limit: int = 10000) -> List[Dict[str, Any]]:
     """Read experiments from the Lakebase cache, optionally filtered by workspace."""
     if workspace_id:

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -785,10 +785,16 @@ def get_trace_detail(request_id: str, *, user_token: Optional[str] = None) -> Op
     spans = trace_data.get("spans")
     if isinstance(spans, list):
         detail["spans"] = spans
-    # Write-through so the next load reads from Lakebase (see _cache_trace_detail_row).
-    _cache_trace_detail_row(
-        "", request_id, detail.get("experiment_id"), trace_info, trace_data,
-    )
+    # Write-through so the next load reads from Lakebase — but ONLY when this fetch
+    # used the app SP (no user_token). observability_trace_details is a SHARED cache
+    # read by every app user with no per-user authz recheck, so it must never hold
+    # anything broader than SP-visible data (the invariant the discovery workflow
+    # already maintains). A user-scoped OBO fetch could see traces the SP can't, so
+    # persisting it would leak that trace to other users — skip write-through then.
+    if not user_token:
+        _cache_trace_detail_row(
+            "", request_id, detail.get("experiment_id"), trace_info, trace_data,
+        )
     return detail
 
 
@@ -1187,6 +1193,12 @@ def _cache_trace_detail_row(
     hitting the live MLflow REST API again. Best-effort — never raises into the
     request path (a cache-write failure must not fail the trace-detail response).
 
+    SECURITY: this table is a SHARED cache read by every app user with no per-user
+    authz recheck, so callers MUST only invoke this for SP-authority fetches (no
+    user OBO token) — persisting a user-scoped fetch could leak a trace to users who
+    can't see it. This keeps the cache ⊆ SP-visible data, the same invariant the
+    discovery workflow maintains.
+
     workspace_id is "" for UC / cross-backend traces that are keyed by request_id
     alone (matches how the discovery workflow and `_get_trace_detail_from_cache_any`
     treat them)."""
@@ -1250,10 +1262,12 @@ def get_trace_detail_for_workspace(
     if isinstance(spans, list):
         detail["spans"] = spans
     detail["data_source"] = "live"
-    # Write-through so the next load reads from Lakebase (see _cache_trace_detail_row).
-    _cache_trace_detail_row(
-        workspace_id, request_id, detail.get("experiment_id"), trace_info, trace_data,
-    )
+    # No write-through here: this cross-workspace path is ALWAYS a user-scoped OBO
+    # fetch (user_token is required), and observability_trace_details is a shared
+    # cache served to every app user with no per-user authz recheck. Persisting an
+    # OBO-visible trace could leak it to users who can't see it, so cross-workspace
+    # detail stays live-per-request. The discovery workflow (SP authority) remains
+    # the only writer of shared cross-workspace trace details.
     return detail
 
 

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -1423,23 +1423,29 @@ def get_cached_traces(
     )
 
 
-def get_cached_models(limit: int = 1000) -> List[Dict[str, Any]]:
+def get_cached_models(limit: int = 1000) -> Optional[List[Dict[str, Any]]]:
     """Read UC registered models from the Lakebase cache (populated by
     04_discover_observability). Returns the same row shape the live
-    search_registered_models produced (name, user_id, last_updated_timestamp,
-    aliases, …) so the frontend is unchanged. aliases/latest_versions are stored
-    as JSONB → returned as parsed lists. Degrades to [] when unsynced.
+    search_registered_models produced (name, workspace_id, user_id,
+    last_updated_timestamp, description, aliases, …) so the frontend is unchanged.
+    aliases/latest_versions are stored as JSONB → returned as parsed lists.
+
+    Returns None when the cache table is ABSENT (never synced) so the caller can
+    fall back to a live search; returns [] when the table exists but is empty
+    (a workspace with no registered models) — the caller should NOT keep hitting
+    the live API in that case.
     """
     try:
         rows = execute_query(
-            """SELECT name, user_id, last_updated_timestamp, creation_timestamp,
-                      description, aliases, latest_versions
+            """SELECT name, workspace_id, user_id, last_updated_timestamp,
+                      creation_timestamp, description, aliases, latest_versions
                FROM model_registry ORDER BY last_updated_timestamp DESC NULLS LAST LIMIT %s""",
             (limit,),
         )
     except Exception as exc:
+        # Table missing / not yet created by the discovery sync → signal "unknown".
         logger.warning("model_registry cache not available: %s", exc)
-        return []
+        return None
     # psycopg2 returns JSONB as already-parsed Python objects; pass through.
     return rows
 

--- a/control-plane-app/backend/services/mlflow_service.py
+++ b/control-plane-app/backend/services/mlflow_service.py
@@ -774,10 +774,20 @@ def get_trace_detail(request_id: str, *, user_token: Optional[str] = None) -> Op
         return cached
 
     data = _get(f"/api/2.0/mlflow/traces/{request_id}", user_token=user_token)
-    trace_info = data.get("trace", {}).get("trace_info", {})
+    trace = data.get("trace", {})
+    trace_info = trace.get("trace_info", {})
     if not trace_info:
         return None
-    return _parse_trace_info_to_detail(trace_info, request_id)
+    detail = _parse_trace_info_to_detail(trace_info, request_id)
+    trace_data = trace.get("trace_data") or {}
+    spans = trace_data.get("spans")
+    if isinstance(spans, list):
+        detail["spans"] = spans
+    # Write-through so the next load reads from Lakebase (see _cache_trace_detail_row).
+    _cache_trace_detail_row(
+        "", request_id, detail.get("experiment_id"), trace_info, trace_data,
+    )
+    return detail
 
 
 # ── Cross-workspace helpers ────────────────────────────────────
@@ -1161,6 +1171,54 @@ def _get_trace_detail_from_cache(
     return _row_to_trace_detail(rows[0], request_id, workspace_id)
 
 
+def _cache_trace_detail_row(
+    workspace_id: str,
+    request_id: str,
+    experiment_id: Optional[str],
+    trace_info: Dict[str, Any],
+    trace_data: Optional[Dict[str, Any]],
+    *,
+    source_type: str = "live_writethrough",
+) -> None:
+    """Write-through: persist a live-fetched trace detail into
+    `observability_trace_details` so the next load reads from Lakebase instead of
+    hitting the live MLflow REST API again. Best-effort — never raises into the
+    request path (a cache-write failure must not fail the trace-detail response).
+
+    workspace_id is "" for UC / cross-backend traces that are keyed by request_id
+    alone (matches how the discovery workflow and `_get_trace_detail_from_cache_any`
+    treat them)."""
+    try:
+        info_json = _json.dumps(trace_info or {})
+        data_json = _json.dumps(trace_data or {})
+        size_bytes = len(info_json) + len(data_json)
+        execute_update(
+            """INSERT INTO observability_trace_details
+                   (workspace_id, request_id, experiment_id, trace_info, trace_data,
+                    request_raw, response_raw, size_bytes, source_type, cached_at)
+               VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, NOW())
+               ON CONFLICT (workspace_id, request_id) DO UPDATE SET
+                   experiment_id = EXCLUDED.experiment_id,
+                   trace_info    = EXCLUDED.trace_info,
+                   trace_data    = EXCLUDED.trace_data,
+                   request_raw   = EXCLUDED.request_raw,
+                   response_raw  = EXCLUDED.response_raw,
+                   size_bytes    = EXCLUDED.size_bytes,
+                   source_type   = EXCLUDED.source_type,
+                   cached_at     = NOW()""",
+            (
+                workspace_id or "", request_id, experiment_id or "",
+                info_json, data_json,
+                trace_info.get("request", "") or "",
+                trace_info.get("response", "") or "",
+                size_bytes, source_type,
+            ),
+        )
+    except Exception as exc:
+        logger.warning("Trace detail write-through failed (ws=%s rid=%s): %s",
+                       workspace_id, request_id, exc)
+
+
 def get_trace_detail_for_workspace(
     request_id: str,
     workspace_id: str,
@@ -1180,11 +1238,20 @@ def get_trace_detail_for_workspace(
     data = _get_for_workspace(
         f"/api/2.0/mlflow/traces/{request_id}", None, workspace_id, user_token,
     )
-    trace_info = data.get("trace", {}).get("trace_info", {})
+    trace = data.get("trace", {})
+    trace_info = trace.get("trace_info", {})
     if not trace_info:
         return None
     detail = _parse_trace_info_to_detail(trace_info, request_id, workspace_id)
+    trace_data = trace.get("trace_data") or {}
+    spans = trace_data.get("spans")
+    if isinstance(spans, list):
+        detail["spans"] = spans
     detail["data_source"] = "live"
+    # Write-through so the next load reads from Lakebase (see _cache_trace_detail_row).
+    _cache_trace_detail_row(
+        workspace_id, request_id, detail.get("experiment_id"), trace_info, trace_data,
+    )
     return detail
 
 
@@ -1447,6 +1514,32 @@ def get_cached_models(limit: int = 1000) -> Optional[List[Dict[str, Any]]]:
         logger.warning("mlflow_registered_models cache not available: %s", exc)
         return None
     # psycopg2 returns JSONB as already-parsed Python objects; pass through.
+    return rows
+
+
+def get_cached_model_versions(name: str, limit: int = 100) -> Optional[List[Dict[str, Any]]]:
+    """Read a registered model's versions from the Lakebase cache (populated by
+    04_discover_observability). Returns the same field shape the live
+    search_model_versions produced (version, status, user_id, creation_timestamp,
+    last_updated_timestamp, description, source, run_id) so the frontend is unchanged.
+
+    Returns None when the cache table is ABSENT (never synced) so the caller can
+    fall back to a live search; returns [] when the table exists but the model has
+    no cached versions — the caller should NOT keep hitting the live API in that case.
+    """
+    try:
+        rows = execute_query(
+            """SELECT name, version, workspace_id, user_id, creation_timestamp,
+                      last_updated_timestamp, status, description, source, run_id
+               FROM mlflow_model_versions WHERE name = %s
+               ORDER BY CASE WHEN version ~ '^[0-9]+$' THEN CAST(version AS BIGINT) END DESC NULLS LAST,
+                        version DESC LIMIT %s""",
+            (name, limit),
+        )
+    except Exception as exc:
+        # Table missing / not yet created by the discovery sync → signal "unknown".
+        logger.warning("mlflow_model_versions cache not available: %s", exc)
+        return None
     return rows
 
 

--- a/control-plane-app/backend/services/tools_service.py
+++ b/control-plane-app/backend/services/tools_service.py
@@ -654,6 +654,51 @@ def get_uc_functions() -> List[Dict[str, Any]]:
     return result
 
 
+def _normalize_tool_name(name: str, span_type: str) -> str:
+    """TOOL span names arrive as catalog__schema__function (MLflow sanitizes the
+    UC FQN's dots to '__'). Reverse only the exact 3-part shape — a blanket
+    replace would mangle names like search__web. Mirrors mlflow_service._asset."""
+    if span_type == "TOOL" and name:
+        parts = name.split("__")
+        if len(parts) == 3 and all(parts):
+            return ".".join(parts)
+    return name or ""
+
+
 def get_tool_usage(days: int = 7) -> List[Dict[str, Any]]:
-    """Get tool call frequency from MLflow traces."""
-    return _get_tool_call_usage(days)
+    """Tool-call frequency/error/latency from the cached agent_tool_usage table
+    (TOOL/RETRIEVER span rollup produced by 07_discover_uc_otel_traces), instead
+    of a live per-request MLflow trace scan. Aggregates across experiments per
+    (tool, span_type). Falls back to the live scan only if the cache is absent.
+    The `days` arg is accepted for compatibility but the cache reflects the
+    discovery window.
+    """
+    try:
+        rows = execute_query(
+            """SELECT tool_name, span_type,
+                      SUM(call_count)::BIGINT       AS call_count,
+                      SUM(error_count)::BIGINT      AS error_count,
+                      SUM(total_latency_ms)::DOUBLE PRECISION AS total_latency_ms
+               FROM agent_tool_usage
+               GROUP BY tool_name, span_type
+               ORDER BY call_count DESC LIMIT 500"""
+        )
+    except Exception as exc:
+        # Cache table absent (never synced) → one-off live fallback.
+        logger.warning("agent_tool_usage cache not available, falling back to live: %s", exc)
+        return _get_tool_call_usage(days)
+
+    usage = []
+    for r in rows:
+        count = int(r.get("call_count") or 0)
+        errors = int(r.get("error_count") or 0)
+        total_lat = float(r.get("total_latency_ms") or 0.0)
+        usage.append({
+            "tool_name": _normalize_tool_name(r.get("tool_name") or "", r.get("span_type") or ""),
+            "span_type": r.get("span_type") or "",
+            "call_count": count,
+            "error_count": errors,
+            "error_rate": round(errors / count * 100, 1) if count > 0 else 0,
+            "avg_latency_ms": round(total_lat / count, 1) if count > 0 else 0,
+        })
+    return usage

--- a/control-plane-app/frontend/src/api/hooks.ts
+++ b/control-plane-app/frontend/src/api/hooks.ts
@@ -730,7 +730,7 @@ export interface UagBreakdownRow {
   cached_tokens: number
 }
 
-/** Unity AI Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh. */
+/** Unity Gateway (v2) usage — v2-routed endpoints only, ~20-min fresh. */
 export function useUagV2Usage() {
   return useQuery({
     queryKey: ['gateway', 'uag-v2-usage'],
@@ -739,6 +739,125 @@ export function useUagV2Usage() {
       return data as UagV2Usage
     },
     staleTime: GW_STALE,
+  })
+}
+
+/** Read-only budget config inventory from the account Budgets API. */
+export interface UagBudgetStatus {
+  as_of: string | null
+  totals: {
+    budget_count?: number
+    enforcing_count?: number
+    alerting_count?: number
+    ai_budget_count?: number
+    over_cap_count?: number
+    near_cap_count?: number
+  }
+  budgets: Array<{
+    budget_id: string
+    display_name: string
+    enforce: boolean
+    alerting: boolean
+    min_threshold_usd: number
+    max_threshold_usd: number
+    time_period: string
+    filter_summary: string
+    is_ai: boolean
+    spent_usd: number | null
+    pct_used: number | null
+  }>
+}
+
+export function useUagBudgetStatus() {
+  return useQuery({
+    queryKey: ['gateway', 'uag-budget-status'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/uag-budget-status')
+      return data as UagBudgetStatus
+    },
+    staleTime: GW_STALE,
+  })
+}
+
+/** Account-wide served-entity inventory (read-only) from system.serving.served_entities. */
+export interface EndpointInventory {
+  as_of: string | null
+  totals: {
+    served_entity_count?: number
+    endpoint_count?: number
+    workspace_count?: number
+    foundation_count?: number
+    custom_count?: number
+    external_count?: number
+  }
+  endpoints: Array<{
+    endpoint_name: string
+    workspace_id: string
+    entity_type: string
+    entity_name: string
+    entity_version: string
+    provider: string
+    task: string
+    created_by: string
+    change_time: string | null
+  }>
+}
+
+export function useEndpointInventory() {
+  return useQuery({
+    queryKey: ['gateway', 'endpoint-inventory'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/endpoint-inventory')
+      return data as EndpointInventory
+    },
+    staleTime: GW_STALE,
+  })
+}
+
+/** v3 Unity Gateway UC model services + their UC grants (OBO, UC-enforced). */
+export interface ModelService {
+  full_name: string
+  owner: string
+  supported_api_types: string[]
+  create_time: string | null
+}
+export interface ModelServiceGrantRow {
+  principal: string
+  privileges: string[]
+}
+
+export function useModelServices() {
+  return useQuery({
+    queryKey: ['gateway', 'model-services'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/model-services')
+      return data as { services: ModelService[] }
+    },
+    staleTime: GW_STALE,
+  })
+}
+
+export function useModelServiceGrants(fullName: string | null) {
+  return useQuery({
+    queryKey: ['gateway', 'model-service-grants', fullName],
+    enabled: !!fullName,
+    queryFn: async () => {
+      const { data } = await apiClient.get('/gateway/model-services/grants', { params: { full_name: fullName } })
+      return data as { grants: ModelServiceGrantRow[]; error?: string }
+    },
+  })
+}
+
+export function useSetModelServiceGrant() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: { full_name: string; principal: string; add?: string[]; remove?: string[] }) => {
+      const { data } = await apiClient.post('/gateway/model-services/grant', body)
+      return data as { ok: boolean; error?: string }
+    },
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: ['gateway', 'model-service-grants', vars.full_name] })
+    },
   })
 }
 
@@ -765,7 +884,7 @@ export interface GuardrailCoverage {
   }>
 }
 
-/** Guardrail coverage/activity per endpoint from Unity AI Gateway v2 (not outcomes). */
+/** Guardrail coverage/activity per endpoint from Unity Gateway v2 (not outcomes). */
 export function useGuardrailCoverage() {
   return useQuery({
     queryKey: ['gateway', 'guardrail-coverage'],
@@ -789,7 +908,7 @@ export interface Throttling {
   }>
 }
 
-/** Per-endpoint throttling (HTTP 429) + server errors (5xx) from Unity AI Gateway usage. */
+/** Per-endpoint throttling (HTTP 429) + server errors (5xx) from Unity Gateway usage. */
 export function useThrottling() {
   return useQuery({
     queryKey: ['gateway', 'throttling'],
@@ -814,7 +933,7 @@ export interface FallbackRouting {
   }>
 }
 
-/** Per-endpoint smart-routing fallback (backup-model routing) from Unity AI Gateway usage. */
+/** Per-endpoint smart-routing fallback (backup-model routing) from Unity Gateway usage. */
 export function useFallbackRouting() {
   return useQuery({
     queryKey: ['gateway', 'fallback-routing'],
@@ -977,7 +1096,7 @@ export interface McpActivity {
   }>
 }
 
-/** Server-grouped MCP tool activity from Unity AI Gateway v2. */
+/** Server-grouped MCP tool activity from Unity Gateway v2. */
 export function useMcpActivity() {
   return useQuery({
     queryKey: ['tools', 'mcp-activity'],
@@ -1131,7 +1250,7 @@ export interface BillingPageData {
   daily_tokens: any[]
   products: any[]
   cost_by_user: any[]
-  /** "actual" = Unity AI Gateway v2 per-user attribution; "estimate" = token-share split */
+  /** "actual" = Unity Gateway v2 per-user attribution; "estimate" = token-share split */
   cost_by_user_source: 'actual' | 'estimate'
   tokens_by_user: any[]
   /** MODEL_SERVING $ attributed by custom_tag (window aggregate, workspace-agnostic) */

--- a/control-plane-app/frontend/src/pages/AIGateway.tsx
+++ b/control-plane-app/frontend/src/pages/AIGateway.tsx
@@ -21,6 +21,10 @@ import {
   type UagBreakdownRow,
   useGatewayInferenceLogs,
   useGatewayMetrics,
+  useEndpointInventory,
+  useUagBudgetStatus,
+  useModelServices,
+  useModelServiceGrants,
   useAppConfig,
   useRefreshGateway,
   useCurrentUser,
@@ -58,21 +62,40 @@ import {
   Pencil,
   Info,
   Sparkles,
+  Archive,
+  Server,
+  Wallet,
 } from 'lucide-react'
 
 /* ── tab definitions ─────────────────────────────────────────── */
 const baseTabs = [
-  { id: 'uag-v2', label: 'Unity AI Gateway', icon: Sparkles, beta: true, legacy: false },
-  { id: 'overview', label: 'Overview', icon: LayoutDashboard, beta: false, legacy: true },
-  { id: 'metrics', label: 'Metrics', icon: Cpu, beta: false, legacy: true },
-  { id: 'permissions', label: 'Permissions', icon: Shield, beta: false, legacy: true },
-  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert, beta: false, legacy: true },
+  { id: 'uag-v2', label: 'Unity Gateway', icon: Sparkles },
+  { id: 'budgets', label: 'Budgets', icon: Wallet },
+  { id: 'legacy', label: 'Legacy AI Gateway', icon: Archive },
 ] as const
 
-type TabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits' | 'uag-v2'
+/** Compact USD formatter for budget caps/spend (matches the Governance style). */
+function fmtCost(v: number): string {
+  if (v >= 1000) return `$${(v / 1000).toFixed(1)}k`
+  if (v >= 1) return `$${v.toFixed(2)}`
+  return `$${v.toFixed(4)}`
+}
+
+// Secondary nav inside the Legacy AI Gateway tab — the per-endpoint serving-gateway
+// views (v1), plus Permissions (endpoint ACLs + UC grants).
+const legacyTabs = [
+  { id: 'overview', label: 'Overview', icon: LayoutDashboard },
+  { id: 'metrics', label: 'Metrics', icon: Cpu },
+  { id: 'permissions', label: 'Permissions', icon: Shield },
+  { id: 'rate-limits', label: 'Rate Limits & Guardrails', icon: ShieldAlert },
+] as const
+
+type TabId = 'uag-v2' | 'budgets' | 'legacy'
+type LegacyTabId = 'overview' | 'metrics' | 'permissions' | 'rate-limits'
 
 export default function AIGatewayPage() {
   const [activeTab, setActiveTab] = useState<TabId>('uag-v2')
+  const [legacyTab, setLegacyTab] = useState<LegacyTabId>('overview')
   const [days, setDays] = useState(7)
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -101,7 +124,7 @@ export default function AIGatewayPage() {
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline inline-flex items-center gap-0.5"
             >
-              (Beta docs <ExternalLink className="w-3 h-3" />)
+              (docs <ExternalLink className="w-3 h-3" />)
             </a>
           </p>
         </div>
@@ -139,17 +162,17 @@ export default function AIGatewayPage() {
       <div className="flex items-start gap-2.5 rounded-lg border border-indigo-200 bg-indigo-50 px-3.5 py-2.5 text-[13px] text-indigo-900 dark:border-indigo-900/50 dark:bg-indigo-950/30 dark:text-indigo-200">
         <Sparkles className="w-4 h-4 mt-0.5 flex-shrink-0 text-indigo-500 dark:text-indigo-400" />
         <p className="leading-snug">
-          <span className="font-semibold">Unity AI Gateway is where this is headed.</span>{' '}
-          It's Databricks' native control plane for AI governance. We integrate its capabilities
-          as soon as their APIs are available — start with the{' '}
-          <span className="font-medium">Unity AI Gateway (Beta)</span> tab — and retire legacy
-          views here as they're superseded. Expect this page to shift toward Unity AI Gateway over time.
+          <span className="font-semibold">Unity Gateway is where this is headed.</span>{' '}
+          It's Databricks' native, generally available control plane for AI governance. We
+          integrate its capabilities as their APIs become available — start with the{' '}
+          <span className="font-medium">Unity Gateway</span> tab — and retire legacy
+          views here as they're superseded. Expect this page to shift toward Unity Gateway over time.
         </p>
       </div>
 
       {/* Tab bar */}
       <div className="flex gap-1 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
-        {tabs.map(({ id, label, icon: Icon, beta, legacy }) => (
+        {tabs.map(({ id, label, icon: Icon }) => (
           <button
             key={id}
             onClick={() => setActiveTab(id)}
@@ -161,43 +184,444 @@ export default function AIGatewayPage() {
           >
             <Icon className="w-4 h-4" />
             {label}
-            {beta && (
-              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300">
-                Beta
-              </span>
-            )}
-            {legacy && (
-              <span className="ml-0.5 px-1.5 py-0.5 rounded text-[9px] font-semibold tracking-wide bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-                v1
-              </span>
-            )}
           </button>
         ))}
       </div>
 
-      {/* KPI Row — Overview only */}
-      {activeTab === 'overview' && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
-          <KpiCard title="Total Endpoints" value={overview?.total_endpoints ?? 0} format="number" />
-          <KpiCard title="Ready" value={overview?.ready_endpoints ?? 0} format="number" />
-          <KpiCard title="Gateway Enabled" value={overview?.gateway_enabled ?? 0} format="number" />
-          <KpiCard title="Requests (24h)" value={overview?.total_requests_24h ?? 0} format="number" />
-          <KpiCard title="Unique Users (24h)" value={overview?.unique_users_24h ?? 0} format="number" />
-          <KpiCard title="Error Rate (24h)" value={overview?.error_rate_24h ?? 0} format="percentage" />
+      {/* Unity Gateway — primary surface, incl. account-wide endpoint inventory */}
+      {activeTab === 'uag-v2' && (
+        <div className="space-y-6">
+          <UagV2Section />
+          <ModelServicesSection />
+          <EndpointInventorySection />
         </div>
       )}
 
-      {/* Tab content */}
-      {activeTab === 'overview' && <OverviewSection endpoints={endpoints} overview={overview} workspaceUrl={workspaceUrl} loading={pageLoading} searchQuery={searchQuery} days={days} />}
-      {activeTab === 'metrics' && <MetricsSection />}
-      {activeTab === 'permissions' && <PermissionsSection />}
-      {activeTab === 'rate-limits' && <RateLimitsAndGuardrailsSection />}
-      {activeTab === 'uag-v2' && <UagV2Section />}
+      {/* Budgets — native account budgets (read-only), config + MTD spend vs cap */}
+      {activeTab === 'budgets' && <BudgetsTab />}
+
+      {/* Legacy AI Gateway — the per-endpoint serving-gateway views, consolidated */}
+      {activeTab === 'legacy' && (
+        <div className="space-y-4">
+          {/* Secondary sub-nav */}
+          <div className="flex flex-wrap gap-1">
+            {legacyTabs.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                onClick={() => setLegacyTab(id)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  legacyTab === id
+                    ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {/* KPI Row — Legacy Overview only */}
+          {legacyTab === 'overview' && (
+            <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+              <KpiCard title="Total Endpoints" value={overview?.total_endpoints ?? 0} format="number" />
+              <KpiCard title="Ready" value={overview?.ready_endpoints ?? 0} format="number" />
+              <KpiCard title="Gateway Enabled" value={overview?.gateway_enabled ?? 0} format="number" />
+              <KpiCard title="Requests (24h)" value={overview?.total_requests_24h ?? 0} format="number" />
+              <KpiCard title="Unique Users (24h)" value={overview?.unique_users_24h ?? 0} format="number" />
+              <KpiCard title="Error Rate (24h)" value={overview?.error_rate_24h ?? 0} format="percentage" />
+            </div>
+          )}
+
+          {legacyTab === 'overview' && <OverviewSection endpoints={endpoints} overview={overview} workspaceUrl={workspaceUrl} loading={pageLoading} searchQuery={searchQuery} days={days} />}
+          {legacyTab === 'metrics' && <MetricsSection />}
+          {legacyTab === 'permissions' && <PermissionsSection />}
+          {legacyTab === 'rate-limits' && <RateLimitsAndGuardrailsSection />}
+        </div>
+      )}
     </div>
   )
 }
 
-/* ── Unity AI Gateway (Beta) Section ───────────────────────── */
+/* ── Budgets (native account budgets, read-only) ───────────────── */
+
+function BudgetsTab() {
+  const { data, isLoading } = useUagBudgetStatus()
+  const budgets = data?.budgets ?? []
+  const totals = data?.totals ?? {}
+  const hasData = budgets.length > 0
+
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const { sort, toggle } = useSort<string>('max_threshold_usd')
+
+  const sorted = useMemo(
+    () =>
+      sortRows(budgets, sort, (b: (typeof budgets)[number], k) => {
+        if (k === 'enforce') return b.enforce ? 2 : b.alerting ? 1 : 0
+        if (k === 'is_ai') return b.is_ai ? 1 : 0
+        return (b as any)[k]
+      }),
+    [budgets, sort],
+  )
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            Budget Status
+            <span className="group relative inline-flex">
+              <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-80 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              >
+                Read-only inventory of native Databricks budgets (account Budgets API).
+                Shows each budget's cap, whether it <strong>enforces</strong> a hard cap
+                (BLOCK_USAGE) or only <strong>alerts</strong>, its filter, and whether it
+                scopes AI spend. <strong>Spent (MTD)</strong> and <strong>% Used</strong> are
+                this month's list-price spend matched to the budget's filter (from
+                <code>system.billing.usage</code>); shown as <em>n/a</em> for complex filters
+                we don't estimate. Budgets are created and enforced by the platform — this app
+                only surfaces their status.
+              </span>
+            </span>
+            {data?.as_of && (
+              <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">
+                as of {formatAsOf(data.as_of)}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading…</div>
+          ) : !hasData ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">
+              No budgets found. Either none are configured in your Databricks account, or the
+              discovery workflow has no account-level credentials to read the (account-scoped)
+              Budgets API — set <code>discovery_sp_secret_scope</code> to an account SP with
+              budget read access.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-5">
+                <KpiCard title="Budgets" value={totals.budget_count ?? 0} />
+                <KpiCard title="Enforcing (hard cap)" value={totals.enforcing_count ?? 0} />
+                <KpiCard title="AI-scoped" value={totals.ai_budget_count ?? 0} />
+                <KpiCard title="≥80% of cap" value={(totals.near_cap_count ?? 0) + (totals.over_cap_count ?? 0)} />
+                <KpiCard title="Over cap" value={totals.over_cap_count ?? 0} />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-gray-200 dark:border-gray-700">
+                    <tr>
+                      <SortableHeader label="Budget" sortKey="display_name" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Period" sortKey="time_period" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Cap" sortKey="max_threshold_usd" current={sort} onToggle={toggle} align="right" />
+                      <SortableHeader label="Spent (MTD)" sortKey="spent_usd" current={sort} onToggle={toggle} align="right" />
+                      <SortableHeader label="% Used" sortKey="pct_used" current={sort} onToggle={toggle} align="right" />
+                      <SortableHeader label="Action" sortKey="enforce" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Scope" sortKey="is_ai" current={sort} onToggle={toggle} />
+                      <th className="py-2 px-2 text-left text-xs text-gray-500 dark:text-gray-400">Filter</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paged.map((b) => (
+                      <tr
+                        key={b.budget_id}
+                        className="border-b border-gray-100 dark:border-gray-700/50 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      >
+                        <td className="py-2 px-2 font-medium">{b.display_name || b.budget_id}</td>
+                        <td className="py-2 px-2 text-gray-500 dark:text-gray-400">{b.time_period || '—'}</td>
+                        <td className="text-right py-2 px-2 tabular-nums">
+                          {b.max_threshold_usd ? fmtCost(b.max_threshold_usd) : '—'}
+                        </td>
+                        <td className="text-right py-2 px-2 tabular-nums">
+                          {b.spent_usd != null ? fmtCost(b.spent_usd) : <span className="text-gray-400 dark:text-gray-500">n/a</span>}
+                        </td>
+                        <td className="py-2 px-2">
+                          {b.pct_used != null ? (
+                            <div className="flex items-center gap-2">
+                              <div className="h-1.5 w-16 rounded bg-gray-200 dark:bg-gray-700 overflow-hidden">
+                                <div
+                                  className={`h-full ${b.pct_used >= 100 ? 'bg-red-500' : b.pct_used >= 80 ? 'bg-amber-500' : 'bg-green-500'}`}
+                                  style={{ width: `${Math.min(b.pct_used, 100)}%` }}
+                                />
+                              </div>
+                              <span className="tabular-nums text-xs">{b.pct_used.toFixed(0)}%</span>
+                            </div>
+                          ) : (
+                            <span className="text-gray-400 dark:text-gray-500 text-xs">n/a</span>
+                          )}
+                        </td>
+                        <td className="py-2 px-2">
+                          {b.enforce ? (
+                            <Badge variant="error" className="text-xs">Enforces</Badge>
+                          ) : b.alerting ? (
+                            <Badge variant="warning" className="text-xs">Alerts</Badge>
+                          ) : (
+                            <Badge variant="default" className="text-xs">None</Badge>
+                          )}
+                        </td>
+                        <td className="py-2 px-2">
+                          {b.is_ai && <Badge variant="info" className="text-xs">AI</Badge>}
+                        </td>
+                        <td className="py-2 px-2 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate" title={b.filter_summary}>
+                          {b.filter_summary}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <TablePagination
+                page={page}
+                totalItems={sorted.length}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+              />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/* ── Model Services (v3 UC securables + UC grants, OBO/UC-enforced) ── */
+
+function ModelServiceGrantsEditor({ fullName }: { fullName: string }) {
+  const { data, isLoading } = useModelServiceGrants(fullName)
+  const grants = data?.grants ?? []
+  if (isLoading) return <div className="px-4 py-2 text-xs text-gray-400 dark:text-gray-500">Loading grants…</div>
+  return (
+    <div className="px-4 py-3 space-y-2">
+      {data?.error && <div className="text-xs text-amber-600 dark:text-amber-400">{data.error}</div>}
+      <table className="w-full text-xs">
+        <tbody>
+          {grants.length === 0 && (
+            <tr><td className="py-1 text-gray-400 dark:text-gray-500">No direct grants</td></tr>
+          )}
+          {grants.map((g) => (
+            <tr key={g.principal} className="border-b border-gray-100 dark:border-gray-700/50 last:border-0">
+              <td className="py-1 font-mono">{g.principal}</td>
+              <td className="py-1">{g.privileges.map((p) => <Badge key={p} variant="info" className="text-[10px] mr-1">{p}</Badge>)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="text-[11px] text-gray-400 dark:text-gray-500">
+        Read-only — grant editing isn't enabled yet (needs the app service principal to have <code>MANAGE</code> on the model service).
+      </p>
+    </div>
+  )
+}
+
+function ModelServicesSection() {
+  const { data, isLoading } = useModelServices()
+  const services = data?.services ?? []
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const [q, setQ] = useState('')
+  const { sort, toggle } = useSort<string>('full_name', 'asc')
+
+  const filtered = useMemo(() => {
+    const n = q.trim().toLowerCase()
+    return n ? services.filter((s) => s.full_name.toLowerCase().includes(n) || (s.owner || '').toLowerCase().includes(n)) : services
+  }, [services, q])
+  const sorted = useMemo(() => sortRows(filtered, sort, (s: (typeof services)[number], k) => (s as any)[k]), [filtered, sort])
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
+
+  if (isLoading || services.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-db-red" />
+          Model Services
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">{services.length}</span>
+          <span className="group relative inline-flex">
+            <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
+            <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-80 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+              Unity Gateway model services — UC securables governed by Unity Catalog grants
+              (metastore-wide). <strong>Read-only</strong>: the list is discovered by the workflow
+              and grants are shown live. Editing is deferred (needs the app SP to have MANAGE, or
+              a UC scope Apps OBO can't yet carry).
+            </span>
+          </span>
+        </CardTitle>
+        <p className="text-[11px] text-gray-400 dark:text-gray-500">Expand a service to view and edit its UC grants.</p>
+      </CardHeader>
+      <CardContent>
+        <div className="relative mb-3 max-w-xs">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+          <input type="text" placeholder="Search model services…" value={q} onChange={(e) => { setQ(e.target.value); setPage(0) }} className="pl-8 pr-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 dark:text-gray-200 w-full" />
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b dark:border-gray-700">
+              <tr>
+                <SortableHeader label="Model Service" sortKey="full_name" current={sort} onToggle={toggle} />
+                <SortableHeader label="Owner" sortKey="owner" current={sort} onToggle={toggle} />
+                <th className="py-2 px-2 text-left text-xs text-gray-500 dark:text-gray-400">API Types</th>
+                <th className="py-2 px-2 text-right text-xs text-gray-500 dark:text-gray-400">Grants</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paged.map((s) => {
+                const open = expanded === s.full_name
+                return (
+                  <Fragment key={s.full_name}>
+                    <tr className="border-b border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer" onClick={() => setExpanded(open ? null : s.full_name)}>
+                      <td className="py-2 px-2 font-mono text-xs truncate max-w-[320px]" title={s.full_name}>{s.full_name}</td>
+                      <td className="py-2 px-2 text-gray-500 dark:text-gray-400 truncate max-w-[200px]" title={s.owner}>{s.owner || '—'}</td>
+                      <td className="py-2 px-2 text-gray-500 dark:text-gray-400 text-xs">{(s.supported_api_types || []).join(', ') || '—'}</td>
+                      <td className="py-2 px-2 text-right text-xs text-db-red">{open ? 'Hide' : 'View'}</td>
+                    </tr>
+                    {open && (
+                      <tr className="bg-gray-50/60 dark:bg-gray-800/30">
+                        <td colSpan={4}><ModelServiceGrantsEditor fullName={s.full_name} /></td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── Endpoints Inventory (account-wide, read-only) ─────────────── */
+
+function EndpointInventorySection() {
+  const { data, isLoading } = useEndpointInventory()
+  const endpoints = data?.endpoints ?? []
+  const totals = data?.totals ?? {}
+  const hasData = endpoints.length > 0
+
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(20)
+  const [q, setQ] = useState('')
+  const { sort, toggle } = useSort<string>('change_time')
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase()
+    if (!needle) return endpoints
+    return endpoints.filter((e) =>
+      [e.endpoint_name, e.entity_name, e.workspace_id, e.created_by, e.entity_type, e.provider]
+        .some((v) => (v || '').toLowerCase().includes(needle)),
+    )
+  }, [endpoints, q])
+
+  const sorted = useMemo(
+    () => sortRows(filtered, sort, (e: (typeof endpoints)[number], k) => (e as any)[k]),
+    [filtered, sort],
+  )
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
+
+  const typeVariant = (t: string): 'info' | 'warning' | 'success' | 'default' =>
+    t === 'FOUNDATION_MODEL' ? 'info' : t === 'EXTERNAL_MODEL' ? 'warning' : t === 'CUSTOM_MODEL' ? 'success' : 'default'
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Server className="w-4 h-4 text-db-red" />
+            Account-wide Endpoints
+            <span className="group relative inline-flex">
+              <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-80 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+              >
+                Every served entity across all workspaces in the metastore, from{' '}
+                <code>system.serving.served_entities</code>. <strong>Read-only</strong> — live
+                management (permissions, gateway config) is per-workspace via the Serving API; the
+                other tabs act on this workspace only.
+              </span>
+            </span>
+            {data?.as_of && (
+              <span className="ml-auto text-[10px] font-normal text-gray-400 dark:text-gray-500">as of {formatAsOf(data.as_of)}</span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading…</div>
+          ) : !hasData ? (
+            <div className="py-12 text-center text-gray-400 dark:text-gray-500">
+              No endpoint inventory yet — the discovery workflow hasn't synced{' '}
+              <code>system.serving.served_entities</code>, or it isn't readable at the discovery scope.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-5">
+                <KpiCard title="Served Entities" value={totals.served_entity_count ?? 0} />
+                <KpiCard title="Endpoints" value={totals.endpoint_count ?? 0} />
+                <KpiCard title="Workspaces" value={totals.workspace_count ?? 0} />
+                <KpiCard title="Foundation" value={totals.foundation_count ?? 0} />
+                <KpiCard title="Custom / External" value={`${totals.custom_count ?? 0} / ${totals.external_count ?? 0}`} />
+              </div>
+              <div className="relative mb-3 max-w-xs">
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                <input
+                  type="text"
+                  placeholder="Search endpoints…"
+                  value={q}
+                  onChange={(e) => { setQ(e.target.value); setPage(0) }}
+                  className="pl-8 pr-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 dark:text-gray-200 w-full"
+                />
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-gray-200 dark:border-gray-700">
+                    <tr>
+                      <SortableHeader label="Endpoint" sortKey="endpoint_name" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Workspace" sortKey="workspace_id" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Type" sortKey="entity_type" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Model" sortKey="entity_name" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Creator" sortKey="created_by" current={sort} onToggle={toggle} />
+                      <SortableHeader label="Changed" sortKey="change_time" current={sort} onToggle={toggle} align="right" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paged.map((e, i) => (
+                      <tr
+                        key={`${e.endpoint_name}-${e.entity_name}-${i}`}
+                        className="border-b border-gray-100 dark:border-gray-700/50 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      >
+                        <td className="py-2 px-2 font-medium">{e.endpoint_name}</td>
+                        <td className="py-2 px-2 text-gray-500 dark:text-gray-400 tabular-nums">{e.workspace_id}</td>
+                        <td className="py-2 px-2"><Badge variant={typeVariant(e.entity_type)} className="text-xs">{e.entity_type || '—'}</Badge></td>
+                        <td className="py-2 px-2 text-gray-600 dark:text-gray-300">{e.provider ? `${e.provider}: ${e.entity_name}` : e.entity_name || '—'}</td>
+                        <td className="py-2 px-2 text-gray-500 dark:text-gray-400 max-w-[12rem] truncate" title={e.created_by}>{e.created_by || '—'}</td>
+                        <td className="text-right py-2 px-2 text-gray-500 dark:text-gray-400 whitespace-nowrap">{e.change_time ? formatAsOf(e.change_time) : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/* ── Unity Gateway Section ───────────────────────── */
 
 function UagV2Section() {
   const { data: uag, isLoading } = useUagV2Usage()
@@ -221,11 +645,11 @@ function UagV2Section() {
       <Card>
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
-            Unity AI Gateway (Beta) Usage
+            Unity Gateway Usage
             <span className="group relative inline-flex">
               <Info className="w-3.5 h-3.5 text-gray-400 cursor-help" tabIndex={0} />
               <span role="tooltip" className="pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-72 rounded-lg border border-gray-200 bg-white p-3 text-left text-[11px] font-normal leading-relaxed text-gray-600 shadow-lg group-hover:block group-focus-within:block dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                Only requests routed through <strong>Unity AI Gateway</strong> endpoints (~20-min fresh) — a subset of all serving. Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
+                Only requests routed through <strong>Unity Gateway</strong> endpoints (~20-min fresh) — a subset of all serving. Broader serving usage is under <strong>Metrics</strong>; dollar cost is under <strong>Governance</strong>. Cached-token % and TTFB come only from this source.
               </span>
             </span>
             {uag?.as_of && (
@@ -240,7 +664,7 @@ function UagV2Section() {
             <div className="py-12 text-center text-gray-400 dark:text-gray-500">Loading…</div>
           ) : !hasData ? (
             <div className="py-12 text-center text-gray-400 dark:text-gray-500">
-              No Unity AI Gateway usage yet — either no gateway-routed traffic in this workspace, or the discovery workflow hasn't synced <code>system.ai_gateway.usage</code> yet.
+              No Unity Gateway usage yet — either no gateway-routed traffic in this workspace, or the discovery workflow hasn't synced <code>system.ai_gateway.usage</code> yet.
             </div>
           ) : (
             <>
@@ -251,6 +675,9 @@ function UagV2Section() {
                 <KpiCard title="Cached Tokens" value={uag!.totals.cached_tokens ?? 0} format="number" />
                 <KpiCard title="Cache Read %" value={uag!.totals.cache_read_pct ?? 0} format="percentage" />
                 <KpiCard title="Endpoints" value={uag!.totals.endpoints ?? 0} format="number" />
+              </div>
+              <div className="mb-4">
+                <UagV2TrendCard />
               </div>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
@@ -351,7 +778,6 @@ function UagV2Section() {
         </div>
       )}
 
-      <UagV2TrendCard />
       <CodingAgentsCard />
       <UagMcpToolsCard />
       <GuardrailCoverageCard />
@@ -466,7 +892,7 @@ function GuardrailCoverageCard() {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          Endpoints with Unity AI Gateway guardrails running + the judge model evaluating them.
+          Endpoints with Unity Gateway guardrails running + the judge model evaluating them.
           Coverage &amp; activity only — block/mask outcomes require UAG feature-results (enrollment-gated).
           {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
@@ -538,7 +964,7 @@ function ThrottlingCard() {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          Endpoints returning HTTP 429 (rate-limited) or 5xx (server error) through Unity AI Gateway.
+          Endpoints returning HTTP 429 (rate-limited) or 5xx (server error) through Unity Gateway.
           Only endpoints with at least one 429/5xx are shown; rates are per-endpoint (share of that endpoint's own requests).
           {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
@@ -668,7 +1094,7 @@ function UagMcpToolsCard() {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          MCP tool invocations governed through Unity AI Gateway
+          MCP tool invocations governed through Unity Gateway
           {mcp?.as_of && <> · as of {formatAsOf(mcp.as_of)}</>}
         </p>
       </CardHeader>

--- a/control-plane-app/frontend/src/pages/Governance.tsx
+++ b/control-plane-app/frontend/src/pages/Governance.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
-  useAgents,
   useBillingPageData,
   useBillingRefresh,
   useBillingCacheStatus,
@@ -19,7 +18,7 @@ import { LineChart } from '@/components/charts/LineChart'
 import { BarChart } from '@/components/charts/BarChart'
 import { PieChart } from '@/components/charts/PieChart'
 import { DB_CHART } from '@/lib/brand'
-import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, BarChart3, Layers, Globe, RefreshCw, Users, Info, Tag, Boxes } from 'lucide-react'
+import { LayoutDashboard, Zap, Server, ChevronDown, ChevronRight, Layers, Globe, RefreshCw, Users, Info, Tag, Boxes } from 'lucide-react'
 
 /* ── helpers ──────────────────────────────────────────────────── */
 
@@ -57,7 +56,6 @@ const TABS = [
   { key: 'endpoints', label: 'Endpoint Costs', icon: Server },
   { key: 'tokens', label: 'Token Usage', icon: Zap },
   { key: 'products', label: 'All Products', icon: Layers },
-  { key: 'guardrails', label: 'Guardrails', icon: BarChart3 },
 ] as const
 
 type TabKey = (typeof TABS)[number]['key']
@@ -233,7 +231,6 @@ export default function GovernancePage() {
       {tab === 'endpoints' && <EndpointCostsTab data={pageData} />}
       {tab === 'tokens' && <TokenUsageTab data={pageData} />}
       {tab === 'products' && <AllProductsTab data={pageData} />}
-      {tab === 'guardrails' && <GuardrailsTab />}
     </div>
   )
 }
@@ -404,10 +401,10 @@ function CostByUserSection({ costByUser, source = 'estimate' }: { costByUser: an
               >
                 <span className="mb-1 block font-semibold text-gray-900 dark:text-gray-100">How per-user cost is calculated</span>
                 <span className={`block ${source === 'actual' ? 'text-green-700 dark:text-green-300' : 'opacity-70'}`}>
-                  <strong>Actual</strong> — real per-user dollars attributed by Unity AI Gateway (<code>system.billing.usage</code>).
+                  <strong>Actual</strong> — real per-user dollars attributed by Unity Gateway (<code>system.billing.usage</code>).
                 </span>
                 <span className={`mt-1.5 block ${source === 'actual' ? 'opacity-70' : 'text-amber-700 dark:text-amber-300'}`}>
-                  <strong>Estimated</strong> — each endpoint’s total cost split across users by their share of tokens. Shown when AI Gateway v2 attribution isn’t available yet.
+                  <strong>Estimated</strong> — each endpoint’s total cost split across users by their share of tokens. Shown when Unity Gateway attribution isn’t available yet.
                 </span>
               </span>
             </span>
@@ -1137,7 +1134,7 @@ function ExternalModelSpendSection({ data }: { data?: BillingPageData }) {
           <span className="ml-1 text-xs font-normal text-gray-400">· {fmtCost(total)} total</span>
         </h3>
         <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-          Actual billed cost for external models (OpenAI, Microsoft Foundry, …) routed through the Unity AI Gateway.
+          Actual billed cost for external models (OpenAI, Microsoft Foundry, …) routed through the Unity Gateway.
           Real dollars from <code>system.ai_gateway.external_model_spend</code> — not estimated.
         </p>
       </div>
@@ -1194,86 +1191,3 @@ function ExternalModelSpendSection({ data }: { data?: BillingPageData }) {
   )
 }
 
-/* ── Guardrails Tab ───────────────────────────────────────────── */
-
-function GuardrailsTab() {
-  const { data: agents } = useAgents()
-
-  return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Rate Limiting Rules</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {agents?.map((agent: any) => (
-              <div
-                key={agent.agent_id}
-                className="flex items-center justify-between py-2 border-b border-gray-100 dark:border-gray-700/50 last:border-0"
-              >
-                <div>
-                  <div className="text-sm font-medium">{agent.name}</div>
-                  <div className="text-xs text-gray-400">{agent.type}</div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Badge variant="default" className="text-xs">
-                    {agent.config?.max_tokens_per_min || '∞'} tok/min
-                  </Badge>
-                  <Badge variant="default" className="text-xs">
-                    {agent.config?.max_requests_per_min || '∞'} req/min
-                  </Badge>
-                </div>
-              </div>
-            ))}
-            {(!agents || agents.length === 0) && (
-              <div className="text-gray-400 dark:text-gray-500 text-center py-4">No agents configured</div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Safety & Guardrails</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {[
-              {
-                name: 'Input Content Filter',
-                desc: 'Blocks harmful or inappropriate user inputs',
-                status: 'Enabled',
-              },
-              {
-                name: 'Output Content Filter',
-                desc: 'Screens agent responses for policy violations',
-                status: 'Enabled',
-              },
-              {
-                name: 'PII Detection',
-                desc: 'Redacts personally identifiable information',
-                status: 'Monitoring',
-              },
-              {
-                name: 'Prompt Injection Guard',
-                desc: 'Detects and blocks prompt injection attacks',
-                status: 'Enabled',
-              },
-            ].map((guard) => (
-              <div key={guard.name} className="flex items-center justify-between">
-                <div>
-                  <div className="text-sm font-medium">{guard.name}</div>
-                  <div className="text-xs text-gray-400">{guard.desc}</div>
-                </div>
-                <Badge variant={guard.status === 'Enabled' ? 'success' : 'warning'} className="text-xs">
-                  {guard.status}
-                </Badge>
-              </div>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  )
-}

--- a/control-plane-app/frontend/src/pages/Observability.tsx
+++ b/control-plane-app/frontend/src/pages/Observability.tsx
@@ -10,12 +10,7 @@ import {
   useMlflowModelVersions,
   useMlflowObservabilityWorkspaces,
   useWorkspaceHosts,
-  useGatewayLogs,
-  useGatewayLogSources,
-  useGatewayLogDetail,
-  useGatewayLogTimeseries,
   useAgentToolUsage,
-  useAgentEvalScores,
   useAiAudit,
 } from '@/api/hooks'
 import { usePersistedWorkspaceFilter } from '@/lib/usePersistedWorkspaceFilter'
@@ -66,7 +61,6 @@ import {
   Calendar,
   Info,
   Wrench,
-  ShieldCheck,
   ScrollText,
 } from 'lucide-react'
 import { DB_RED_SHADES } from '@/lib/brand'
@@ -164,11 +158,9 @@ function dataSourceBadge(source: string | undefined) {
 /* ── tab definitions ─────────────────────────────────────────── */
 const tabs = [
   { id: 'traces', label: 'Traces', icon: Search },
-  { id: 'gateway', label: 'Gateway Requests', icon: Activity },
   { id: 'experiments', label: 'Experiments', icon: FlaskConical },
   { id: 'runs', label: 'Evaluation Runs', icon: Activity },
   { id: 'tool-usage', label: 'Tool & Asset Usage', icon: Wrench },
-  { id: 'eval-scores', label: 'Quality & Evals', icon: ShieldCheck },
   { id: 'ai-audit', label: 'AI Audit', icon: ScrollText },
   { id: 'models', label: 'Model Registry', icon: Database },
 ] as const
@@ -266,11 +258,9 @@ export default function ObservabilityPage() {
 
       {/* Tab content */}
       {activeTab === 'traces' && <TracesPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
-      {activeTab === 'gateway' && <GatewayRequestsPanel />}
       {activeTab === 'experiments' && <ExperimentsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'runs' && <RunsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
       {activeTab === 'tool-usage' && <ToolUsagePanel />}
-      {activeTab === 'eval-scores' && <EvalScoresPanel />}
       {activeTab === 'ai-audit' && <AiAuditPanel />}
       {activeTab === 'models' && <ModelsPanel workspaceUrl={workspaceUrl} workspaceId={wsParam} workspaceHosts={workspaceHosts} />}
     </div>
@@ -347,109 +337,6 @@ function ToolUsagePanel() {
                     <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[220px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.call_count.toLocaleString()}</td>
                     <td className="py-1.5 text-right tabular-nums">{r.trace_count.toLocaleString()}</td>
-                    <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <TablePagination page={safePage} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
-        </CardContent>
-      </Card>
-    </div>
-  )
-}
-
-/* ── Quality & Evals Panel (F7) ──────────────────────────────────
-   MLflow-3 assessments (LLM-judge + human) rolled up per experiment from
-   agent_eval_scores: how each agent's traces score on safety, relevance,
-   groundedness, etc. Same experiment grain as tool usage. */
-function pctLabel(v: number | null | undefined): string {
-  return v == null ? '—' : `${Math.round(v * 100)}%`
-}
-function passRateClass(v: number | null | undefined): string {
-  if (v == null) return 'text-gray-400 dark:text-gray-500'
-  // Threshold on the same rounded percentage the label shows, so colour and
-  // number never disagree (e.g. 0.896 → "90%" reads green, not amber).
-  const pct = Math.round(v * 100)
-  if (pct >= 90) return 'text-green-600 dark:text-green-400'
-  if (pct >= 70) return 'text-amber-600 dark:text-amber-400'
-  return 'text-red-600 dark:text-red-400'
-}
-
-function EvalScoresPanel() {
-  const { data, isLoading } = useAgentEvalScores()
-  const sort = useSort('assessment_count', 'desc')
-  const [page, setPage] = useState(0)
-  const [pageSize, setPageSize] = useState(15)
-  const rows = data?.rows || []
-  const sorted = useMemo(() => sortRows(rows, sort.sort, (r: any, k) => {
-    if (k === 'assessment_count' || k === 'pass_count' || k === 'fail_count') return Number(r[k] || 0)
-    // Return null (not a sentinel) so sortRows pushes ungraded scorers to the
-    // bottom in both directions, instead of ranking them below a genuine 0%.
-    if (k === 'pass_rate') return r[k] == null ? null : Number(r[k])
-    return (r[k] || '').toString().toLowerCase()
-  }), [rows, sort.sort])
-  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize))
-  const safePage = Math.min(page, totalPages - 1)
-  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize)
-
-  if (isLoading) return <div className="flex items-center justify-center h-32 text-gray-400 dark:text-gray-500">Loading…</div>
-  if (rows.length === 0) {
-    return (
-      <Card><CardContent className="py-12 text-center text-gray-400 dark:text-gray-500">
-        No eval scores yet — agents need MLflow-3 assessments (LLM-judge or human labels) attached to their traces,
-        and the discovery workflow must have synced them. Sourced from the <code>assessments</code> on Databricks-native
-        <code> trace_logs</code> tables.
-      </CardContent></Card>
-    )
-  }
-  const t = data!.totals
-  return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        <KpiCard title="Experiments" value={t.experiments ?? 0} format="number" />
-        <KpiCard title="Scorers" value={t.scorers ?? 0} format="number" />
-        <KpiCard title="Assessments" value={t.assessments ?? 0} format="number" />
-        <KpiCard title="Overall Pass Rate" value={pctLabel(t.pass_rate)} />
-      </div>
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Quality & Eval Scores</CardTitle>
-          <p className="text-[11px] text-gray-400 dark:text-gray-500">
-            MLflow-3 assessments (LLM-judge & human) per scorer, rolled up by <strong>experiment</strong> — the app has no
-            experiment→agent mapping yet. Pass rate covers yes/no verdicts only; scorers with non-binary feedback show “—”.
-          </p>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-                  <SortableHeader label="Scorer" sortKey="scorer_name" current={sort.sort} onToggle={sort.toggle} />
-                  <SortableHeader label="Source" sortKey="source_type" current={sort.sort} onToggle={sort.toggle} />
-                  <SortableHeader label="Experiment" sortKey="experiment_name" current={sort.sort} onToggle={sort.toggle} />
-                  <SortableHeader label="Assessments" sortKey="assessment_count" current={sort.sort} onToggle={sort.toggle} align="right" />
-                  <SortableHeader label="Pass" sortKey="pass_count" current={sort.sort} onToggle={sort.toggle} align="right" />
-                  <SortableHeader label="Fail" sortKey="fail_count" current={sort.sort} onToggle={sort.toggle} align="right" />
-                  <SortableHeader label="Pass Rate" sortKey="pass_rate" current={sort.sort} onToggle={sort.toggle} align="right" />
-                  <SortableHeader label="Last Seen" sortKey="last_seen" current={sort.sort} onToggle={sort.toggle} align="right" />
-                </tr>
-              </thead>
-              <tbody>
-                {paged.map((r: any, i: number) => (
-                  <tr key={`${r.experiment_id}-${r.scorer_name}-${r.source_type}-${i}`} className="border-b border-gray-50 dark:border-gray-800 last:border-0">
-                    <td className="py-1.5 font-medium truncate max-w-[220px]" title={r.scorer_name}>{r.scorer_name}</td>
-                    <td className="py-1.5">
-                      <Badge variant={r.source_type === 'HUMAN' ? 'info' : 'default'} className="text-xs">
-                        {r.source_type === 'HUMAN' ? 'Human' : r.source_type === 'LLM_JUDGE' ? 'LLM judge' : (r.source_type || '—')}
-                      </Badge>
-                    </td>
-                    <td className="py-1.5 text-gray-600 dark:text-gray-400 truncate max-w-[200px]" title={r.experiment_name || r.experiment_id}>{r.experiment_name || r.experiment_id || '—'}</td>
-                    <td className="py-1.5 text-right tabular-nums">{r.assessment_count.toLocaleString()}</td>
-                    <td className="py-1.5 text-right tabular-nums text-green-600 dark:text-green-400">{r.pass_count.toLocaleString()}</td>
-                    <td className="py-1.5 text-right tabular-nums text-red-600 dark:text-red-400">{r.fail_count.toLocaleString()}</td>
-                    <td className={`py-1.5 text-right tabular-nums font-medium ${passRateClass(r.pass_rate)}`}>{pctLabel(r.pass_rate)}</td>
                     <td className="py-1.5 text-right text-xs text-gray-500 dark:text-gray-400 tabular-nums">{r.last_seen ? r.last_seen.slice(0, 10) : '—'}</td>
                   </tr>
                 ))}
@@ -2839,12 +2726,11 @@ function RunMetricTrends({ runs }: { runs: any[] }) {
   )
 }
 
-/* ── Gateway Requests time-series ─────────────────────────────── */
+/* ── MiniLineChart (shared inline chart) ──────────────────────── */
 
-/** A small line chart for one metric over time. Used in a 4-up grid above
- *  the Gateway Requests list (request rate / P95 latency / errors / tokens).
- *  Inline-recharts because the shared LineChart wrapper only supports a
- *  single 'value' field. */
+/** A small line chart for one metric over time (used by the Runs "Metric
+ *  trends" grid). Inline-recharts because the shared LineChart wrapper only
+ *  supports a single 'value' field. */
 function MiniLineChart({
   data, dataKey, name, color, height = 110, valueFormatter,
 }: {
@@ -2873,325 +2759,3 @@ function MiniLineChart({
   )
 }
 
-function GatewayTimeSeries({ windowDays, sourceTable }: { windowDays: number; sourceTable: string | null }) {
-  // Choose bucket size: hourly for 1d, daily for >7d, hourly otherwise.
-  const bucket: 'hour' | 'day' = windowDays >= 14 ? 'day' : 'hour'
-  const { data: rows, isLoading } = useGatewayLogTimeseries(windowDays, sourceTable, bucket)
-  if (isLoading) {
-    return (
-      <Card>
-        <CardContent className="py-6 text-xs text-gray-400 text-center flex items-center justify-center gap-2">
-          <Loader2 className="w-4 h-4 animate-spin" /> Loading trend data…
-        </CardContent>
-      </Card>
-    )
-  }
-  const list = rows || []
-  if (!list.length) return null
-
-  // Aggregate across endpoints when no specific filter; preserve per-endpoint
-  // when one source_table is selected. Group by bucket.
-  const byBucket = new Map<string, any>()
-  for (const r of list) {
-    const key = r.bucket
-    const cur = byBucket.get(key) || { bucket: key, requests: 0, errors: 0, total_tokens: 0, p95_acc: [], avg_acc: [] }
-    cur.requests += Number(r.requests || 0)
-    cur.errors += Number(r.errors || 0)
-    cur.total_tokens += Number(r.total_tokens || 0)
-    if (r.p95_ms != null) cur.p95_acc.push(Number(r.p95_ms))
-    if (r.avg_ms != null) cur.avg_acc.push(Number(r.avg_ms))
-    byBucket.set(key, cur)
-  }
-  const merged = Array.from(byBucket.values()).sort((a, b) => a.bucket.localeCompare(b.bucket))
-  // Take the max p95 across endpoints for that bucket — that's the worst-
-  // case latency anyone saw in that window. Avg is a simple mean.
-  for (const m of merged) {
-    m.p95_ms = m.p95_acc.length ? Math.round(Math.max(...m.p95_acc)) : null
-    m.avg_ms = m.avg_acc.length ? Math.round(m.avg_acc.reduce((s: number, n: number) => s + n, 0) / m.avg_acc.length) : null
-    m.error_rate = m.requests > 0 ? (m.errors / m.requests) * 100 : 0
-    m.bucket_label = (() => {
-      const t = Date.parse(m.bucket)
-      if (!Number.isFinite(t)) return m.bucket
-      return bucket === 'hour' ? format(new Date(t), 'MM-dd HH:mm') : format(new Date(t), 'MM-dd')
-    })()
-  }
-
-  const totalRequests = merged.reduce((s, m) => s + m.requests, 0)
-  const totalErrors = merged.reduce((s, m) => s + m.errors, 0)
-  const totalTokens = merged.reduce((s, m) => s + m.total_tokens, 0)
-
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base flex items-center gap-2">
-          <BarChart3 className="w-4 h-4" /> Trends
-          <span className="text-[11px] text-gray-500 dark:text-gray-400 font-normal ml-2">
-            {sourceTable ? sourceTable.split('.').pop() : 'all endpoints'} · last {windowDays}d · per {bucket}
-            <span className="ml-2">· {totalRequests.toLocaleString()} requests · {totalErrors.toLocaleString()} errors · {totalTokens.toLocaleString()} tokens</span>
-          </span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <div>
-            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Requests</div>
-            <MiniLineChart data={merged} dataKey="requests" name="Requests" color="#dc2626" />
-          </div>
-          <div>
-            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">P95 Latency</div>
-            <MiniLineChart data={merged} dataKey="p95_ms" name="P95 ms" color="#7c3aed"
-                           valueFormatter={(v) => v == null ? '—' : (Number(v) >= 1000 ? `${(Number(v)/1000).toFixed(1)}s` : `${v}ms`)} />
-          </div>
-          <div>
-            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Error Rate</div>
-            <MiniLineChart data={merged} dataKey="error_rate" name="Error %" color="#f59e0b"
-                           valueFormatter={(v) => v == null ? '—' : `${Number(v).toFixed(1)}%`} />
-          </div>
-          <div>
-            <div className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Tokens</div>
-            <MiniLineChart data={merged} dataKey="total_tokens" name="Tokens" color="#0ea5e9"
-                           valueFormatter={(v) => Number(v).toLocaleString()} />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-/* ── Gateway Requests Panel (Tier 2a) ─────────────────────────── */
-
-const GATEWAY_WINDOW_OPTIONS = [1, 7, 30, 90, 180, 365] as const
-type GatewayWindow = (typeof GATEWAY_WINDOW_OPTIONS)[number]
-
-function GatewayRequestsPanel() {
-  const [windowDays, setWindowDays] = useState<GatewayWindow>(7)
-  const [sourceFilter, setSourceFilter] = useState<string | null>(null)
-  const [selected, setSelected] = useState<{ source_table: string; request_id: string } | null>(null)
-  const [page, setPage] = useState(0)
-  const [pageSize, setPageSize] = useState(10)
-
-  const { data: rows, isLoading } = useGatewayLogs(windowDays, sourceFilter)
-  const { data: sources } = useGatewayLogSources()
-
-  const list = rows || []
-  const okCount = list.filter((r: any) => r.status_code != null && r.status_code < 400).length
-  const errCount = list.filter((r: any) => r.status_code != null && r.status_code >= 400).length
-  const avgLatency =
-    list.length > 0
-      ? list.reduce((sum: number, r: any) => sum + (Number(r.execution_ms) || 0), 0) / list.length
-      : 0
-
-  if (selected) {
-    return (
-      <GatewayRequestDetailView
-        sourceTable={selected.source_table}
-        requestId={selected.request_id}
-        onBack={() => setSelected(null)}
-      />
-    )
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-        <KpiCard title="Total Requests" value={list.length} format="number" />
-        <KpiCard title="Successful" value={okCount} format="number" />
-        <KpiCard title="Errors" value={errCount} format="number" />
-        <KpiCard title="Avg Latency" value={avgLatency} format="duration" />
-      </div>
-
-      <GatewayTimeSeries windowDays={windowDays} sourceTable={sourceFilter} />
-
-      <Card>
-        <CardHeader className="pb-3 flex flex-row items-center justify-between gap-3 flex-wrap">
-          <CardTitle className="text-base">AI Gateway / Inference Requests</CardTitle>
-          <div className="flex items-center gap-3">
-            <select
-              value={sourceFilter || ''}
-              onChange={(e) => { setSourceFilter(e.target.value || null); setPage(0) }}
-              className="text-xs px-2 py-1 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
-            >
-              <option value="">All endpoints ({(sources || []).length})</option>
-              {(sources || []).map((s: any) => (
-                <option key={s.source_table} value={s.source_table}>
-                  {s.source_table.split('.').pop()} ({s.row_count})
-                </option>
-              ))}
-            </select>
-            <div className="inline-flex items-center gap-1 text-xs">
-              <span className="text-gray-500 dark:text-gray-400 mr-1">Window:</span>
-              {GATEWAY_WINDOW_OPTIONS.map((d) => (
-                <button
-                  key={d}
-                  onClick={() => { setWindowDays(d); setPage(0) }}
-                  className={`px-2 py-1 rounded font-medium transition-colors ${
-                    windowDays === d
-                      ? 'bg-db-red text-white'
-                      : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
-                  }`}
-                >
-                  {d}d
-                </button>
-              ))}
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12 text-gray-400">
-              <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading inference logs…
-            </div>
-          ) : list.length === 0 ? (
-            <div className="text-sm text-gray-400 text-center py-12">
-              No gateway/inference logs found. Enable AI Gateway request logging on your endpoints, or pick a wider window.
-            </div>
-          ) : (
-            <>
-              <div className="divide-y divide-gray-100 dark:divide-gray-700">
-                <div className="grid grid-cols-12 gap-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                  <div className="col-span-2">Endpoint</div>
-                  <div className="col-span-2">Request ID</div>
-                  <div className="col-span-2">Time</div>
-                  <div className="col-span-2">Model</div>
-                  <div>Status</div>
-                  <div className="text-right">Latency</div>
-                  <div className="text-right">Tokens</div>
-                  <div>Requester</div>
-                </div>
-                {(() => {
-                  const totalPages = Math.max(1, Math.ceil(list.length / pageSize))
-                  const safePage = Math.min(page, totalPages - 1)
-                  const paged = list.slice(safePage * pageSize, (safePage + 1) * pageSize)
-                  return paged.map((r: any) => {
-                    const rid = r.request_id || ''
-                    const endpoint = (r.source_table || '').split('.').pop() || ''
-                    const status = r.status_code
-                    const isErr = status != null && status >= 400
-                    const modelShort = r.model ? (r.model.length > 22 ? r.model.slice(0, 22) + '…' : r.model) : '—'
-                    return (
-                      <div
-                        key={`${r.source_table}::${rid}`}
-                        className="grid grid-cols-12 gap-3 py-3 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/40"
-                        onClick={() => setSelected({ source_table: r.source_table, request_id: rid })}
-                      >
-                        <div className="col-span-2 truncate font-mono text-xs" title={r.source_table}>{endpoint}</div>
-                        <div className="col-span-2 truncate font-mono text-xs">{rid.slice(0, 36)}</div>
-                        <div className="col-span-2 text-xs text-gray-500">
-                          {r.request_time ? format(new Date(r.request_time), 'yyyy-MM-dd HH:mm:ss') : '—'}
-                        </div>
-                        <div className="col-span-2 truncate text-xs text-gray-600 dark:text-gray-300" title={r.model || ''}>{modelShort}</div>
-                        <div>
-                          <Badge variant={isErr ? 'error' : status != null ? 'success' : 'default'} className="text-[10px]">
-                            {status ?? '—'}
-                          </Badge>
-                        </div>
-                        <div className="text-xs text-right">{r.execution_ms != null ? msToReadable(Number(r.execution_ms)) : '—'}</div>
-                        <div className="text-xs text-right text-gray-600 dark:text-gray-300"
-                             title={r.input_tokens != null ? `in ${r.input_tokens} / out ${r.output_tokens || 0}` : ''}>
-                          {r.total_tokens != null ? Number(r.total_tokens).toLocaleString() : '—'}
-                        </div>
-                        <div className="truncate text-xs text-gray-500" title={r.requester || ''}>
-                          {r.requester || '—'}
-                        </div>
-                      </div>
-                    )
-                  })
-                })()}
-              </div>
-              <TablePagination page={page} totalItems={list.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
-            </>
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  )
-}
-
-function GatewayRequestDetailView({
-  sourceTable, requestId, onBack,
-}: { sourceTable: string; requestId: string; onBack: () => void }) {
-  const { data: detail, isLoading } = useGatewayLogDetail(sourceTable, requestId)
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12 text-gray-400">
-        <Loader2 className="w-6 h-6 animate-spin mr-3" /> Loading request detail…
-      </div>
-    )
-  }
-  if (!detail) {
-    return (
-      <div className="space-y-4">
-        <button onClick={onBack} className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
-          <ArrowLeft className="w-4 h-4" /> Back to gateway requests
-        </button>
-        <Card><CardContent className="py-12 text-center text-gray-400">
-          Request detail not found.
-        </CardContent></Card>
-      </div>
-    )
-  }
-
-  const statusCode = (detail as any).status_code
-  const isErr = statusCode != null && statusCode >= 400
-
-  return (
-    <div className="space-y-4">
-      <button onClick={onBack} className="flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
-        <ArrowLeft className="w-4 h-4" /> Back to gateway requests
-      </button>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base flex items-center gap-2">
-            <span className="font-mono text-sm">{(detail as any).request_id}</span>
-            <Badge variant={isErr ? 'error' : 'success'} className="text-[10px]">
-              {statusCode ?? '—'}
-            </Badge>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-xs">
-            <MetadataRow label="Endpoint" value={(detail as any).source_table} />
-            <MetadataRow label="Model" value={(detail as any).model || '—'} />
-            <MetadataRow label="Latency" value={(detail as any).execution_ms != null ? msToReadable(Number((detail as any).execution_ms)) : '—'} />
-            <MetadataRow label="Time" value={(detail as any).request_time ? format(new Date((detail as any).request_time), 'yyyy-MM-dd HH:mm:ss') : '—'} />
-            <MetadataRow label="Total Tokens" value={(detail as any).total_tokens != null ? Number((detail as any).total_tokens).toLocaleString() : '—'} />
-            <MetadataRow label="Input / Output" value={(detail as any).input_tokens != null ? `${(detail as any).input_tokens} / ${(detail as any).output_tokens || 0}` : '—'} />
-            <MetadataRow label="Finish Reason" value={(detail as any).finish_reason || '—'} />
-            <MetadataRow label="Tool Calls" value={(detail as any).tool_call_count != null ? String((detail as any).tool_call_count) : '—'} />
-            <MetadataRow label="Requester" value={(detail as any).requester || '—'} />
-            <MetadataRow label="Served Entity" value={(detail as any).served_entity_id || '—'} />
-            <MetadataRow label="Client Request ID" value={(detail as any).client_request_id || '—'} />
-            <MetadataRow label="Request Size" value={(detail as any).request_size_bytes != null ? `${(detail as any).request_size_bytes} B` : '—'} />
-            <MetadataRow label="Response Size" value={(detail as any).response_size_bytes != null ? `${(detail as any).response_size_bytes} B` : '—'} />
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2"><CardTitle className="text-base">Request payload</CardTitle></CardHeader>
-        <CardContent>
-          <pre className="text-xs font-mono overflow-auto max-h-96 bg-gray-50 dark:bg-gray-800 p-3 rounded">
-            {(() => {
-              const v = (detail as any).request_payload || ''
-              try { return JSON.stringify(JSON.parse(v), null, 2) } catch { return v || '(empty)' }
-            })()}
-          </pre>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2"><CardTitle className="text-base">Response payload</CardTitle></CardHeader>
-        <CardContent>
-          <pre className="text-xs font-mono overflow-auto max-h-96 bg-gray-50 dark:bg-gray-800 p-3 rounded">
-            {(() => {
-              const v = (detail as any).response_payload || ''
-              try { return JSON.stringify(JSON.parse(v), null, 2) } catch { return v || '(empty)' }
-            })()}
-          </pre>
-        </CardContent>
-      </Card>
-    </div>
-  )
-}

--- a/control-plane-app/frontend/src/pages/Tools.tsx
+++ b/control-plane-app/frontend/src/pages/Tools.tsx
@@ -500,19 +500,27 @@ export default function ToolsPage() {
   )
 }
 
-/* MCP usage via Unity AI Gateway v2 (uag_mcp_tool_daily). Server-grouped, with a
+/* MCP usage via Unity Gateway v2 (uag_mcp_tool_daily). Server-grouped, with a
  * managed (system.ai.*) vs UC-registered split — a distinct namespace from the
  * connection inventory below, so it's shown as its own panel. Hidden when no MCP
  * traffic has routed through the gateway. */
 function McpUsageSection({ query }: { query: string }) {
   const { data, isLoading } = useMcpActivity()
   const [expanded, setExpanded] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(10)
+  const { sort, toggle } = useSort<string>('request_count', 'desc')
   const q = query.trim().toLowerCase()
   const servers = (data?.servers || []).filter((s) =>
     !q ||
     s.service_name.toLowerCase().includes(q) ||
     s.tools.some((t) => t.tool_name.toLowerCase().includes(q))
   )
+  const sorted = useMemo(
+    () => sortRows(servers, sort, (s: any, k) => (k === 'managed' ? (s.managed ? 1 : 0) : (s as any)[k])),
+    [servers, sort],
+  )
+  const paged = sorted.slice(page * pageSize, (page + 1) * pageSize)
   if (isLoading || servers.length === 0) return null
 
   return (
@@ -525,7 +533,7 @@ function McpUsageSection({ query }: { query: string }) {
           </span>
         </CardTitle>
         <p className="text-[11px] text-gray-400 dark:text-gray-500">
-          MCP tool calls governed through Unity AI Gateway v2 (distinct from the configured connections below)
+          MCP tool calls governed through Unity Gateway (distinct from the configured connections below)
           {data?.as_of && <> · as of {formatAsOf(data.as_of)}</>}
         </p>
       </CardHeader>
@@ -533,16 +541,16 @@ function McpUsageSection({ query }: { query: string }) {
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b dark:border-gray-700 text-left text-gray-500 dark:text-gray-400">
-                <th className="py-2 font-medium">MCP Service</th>
-                <th className="py-2 font-medium">Class</th>
-                <th className="py-2 font-medium text-right">Tools</th>
-                <th className="py-2 font-medium text-right">Requests</th>
-                <th className="py-2 font-medium text-right">Errors</th>
+              <tr className="border-b dark:border-gray-700">
+                <SortableHeader label="MCP Service" sortKey="service_name" current={sort} onToggle={toggle} />
+                <SortableHeader label="Class" sortKey="managed" current={sort} onToggle={toggle} />
+                <SortableHeader label="Tools" sortKey="tool_count" current={sort} onToggle={toggle} align="right" />
+                <SortableHeader label="Requests" sortKey="request_count" current={sort} onToggle={toggle} align="right" />
+                <SortableHeader label="Errors" sortKey="error_count" current={sort} onToggle={toggle} align="right" />
               </tr>
             </thead>
             <tbody>
-              {servers.map((s) => {
+              {paged.map((s) => {
                 const open = expanded === s.service_name
                 return (
                   <Fragment key={s.service_name}>
@@ -578,7 +586,7 @@ function McpUsageSection({ query }: { query: string }) {
                               </tr>
                             </thead>
                             <tbody>
-                              {s.tools.map((t, i) => (
+                              {s.tools.map((t: any, i: number) => (
                                 <tr key={`${s.service_name}:${t.tool_name}:${i}`}>
                                   <td className="py-1">{t.tool_name || <span className="text-gray-400">(server)</span>}</td>
                                   <td className="py-1 text-right tabular-nums">{t.request_count.toLocaleString()}</td>
@@ -597,6 +605,7 @@ function McpUsageSection({ query }: { query: string }) {
             </tbody>
           </table>
         </div>
+        <TablePagination page={page} totalItems={sorted.length} pageSize={pageSize} onPageChange={setPage} onPageSizeChange={setPageSize} />
       </CardContent>
     </Card>
   )

--- a/control-plane-app/package.json
+++ b/control-plane-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "control-plane-app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/control-plane-app/pyproject.toml
+++ b/control-plane-app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "control-plane-app"
-version = "0.1.2"
+version = "0.1.3"
 description = "AI Agent Control Plane - FastAPI Backend"
 requires-python = ">=3.11"
 dependencies = [

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -679,9 +679,15 @@ with obs_conn.cursor() as cur:
         """CREATE TABLE IF NOT EXISTS agent_tool_usage (
             experiment_id TEXT, tool_name TEXT NOT NULL, span_type TEXT NOT NULL,
             call_count BIGINT DEFAULT 0, trace_count BIGINT DEFAULT 0,
+            error_count BIGINT DEFAULT 0, total_latency_ms DOUBLE PRECISION DEFAULT 0,
             last_seen TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
         "CREATE INDEX IF NOT EXISTS idx_atu_exp ON agent_tool_usage (experiment_id)",
+        # Reconcile the error/latency columns onto pre-existing tables (CREATE IF
+        # NOT EXISTS is a no-op when the table already exists). Workflow-owned, so
+        # the workflow can ALTER it.
+        "ALTER TABLE agent_tool_usage ADD COLUMN IF NOT EXISTS error_count BIGINT DEFAULT 0",
+        "ALTER TABLE agent_tool_usage ADD COLUMN IF NOT EXISTS total_latency_ms DOUBLE PRECISION DEFAULT 0",
         """CREATE TABLE IF NOT EXISTS mlflow_registered_models (
             name TEXT NOT NULL, workspace_id TEXT, user_id TEXT,
             last_updated_timestamp BIGINT, creation_timestamp BIGINT,
@@ -1180,13 +1186,15 @@ try:
     # insert rolls back the truncate rather than leaving the table empty.
     atu_rows = spark.read.table(TOOL_USAGE_DELTA).collect()
     values = [(r.experiment_id, r.tool_name, r.span_type, int(r.call_count or 0),
-               int(r.trace_count or 0), r.last_seen, now) for r in atu_rows]
+               int(r.trace_count or 0), int(getattr(r, "error_count", 0) or 0),
+               float(getattr(r, "total_latency_ms", 0.0) or 0.0), r.last_seen, now) for r in atu_rows]
     with obs_conn.cursor() as cur:
         cur.execute("TRUNCATE TABLE agent_tool_usage")
         if values:
             execute_values(cur,
                 """INSERT INTO agent_tool_usage
-                   (experiment_id, tool_name, span_type, call_count, trace_count, last_seen, last_synced)
+                   (experiment_id, tool_name, span_type, call_count, trace_count,
+                    error_count, total_latency_ms, last_seen, last_synced)
                    VALUES %s""",
                 values, page_size=500)
     obs_conn.commit()

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -682,7 +682,7 @@ with obs_conn.cursor() as cur:
             last_seen TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
         "CREATE INDEX IF NOT EXISTS idx_atu_exp ON agent_tool_usage (experiment_id)",
-        """CREATE TABLE IF NOT EXISTS model_registry (
+        """CREATE TABLE IF NOT EXISTS mlflow_registered_models (
             name TEXT NOT NULL, workspace_id TEXT, user_id TEXT,
             last_updated_timestamp BIGINT, creation_timestamp BIGINT,
             description TEXT, aliases JSONB, latest_versions JSONB,
@@ -1275,10 +1275,10 @@ except Exception as exc:
     obs_conn.rollback()
     print(f"  ⚠️  ai_audit_recent sync failed: {exc}")
 
-# Sync model_registry (UC registered models from 04_discover_observability).
-MODEL_REGISTRY_DELTA = f"{CATALOG}.{SCHEMA}.model_registry"
+# Sync mlflow_registered_models (UC registered models from 04_discover_observability).
+MODEL_REGISTRY_DELTA = f"{CATALOG}.{SCHEMA}.mlflow_registered_models"
 mr_count = 0
-print(f"▸ Syncing {MODEL_REGISTRY_DELTA} → model_registry ...")
+print(f"▸ Syncing {MODEL_REGISTRY_DELTA} → mlflow_registered_models ...")
 try:
     mr_rows = spark.read.table(MODEL_REGISTRY_DELTA).collect()
     values = [(r.name, r.workspace_id, r.user_id,
@@ -1286,10 +1286,10 @@ try:
                int(r.creation_timestamp) if r.creation_timestamp is not None else None,
                r.description, r.aliases, r.latest_versions, now) for r in mr_rows]
     with obs_conn.cursor() as cur:
-        cur.execute("TRUNCATE TABLE model_registry")
+        cur.execute("TRUNCATE TABLE mlflow_registered_models")
         if values:
             execute_values(cur,
-                """INSERT INTO model_registry
+                """INSERT INTO mlflow_registered_models
                    (name, workspace_id, user_id, last_updated_timestamp, creation_timestamp,
                     description, aliases, latest_versions, last_synced)
                    VALUES %s""",
@@ -1299,7 +1299,7 @@ try:
     print(f"  ✅ {mr_count} registered-model rows synced")
 except Exception as exc:
     obs_conn.rollback()
-    print(f"  ⚠️  model_registry sync failed: {exc}")
+    print(f"  ⚠️  mlflow_registered_models sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -694,6 +694,13 @@ with obs_conn.cursor() as cur:
             description TEXT, aliases JSONB, latest_versions JSONB,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
             PRIMARY KEY (name))""",
+        """CREATE TABLE IF NOT EXISTS mlflow_model_versions (
+            name TEXT NOT NULL, version TEXT NOT NULL, workspace_id TEXT,
+            user_id TEXT, creation_timestamp BIGINT, last_updated_timestamp BIGINT,
+            status TEXT, description TEXT, source TEXT, run_id TEXT, aliases JSONB,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (name, version))""",
+        "CREATE INDEX IF NOT EXISTS idx_mmv_name ON mlflow_model_versions (name)",
         """CREATE TABLE IF NOT EXISTS agent_eval_scores (
             experiment_id TEXT, scorer_name TEXT NOT NULL, source_type TEXT,
             assessment_count BIGINT DEFAULT 0, pass_count BIGINT DEFAULT 0,
@@ -1308,6 +1315,34 @@ try:
 except Exception as exc:
     obs_conn.rollback()
     print(f"  ⚠️  mlflow_registered_models sync failed: {exc}")
+
+# COMMAND ----------
+
+# Sync mlflow_model_versions (all versions per model from 04_discover_observability).
+MODEL_VERSIONS_DELTA = f"{CATALOG}.{SCHEMA}.mlflow_model_versions"
+mv_count = 0
+print(f"▸ Syncing {MODEL_VERSIONS_DELTA} → mlflow_model_versions ...")
+try:
+    mv_rows = spark.read.table(MODEL_VERSIONS_DELTA).collect()
+    values = [(r.name, r.version, r.workspace_id, r.user_id,
+               int(r.creation_timestamp) if r.creation_timestamp is not None else None,
+               int(r.last_updated_timestamp) if r.last_updated_timestamp is not None else None,
+               r.status, r.description, r.source, r.run_id, r.aliases, now) for r in mv_rows]
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE mlflow_model_versions")
+        if values:
+            execute_values(cur,
+                """INSERT INTO mlflow_model_versions
+                   (name, version, workspace_id, user_id, creation_timestamp,
+                    last_updated_timestamp, status, description, source, run_id, aliases, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    obs_conn.commit()
+    mv_count = len(values)
+    print(f"  ✅ {mv_count} model-version rows synced")
+except Exception as exc:
+    obs_conn.rollback()
+    print(f"  ⚠️  mlflow_model_versions sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -2081,6 +2081,138 @@ except Exception as exc:
     uag_conn.rollback()
     print(f"  ⚠️  uag_fallback_routing_daily sync failed: {exc}")
 
+# Sync uag_budget_status (account Budgets API config inventory — F5, read-only).
+UAG_BUDGET_TABLE = f"{CATALOG}.{SCHEMA}.uag_budget_status"
+uag_budget_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS uag_budget_status (
+            budget_id         TEXT NOT NULL,
+            account_id        TEXT,
+            display_name      TEXT,
+            enforce           BOOLEAN DEFAULT FALSE,
+            alerting          BOOLEAN DEFAULT FALSE,
+            min_threshold_usd NUMERIC(18,2),
+            max_threshold_usd NUMERIC(18,2),
+            time_period       TEXT,
+            filter_summary    TEXT,
+            is_ai             BOOLEAN DEFAULT FALSE,
+            spent_usd         NUMERIC(18,2),
+            pct_used          DOUBLE PRECISION,
+            discovered_at     TIMESTAMP WITH TIME ZONE,
+            last_synced       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (budget_id))""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_ubs_ai ON uag_budget_status (is_ai)")
+    # additive columns for pre-existing tables (workflow-owned, so ALTER is safe here)
+    cur.execute("ALTER TABLE uag_budget_status ADD COLUMN IF NOT EXISTS spent_usd NUMERIC(18,2)")
+    cur.execute("ALTER TABLE uag_budget_status ADD COLUMN IF NOT EXISTS pct_used DOUBLE PRECISION")
+    uag_conn.commit()
+print(f"▸ Syncing {UAG_BUDGET_TABLE} → uag_budget_status ...")
+try:
+    bg_rows = spark.read.table(UAG_BUDGET_TABLE).collect()
+    values = [(r.budget_id, r.account_id, r.display_name, bool(r.enforce), bool(r.alerting),
+               r.min_threshold_usd, r.max_threshold_usd, r.time_period, r.filter_summary,
+               bool(r.is_ai), r.spent_usd, r.pct_used, r.discovered_at, now) for r in bg_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE uag_budget_status")
+        if values:
+            execute_values(cur,
+                """INSERT INTO uag_budget_status
+                   (budget_id, account_id, display_name, enforce, alerting,
+                    min_threshold_usd, max_threshold_usd, time_period, filter_summary,
+                    is_ai, spent_usd, pct_used, discovered_at, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    uag_conn.commit()
+    uag_budget_count = len(values)
+    print(f"  ✅ {uag_budget_count} budget rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  uag_budget_status sync failed: {exc}")
+
+# Sync serving_endpoints_inventory (account-wide served-entity inventory, read-only).
+EP_INV_TABLE = f"{CATALOG}.{SCHEMA}.serving_endpoints_inventory"
+ep_inv_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS serving_endpoints_inventory (
+            served_entity_id        TEXT NOT NULL,
+            endpoint_id             TEXT,
+            endpoint_name           TEXT,
+            workspace_id            TEXT,
+            served_entity_name      TEXT,
+            entity_type             TEXT,
+            entity_name             TEXT,
+            entity_version          TEXT,
+            provider                TEXT,
+            task                    TEXT,
+            created_by              TEXT,
+            endpoint_config_version INTEGER,
+            change_time             TIMESTAMP WITH TIME ZONE,
+            discovered_at           TIMESTAMP WITH TIME ZONE,
+            last_synced             TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (served_entity_id))""")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_sei_ws ON serving_endpoints_inventory (workspace_id)")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_sei_type ON serving_endpoints_inventory (entity_type)")
+    uag_conn.commit()
+print(f"▸ Syncing {EP_INV_TABLE} → serving_endpoints_inventory ...")
+try:
+    ei_rows = spark.read.table(EP_INV_TABLE).collect()
+    values = [(r.served_entity_id, r.endpoint_id, r.endpoint_name, r.workspace_id,
+               r.served_entity_name, r.entity_type, r.entity_name, r.entity_version,
+               r.provider, r.task, r.created_by, r.endpoint_config_version,
+               r.change_time, r.discovered_at, now) for r in ei_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE serving_endpoints_inventory")
+        if values:
+            execute_values(cur,
+                """INSERT INTO serving_endpoints_inventory
+                   (served_entity_id, endpoint_id, endpoint_name, workspace_id,
+                    served_entity_name, entity_type, entity_name, entity_version,
+                    provider, task, created_by, endpoint_config_version,
+                    change_time, discovered_at, last_synced)
+                   VALUES %s""",
+                values, page_size=1000)
+    uag_conn.commit()
+    ep_inv_count = len(values)
+    print(f"  ✅ {ep_inv_count} endpoint-inventory rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  serving_endpoints_inventory sync failed: {exc}")
+
+# Sync model_services_inventory (v3 UC model services — account-wide, read-only).
+MS_INV_TABLE = f"{CATALOG}.{SCHEMA}.model_services_inventory"
+ms_inv_count = 0
+with uag_conn.cursor() as cur:
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS model_services_inventory (
+            full_name           TEXT NOT NULL,
+            owner               TEXT,
+            supported_api_types TEXT,
+            create_time         TEXT,
+            discovered_at       TIMESTAMP WITH TIME ZONE,
+            last_synced         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (full_name))""")
+    uag_conn.commit()
+print(f"▸ Syncing {MS_INV_TABLE} → model_services_inventory ...")
+try:
+    ms_rows = spark.read.table(MS_INV_TABLE).collect()
+    values = [(r.full_name, r.owner, r.supported_api_types, r.create_time, r.discovered_at, now) for r in ms_rows]
+    with uag_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE model_services_inventory")
+        if values:
+            execute_values(cur,
+                """INSERT INTO model_services_inventory
+                   (full_name, owner, supported_api_types, create_time, discovered_at, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    uag_conn.commit()
+    ms_inv_count = len(values)
+    print(f"  ✅ {ms_inv_count} model-service rows synced")
+except Exception as exc:
+    uag_conn.rollback()
+    print(f"  ⚠️  model_services_inventory sync failed: {exc}")
+
 uag_conn.close()
 
 # COMMAND ----------

--- a/workflows/02_sync_to_lakebase.py
+++ b/workflows/02_sync_to_lakebase.py
@@ -682,6 +682,12 @@ with obs_conn.cursor() as cur:
             last_seen TEXT,
             last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW())""",
         "CREATE INDEX IF NOT EXISTS idx_atu_exp ON agent_tool_usage (experiment_id)",
+        """CREATE TABLE IF NOT EXISTS model_registry (
+            name TEXT NOT NULL, workspace_id TEXT, user_id TEXT,
+            last_updated_timestamp BIGINT, creation_timestamp BIGINT,
+            description TEXT, aliases JSONB, latest_versions JSONB,
+            last_synced TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            PRIMARY KEY (name))""",
         """CREATE TABLE IF NOT EXISTS agent_eval_scores (
             experiment_id TEXT, scorer_name TEXT NOT NULL, source_type TEXT,
             assessment_count BIGINT DEFAULT 0, pass_count BIGINT DEFAULT 0,
@@ -1268,6 +1274,32 @@ try:
 except Exception as exc:
     obs_conn.rollback()
     print(f"  ⚠️  ai_audit_recent sync failed: {exc}")
+
+# Sync model_registry (UC registered models from 04_discover_observability).
+MODEL_REGISTRY_DELTA = f"{CATALOG}.{SCHEMA}.model_registry"
+mr_count = 0
+print(f"▸ Syncing {MODEL_REGISTRY_DELTA} → model_registry ...")
+try:
+    mr_rows = spark.read.table(MODEL_REGISTRY_DELTA).collect()
+    values = [(r.name, r.workspace_id, r.user_id,
+               int(r.last_updated_timestamp) if r.last_updated_timestamp is not None else None,
+               int(r.creation_timestamp) if r.creation_timestamp is not None else None,
+               r.description, r.aliases, r.latest_versions, now) for r in mr_rows]
+    with obs_conn.cursor() as cur:
+        cur.execute("TRUNCATE TABLE model_registry")
+        if values:
+            execute_values(cur,
+                """INSERT INTO model_registry
+                   (name, workspace_id, user_id, last_updated_timestamp, creation_timestamp,
+                    description, aliases, latest_versions, last_synced)
+                   VALUES %s""",
+                values, page_size=500)
+    obs_conn.commit()
+    mr_count = len(values)
+    print(f"  ✅ {mr_count} registered-model rows synced")
+except Exception as exc:
+    obs_conn.rollback()
+    print(f"  ⚠️  model_registry sync failed: {exc}")
 
 # COMMAND ----------
 

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -684,9 +684,18 @@ else:
 # COMMAND ----------
 
 model_rows = []
+# Resolve the deploy workspace id defensively — spark.conf.get raises
+# CONFIG_NOT_AVAILABLE on serverless (the 2-arg default is NOT honored for this
+# key), which would otherwise abort the whole enumeration below.
+try:
+    _mw_ws_id = spark.conf.get("spark.databricks.clusterUsageTags.orgId")
+except Exception:
+    _mw_ws_id = None
+if not _mw_ws_id:
+    # Fall back to the local workspace id resolved earlier for host mapping.
+    _mw_ws_id = _local_ws_id if "_local_ws_id" in dir() else None
 try:
     _mw = WorkspaceClient()
-    _mw_ws_id = spark.conf.get("spark.databricks.clusterUsageTags.orgId", "") or None
     page_token = None
     pages = 0
     while pages < 50:  # safety bound; 100/page → up to 5k models
@@ -756,6 +765,7 @@ result = {
     "total_traces": len(all_traces),
     "total_trace_details": len(all_details),
     "total_detail_errors": total_detail_errors,
+    "registered_models": len(model_rows),
     "retention_days": RETENTION_DAYS,
     "sp_auth_enabled": bool(SP_CLIENT_ID),
     "narrow_test_ws": NARROW_TEST_WS or None,

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -73,7 +73,7 @@ if ACCOUNT_ID:
     os.environ["DATABRICKS_ACCOUNT_ID"] = ACCOUNT_ID
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces"
 TRACE_DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details"
-MODEL_REGISTRY_TABLE = f"{CATALOG}.{SCHEMA}.model_registry"
+MODEL_REGISTRY_TABLE = f"{CATALOG}.{SCHEMA}.mlflow_registered_models"
 
 try:
     RETENTION_DAYS = max(1, int(dbutils.widgets.get("trace_retention_days") or "90"))

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -822,11 +822,25 @@ if model_rows:
             ))
     print(f"  ✅ enumerated {len(version_rows)} model versions across {len(_model_names)} models")
 
+try:
+    _mv_table_exists = spark.catalog.tableExists(MODEL_VERSIONS_TABLE)
+except Exception:
+    _mv_table_exists = False
+
 if version_rows:
     spark.createDataFrame(version_rows, MODEL_VERSIONS_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_VERSIONS_TABLE)
+    print(f"✅ Wrote {len(version_rows)} rows to {MODEL_VERSIONS_TABLE}")
+elif model_rows and _mv_table_exists:
+    # Models exist but enumeration produced zero versions — almost certainly a
+    # transient/permission failure this run (real models virtually always have
+    # ≥1 version). Preserve the last-good table instead of overwriting it empty,
+    # which would blank the Model Registry drill-down for every model until the
+    # next fully-successful run. Self-heals on the next good run.
+    print(f"⚠️  0 versions enumerated for {len(model_rows)} models — preserving existing {MODEL_VERSIONS_TABLE} (assumed transient)")
 else:
+    # No registered models at all, or the table doesn't exist yet → (re)initialize empty.
     spark.createDataFrame([], MODEL_VERSIONS_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_VERSIONS_TABLE)
-print(f"✅ Wrote {len(version_rows)} rows to {MODEL_VERSIONS_TABLE}")
+    print(f"✅ Wrote 0 rows to {MODEL_VERSIONS_TABLE}")
 
 # COMMAND ----------
 

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -73,6 +73,7 @@ if ACCOUNT_ID:
     os.environ["DATABRICKS_ACCOUNT_ID"] = ACCOUNT_ID
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces"
 TRACE_DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details"
+MODEL_REGISTRY_TABLE = f"{CATALOG}.{SCHEMA}.model_registry"
 
 try:
     RETENTION_DAYS = max(1, int(dbutils.widgets.get("trace_retention_days") or "90"))
@@ -118,6 +119,21 @@ if CROSS_WS_FANOUT_ENABLED:
 # MAGIC ## Delta Table Schema
 
 # COMMAND ----------
+
+# UC registered models (Model Registry), enumerated via REST on the deploy
+# workspace. Cached so the Observability → MLflow Assets tab reads Lakebase
+# instead of a live REST search on every load. `name` is the 3-part UC FQN.
+MODEL_REGISTRY_SCHEMA = StructType([
+    StructField("name", StringType(), False),
+    StructField("workspace_id", StringType(), True),
+    StructField("user_id", StringType(), True),
+    StructField("last_updated_timestamp", LongType(), True),
+    StructField("creation_timestamp", LongType(), True),
+    StructField("description", StringType(), True),
+    StructField("aliases", StringType(), True),          # JSON string
+    StructField("latest_versions", StringType(), True),  # JSON string
+    StructField("discovered_at", TimestampType(), False),
+])
 
 TRACES_SCHEMA = StructType([
     StructField("request_id", StringType(), False),
@@ -655,6 +671,58 @@ else:
     empty_df = spark.createDataFrame([], TRACE_DETAILS_SCHEMA)
     empty_df.write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TRACE_DETAILS_TABLE)
     print("ℹ️  No trace details to write — empty Delta table written")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Registered models (UC Model Registry → Lakebase cache)
+# MAGIC
+# MAGIC Enumerate UC registered models via REST on the deploy workspace so the app's
+# MAGIC Model Registry view reads Lakebase instead of a live search on every load.
+# MAGIC Deploy-workspace scope (same as the app's previous live call). Fail-open.
+
+# COMMAND ----------
+
+model_rows = []
+try:
+    _mw = WorkspaceClient()
+    _mw_ws_id = spark.conf.get("spark.databricks.clusterUsageTags.orgId", "") or None
+    page_token = None
+    pages = 0
+    while pages < 50:  # safety bound; 100/page → up to 5k models
+        params = {"max_results": 100}
+        if page_token:
+            params["page_token"] = page_token
+        resp = _mw.api_client.do(
+            "GET", "/api/2.0/mlflow/unity-catalog/registered-models/search", query=params
+        )
+        for m in (resp.get("registered_models") or []):
+            model_rows.append((
+                m.get("name", ""),
+                _mw_ws_id,
+                m.get("user_id"),
+                int(m["last_updated_timestamp"]) if m.get("last_updated_timestamp") is not None else None,
+                int(m["creation_timestamp"]) if m.get("creation_timestamp") is not None else None,
+                # search endpoint returns `description`, not `comment`
+                m.get("description") or m.get("comment"),
+                json.dumps(m.get("aliases") or []),
+                json.dumps(m.get("latest_versions") or []),
+                now,
+            ))
+        page_token = resp.get("next_page_token")
+        pages += 1
+        if not page_token:
+            break
+    print(f"  ✅ enumerated {len(model_rows)} registered models")
+except Exception as exc:
+    print(f"  ⚠️  registered-models enumeration unavailable: {exc}")
+    model_rows = []
+
+if model_rows:
+    spark.createDataFrame(model_rows, MODEL_REGISTRY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_REGISTRY_TABLE)
+else:
+    spark.createDataFrame([], MODEL_REGISTRY_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_REGISTRY_TABLE)
+print(f"✅ Wrote {len(model_rows)} rows to {MODEL_REGISTRY_TABLE}")
 
 # COMMAND ----------
 

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -74,6 +74,7 @@ if ACCOUNT_ID:
 TRACES_TABLE = f"{CATALOG}.{SCHEMA}.observability_traces"
 TRACE_DETAILS_TABLE = f"{CATALOG}.{SCHEMA}.observability_trace_details"
 MODEL_REGISTRY_TABLE = f"{CATALOG}.{SCHEMA}.mlflow_registered_models"
+MODEL_VERSIONS_TABLE = f"{CATALOG}.{SCHEMA}.mlflow_model_versions"
 
 try:
     RETENTION_DAYS = max(1, int(dbutils.widgets.get("trace_retention_days") or "90"))
@@ -132,6 +133,24 @@ MODEL_REGISTRY_SCHEMA = StructType([
     StructField("description", StringType(), True),
     StructField("aliases", StringType(), True),          # JSON string
     StructField("latest_versions", StringType(), True),  # JSON string
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# All versions per registered model, enumerated via the model-versions search
+# REST endpoint. Cached so the Model Registry drill-down reads Lakebase instead
+# of a live search on every model expand. `name` is the 3-part UC FQN.
+MODEL_VERSIONS_SCHEMA = StructType([
+    StructField("name", StringType(), False),
+    StructField("version", StringType(), False),
+    StructField("workspace_id", StringType(), True),
+    StructField("user_id", StringType(), True),
+    StructField("creation_timestamp", LongType(), True),
+    StructField("last_updated_timestamp", LongType(), True),
+    StructField("status", StringType(), True),
+    StructField("description", StringType(), True),
+    StructField("source", StringType(), True),
+    StructField("run_id", StringType(), True),
+    StructField("aliases", StringType(), True),  # JSON string
     StructField("discovered_at", TimestampType(), False),
 ])
 
@@ -736,6 +755,68 @@ print(f"✅ Wrote {len(model_rows)} rows to {MODEL_REGISTRY_TABLE}")
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC ## Model versions (UC Model Registry → Lakebase cache)
+# MAGIC
+# MAGIC Enumerate every version per registered model via the model-versions search
+# MAGIC REST endpoint so the app's per-model drill-down reads Lakebase instead of a
+# MAGIC live search on every expand. Bounded (versions/model + total) and fail-open.
+
+# COMMAND ----------
+
+# Bounds so a metastore with many models/versions can't make this task unbounded.
+_MV_PER_MODEL = 200      # newest versions kept per model
+_MV_TOTAL_CAP = 50000    # hard cap across all models
+version_rows = []
+if model_rows:
+    _mvw = WorkspaceClient()
+    _model_names = [m[0] for m in model_rows if m[0]]
+    for _mname in _model_names:
+        if len(version_rows) >= _MV_TOTAL_CAP:
+            print(f"  ⚠️  hit total version cap ({_MV_TOTAL_CAP}) — stopping enumeration")
+            break
+        try:
+            _v_token = None
+            _fetched = 0
+            while _fetched < _MV_PER_MODEL:
+                _vparams = {"filter": f"name='{_mname}'", "max_results": 50}
+                if _v_token:
+                    _vparams["page_token"] = _v_token
+                _vresp = _mvw.api_client.do(
+                    "GET", "/api/2.0/mlflow/unity-catalog/model-versions/search", query=_vparams
+                )
+                _batch = _vresp.get("model_versions") or []
+                for v in _batch:
+                    version_rows.append((
+                        v.get("name", _mname),
+                        str(v.get("version", "")),
+                        _mw_ws_id,
+                        v.get("user_id"),
+                        int(v["creation_timestamp"]) if v.get("creation_timestamp") is not None else None,
+                        int(v["last_updated_timestamp"]) if v.get("last_updated_timestamp") is not None else None,
+                        v.get("status"),
+                        v.get("description") or v.get("comment"),
+                        v.get("source"),
+                        v.get("run_id"),
+                        json.dumps(v.get("aliases") or []),
+                        now,
+                    ))
+                _fetched += len(_batch)
+                _v_token = _vresp.get("next_page_token")
+                if not _v_token or not _batch:
+                    break
+        except Exception as exc:
+            print(f"  ⚠️  version enumeration failed for {_mname}: {exc}")
+    print(f"  ✅ enumerated {len(version_rows)} model versions across {len(_model_names)} models")
+
+if version_rows:
+    spark.createDataFrame(version_rows, MODEL_VERSIONS_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_VERSIONS_TABLE)
+else:
+    spark.createDataFrame([], MODEL_VERSIONS_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(MODEL_VERSIONS_TABLE)
+print(f"✅ Wrote {len(version_rows)} rows to {MODEL_VERSIONS_TABLE}")
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC ## Summary
 
 # COMMAND ----------
@@ -766,6 +847,7 @@ result = {
     "total_trace_details": len(all_details),
     "total_detail_errors": total_detail_errors,
     "registered_models": len(model_rows),
+    "model_versions": len(version_rows),
     "retention_days": RETENTION_DAYS,
     "sp_auth_enabled": bool(SP_CLIENT_ID),
     "narrow_test_ws": NARROW_TEST_WS or None,

--- a/workflows/04_discover_observability.py
+++ b/workflows/04_discover_observability.py
@@ -770,42 +770,56 @@ version_rows = []
 if model_rows:
     _mvw = WorkspaceClient()
     _model_names = [m[0] for m in model_rows if m[0]]
+    def _fetch_versions(mname):
+        """Newest-first versions for one model, capped at _MV_PER_MODEL. Orders by
+        last_updated_timestamp DESC so the cap keeps the NEWEST versions (not an
+        arbitrary page order); retries once without order_by if the endpoint rejects
+        it, so an unsupported order_by never silently zeroes a model. Escapes single
+        quotes in the name so a name with an apostrophe can't break the filter."""
+        name_esc = mname.replace("'", "''")
+        for order_by in (["last_updated_timestamp DESC"], None):
+            got, token = [], None
+            try:
+                while len(got) < _MV_PER_MODEL:
+                    p = {"filter": f"name='{name_esc}'", "max_results": 50}
+                    if order_by:
+                        p["order_by"] = order_by
+                    if token:
+                        p["page_token"] = token
+                    resp = _mvw.api_client.do(
+                        "GET", "/api/2.0/mlflow/unity-catalog/model-versions/search", query=p
+                    )
+                    batch = resp.get("model_versions") or []
+                    got.extend(batch)
+                    token = resp.get("next_page_token")
+                    if not token or not batch:
+                        break
+                return got[:_MV_PER_MODEL]
+            except Exception as exc:
+                if order_by is None:  # unordered attempt also failed → give up on this model
+                    print(f"  ⚠️  version enumeration failed for {mname}: {exc}")
+                    return []
+        return []
+
     for _mname in _model_names:
         if len(version_rows) >= _MV_TOTAL_CAP:
             print(f"  ⚠️  hit total version cap ({_MV_TOTAL_CAP}) — stopping enumeration")
             break
-        try:
-            _v_token = None
-            _fetched = 0
-            while _fetched < _MV_PER_MODEL:
-                _vparams = {"filter": f"name='{_mname}'", "max_results": 50}
-                if _v_token:
-                    _vparams["page_token"] = _v_token
-                _vresp = _mvw.api_client.do(
-                    "GET", "/api/2.0/mlflow/unity-catalog/model-versions/search", query=_vparams
-                )
-                _batch = _vresp.get("model_versions") or []
-                for v in _batch:
-                    version_rows.append((
-                        v.get("name", _mname),
-                        str(v.get("version", "")),
-                        _mw_ws_id,
-                        v.get("user_id"),
-                        int(v["creation_timestamp"]) if v.get("creation_timestamp") is not None else None,
-                        int(v["last_updated_timestamp"]) if v.get("last_updated_timestamp") is not None else None,
-                        v.get("status"),
-                        v.get("description") or v.get("comment"),
-                        v.get("source"),
-                        v.get("run_id"),
-                        json.dumps(v.get("aliases") or []),
-                        now,
-                    ))
-                _fetched += len(_batch)
-                _v_token = _vresp.get("next_page_token")
-                if not _v_token or not _batch:
-                    break
-        except Exception as exc:
-            print(f"  ⚠️  version enumeration failed for {_mname}: {exc}")
+        for v in _fetch_versions(_mname):
+            version_rows.append((
+                v.get("name", _mname),
+                str(v.get("version", "")),
+                _mw_ws_id,
+                v.get("user_id"),
+                int(v["creation_timestamp"]) if v.get("creation_timestamp") is not None else None,
+                int(v["last_updated_timestamp"]) if v.get("last_updated_timestamp") is not None else None,
+                v.get("status"),
+                v.get("description") or v.get("comment"),
+                v.get("source"),
+                v.get("run_id"),
+                json.dumps(v.get("aliases") or []),
+                now,
+            ))
     print(f"  ✅ enumerated {len(version_rows)} model versions across {len(_model_names)} models")
 
 if version_rows:

--- a/workflows/07_discover_uc_otel_traces.py
+++ b/workflows/07_discover_uc_otel_traces.py
@@ -137,6 +137,8 @@ TOOL_USAGE_SCHEMA = StructType([
     StructField("span_type",     StringType(), False),   # TOOL | RETRIEVER
     StructField("call_count",    LongType(),   True),
     StructField("trace_count",   LongType(),   True),
+    StructField("error_count",   LongType(),   True),     # spans with status_code != OK
+    StructField("total_latency_ms", DoubleType(), True),  # summed span duration (for avg = /call_count)
     StructField("last_seen",     StringType(), True),
     StructField("discovered_at", TimestampType(), False),
 ])
@@ -597,6 +599,9 @@ for cat, sch, tbl in trace_log_tables:
                    trim(BOTH '"' FROM s.attributes['mlflow.spanType'])       AS span_type,
                    COUNT(*)                                                 AS call_count,
                    COUNT(DISTINCT trace_id)                                 AS trace_count,
+                   SUM(CASE WHEN upper(COALESCE(s.status_code, '')) NOT IN ('OK', 'STATUS_CODE_OK', '')
+                            THEN 1 ELSE 0 END)                              AS error_count,
+                   SUM((unix_micros(s.end_time) - unix_micros(s.start_time)) / 1000.0) AS total_latency_ms,
                    CAST(MAX(request_time) AS STRING)                        AS last_seen
             FROM src LATERAL VIEW explode(spans) t AS s
             WHERE trim(BOTH '"' FROM s.attributes['mlflow.spanType']) IN ('TOOL', 'RETRIEVER')
@@ -606,6 +611,8 @@ for cat, sch, tbl in trace_log_tables:
         for r in agg:
             tool_usage_rows.append((r["experiment_id"], r["tool_name"], r["span_type"],
                                     int(r["call_count"] or 0), int(r["trace_count"] or 0),
+                                    int(r["error_count"] or 0),
+                                    float(r["total_latency_ms"] or 0.0),
                                     r["last_seen"], NOW))
         print(f"  ✅ tool-usage {label}: {len(agg)} (tool,type) rows")
     except Exception as exc:

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -94,6 +94,7 @@ EXPECTED = [
     "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
     "ai_audit_summary",              # AI activity rollup from system.access.audit; empty if audit unreadable
     "ai_audit_recent",               # recent AI audit events; empty if audit unreadable
+    "model_registry",                # UC registered models (deploy-ws); empty if none / not readable
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -95,6 +95,7 @@ EXPECTED = [
     "ai_audit_summary",              # AI activity rollup from system.access.audit; empty if audit unreadable
     "ai_audit_recent",               # recent AI audit events; empty if audit unreadable
     "mlflow_registered_models",       # UC registered models (deploy-ws); empty if none / not readable
+    "mlflow_model_versions",          # all versions per registered model; empty if none / not readable
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -94,7 +94,7 @@ EXPECTED = [
     "agent_eval_scores",             # MLflow-3 assessment rollup; empty when no eval'd traces
     "ai_audit_summary",              # AI activity rollup from system.access.audit; empty if audit unreadable
     "ai_audit_recent",               # recent AI audit events; empty if audit unreadable
-    "model_registry",                # UC registered models (deploy-ws); empty if none / not readable
+    "mlflow_registered_models",       # UC registered models (deploy-ws); empty if none / not readable
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks

--- a/workflows/10_smoke_check_lakebase.py
+++ b/workflows/10_smoke_check_lakebase.py
@@ -98,6 +98,9 @@ EXPECTED = [
     "uag_coding_agent_usage",        # coding-agent activity; empty when no coding-agent traffic
     "uag_throttling_daily",          # 429/5xx per endpoint; empty when no throttling/errors
     "uag_fallback_routing_daily",    # smart-routing fallbacks per endpoint; empty when no fallbacks
+    "uag_budget_status",             # account Budgets API config inventory; empty without account creds
+    "serving_endpoints_inventory",   # account-wide served-entity inventory; empty if served_entities unreadable
+    "model_services_inventory",      # v3 UC model services; empty if model-services API unreadable
     "billing_cache_meta",
     # App-managed tables created in Phase 7 of 02_sync_to_lakebase. These were
     # historically created lazily by the app's startup hook, but the app SP
@@ -134,8 +137,7 @@ if INSTANCE:
 else:
     # Autoscaling endpoint path
     import requests
-    auth_h = {}
-    w.config.authenticate(auth_h)
+    auth_h = w.config.authenticate()
     resp = requests.post(
         f"{w.config.host.rstrip('/')}/api/2.0/postgres/credentials",
         headers={**auth_h, "Content-Type": "application/json"},

--- a/workflows/13_discover_budgets.py
+++ b/workflows/13_discover_budgets.py
@@ -1,0 +1,345 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Budget Discovery Job (F5 — UAG budget status, read-only)
+# MAGIC
+# MAGIC Reads the **account Budgets API** (`GET /api/2.1/accounts/{account_id}/budgets`)
+# MAGIC and writes one Delta table for the sync task (`02_sync_to_lakebase`) to
+# MAGIC mirror into Lakebase. Surfaces each native budget's cap thresholds, whether
+# MAGIC it **enforces** (BLOCK_USAGE) vs only **alerts**, its filter, and AI-relevance.
+# MAGIC
+# MAGIC **Read-only / visualize-only:** the app never creates or enforces budgets —
+# MAGIC enforcement stays entirely platform-side. This is the fleet-wide status view
+# MAGIC the native per-budget UI doesn't give.
+# MAGIC
+# MAGIC **Table written:** `uag_budget_status`
+# MAGIC
+# MAGIC **Account auth.** The Budgets API is account-scoped, so this task needs
+# MAGIC account-level credentials — a service principal whose OAuth creds
+# MAGIC (`client_id` / `client_secret`) live in the secret scope named by
+# MAGIC `discovery_sp_secret_scope`, and which has account budget read. Without
+# MAGIC them the task **degrades to an empty table** (app shows "account access
+# MAGIC needed"), never failing the run.
+# MAGIC
+# MAGIC **Data flow:** account Budgets API → Delta → Lakebase (sync task) → app reads
+
+# COMMAND ----------
+
+# MAGIC %pip install databricks-sdk --upgrade
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Dict, List
+
+from pyspark.sql import SparkSession
+import re
+
+from pyspark.sql.types import (
+    StructType, StructField, StringType, BooleanType, DecimalType, DoubleType, TimestampType,
+)
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Configuration
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name")
+dbutils.widgets.text("schema", "", "Schema name")
+dbutils.widgets.text("account_id", "", "Databricks account ID")
+dbutils.widgets.text("account_host", "https://accounts.cloud.databricks.com", "Account console host")
+dbutils.widgets.text("discovery_sp_secret_scope", "", "Secret scope with account-SP creds (keys: client_id, client_secret)")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+ACCOUNT_ID = dbutils.widgets.get("account_id")
+ACCOUNT_HOST = (dbutils.widgets.get("account_host") or "https://accounts.cloud.databricks.com").rstrip("/")
+SP_SECRET_SCOPE = dbutils.widgets.get("discovery_sp_secret_scope") or ""
+
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+
+BUDGET_TABLE = f"{CATALOG}.{SCHEMA}.uag_budget_status"
+
+BUDGET_SCHEMA = StructType([
+    StructField("budget_id", StringType(), False),
+    StructField("account_id", StringType(), True),
+    StructField("display_name", StringType(), True),
+    StructField("enforce", BooleanType(), True),
+    StructField("alerting", BooleanType(), True),
+    StructField("min_threshold_usd", DecimalType(18, 2), True),
+    StructField("max_threshold_usd", DecimalType(18, 2), True),
+    StructField("time_period", StringType(), True),
+    StructField("filter_summary", StringType(), True),
+    StructField("is_ai", BooleanType(), True),
+    StructField("spent_usd", DecimalType(18, 2), True),   # current-period spend; NULL = not computable (n/a)
+    StructField("pct_used", DoubleType(), True),          # spent / max cap * 100; NULL when spend or cap missing
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# Product values (on the `databricks-product` tag) that mark a budget as AI-scoped.
+_AI_PRODUCTS = {
+    "genie", "model_serving", "mosaic_ai_model_serving", "foundation_model",
+    "vector_search", "ai_gateway", "agent", "mosaic_ai_agent",
+}
+# Tag keys that always mark a budget as AI-scoped regardless of value.
+_AI_TAG_KEYS = {"ai_model"}
+# Name markers (lowercased substring) that mark a budget as AI-scoped.
+_AI_NAME_MARKERS = ("genie", "gateway", "ai_model", "ai-gateway", "llm")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Load account credentials + call the Budgets API
+
+# COMMAND ----------
+
+def _load_budgets() -> List[Dict[str, Any]]:
+    """Return the raw budget objects from the account Budgets API, or [] if
+    account credentials aren't configured / the call fails (degrade to empty)."""
+    if not ACCOUNT_ID:
+        print("  account_id not set — writing empty budget table")
+        return []
+    if not SP_SECRET_SCOPE:
+        print("  discovery_sp_secret_scope not set — no account creds; writing empty budget table")
+        return []
+    try:
+        client_id = dbutils.secrets.get(scope=SP_SECRET_SCOPE, key="client_id")
+        client_secret = dbutils.secrets.get(scope=SP_SECRET_SCOPE, key="client_secret")
+    except Exception as exc:
+        print(f"  WARNING: could not load SP creds from scope '{SP_SECRET_SCOPE}': {exc}")
+        return []
+
+    try:
+        from databricks.sdk import AccountClient
+        ac = AccountClient(
+            host=ACCOUNT_HOST,
+            account_id=ACCOUNT_ID,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        budgets: List[Dict[str, Any]] = []
+        page_token = None
+        while True:
+            query = {"page_token": page_token} if page_token else None
+            resp = ac.api_client.do(
+                "GET", f"/api/2.1/accounts/{ACCOUNT_ID}/budgets", query=query
+            )
+            batch = (resp or {}).get("budgets", []) if isinstance(resp, dict) else []
+            budgets.extend(batch)
+            page_token = (resp or {}).get("next_page_token") if isinstance(resp, dict) else None
+            if not page_token:
+                break
+        print(f"  Loaded {len(budgets)} budgets from the account Budgets API")
+        return budgets
+    except Exception as exc:
+        print(f"  WARNING: Budgets API call failed ({type(exc).__name__}: {exc}) — writing empty table")
+        return []
+
+
+def _to_row(b: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten one raw budget object into our Delta schema."""
+    alert_cfgs = b.get("alert_configurations") or []
+    thresholds: List[float] = []
+    actions: set = set()
+    time_period = ""
+    for a in alert_cfgs:
+        try:
+            thresholds.append(float(a.get("quantity_threshold") or 0))
+        except (TypeError, ValueError):
+            pass
+        if not time_period:
+            time_period = a.get("time_period") or ""
+        for ac_ in (a.get("action_configurations") or []):
+            if ac_.get("action_type"):
+                actions.add(ac_["action_type"])
+
+    filt = b.get("filter") or {}
+    tags = filt.get("tags") or []
+    tag_bits = []
+    for t in tags:
+        key = t.get("key", "")
+        val = t.get("value") or {}
+        op = val.get("operator", "IN")
+        vals = val.get("values") or []
+        tag_bits.append(f"{key} {op} [{', '.join(str(v) for v in vals[:3])}]")
+    ws = filt.get("workspace_id") or {}
+    ws_vals = ws.get("values") or []
+    filter_bits = list(tag_bits)
+    if ws_vals:
+        filter_bits.append(f"workspaces: {len(ws_vals)}")
+    filter_summary = "; ".join(filter_bits) if filter_bits else "account-wide"
+
+    # AI-relevance: AI tag key, an AI product value, or a name marker.
+    is_ai = False
+    for t in tags:
+        key = t.get("key", "")
+        if key in _AI_TAG_KEYS:
+            is_ai = True
+        if key == "databricks-product":
+            vals = {str(v).lower() for v in (t.get("value") or {}).get("values", [])}
+            if vals & _AI_PRODUCTS:
+                is_ai = True
+    name_l = (b.get("display_name") or "").lower()
+    if any(m in name_l for m in _AI_NAME_MARKERS):
+        is_ai = True
+
+    def _dec(v):
+        return Decimal(str(round(v, 2))) if v else None
+
+    return {
+        "budget_id": b.get("budget_configuration_id", ""),
+        "account_id": b.get("account_id", ACCOUNT_ID),
+        "display_name": b.get("display_name", ""),
+        "enforce": "BLOCK_USAGE" in actions,
+        "alerting": "EMAIL_NOTIFICATION" in actions,
+        "min_threshold_usd": _dec(min(thresholds)) if thresholds else None,
+        "max_threshold_usd": _dec(max(thresholds)) if thresholds else None,
+        "time_period": time_period,
+        "filter_summary": filter_summary,
+        "is_ai": is_ai,
+    }
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Current-period consumption (spend vs cap)
+# MAGIC
+# MAGIC Bounded current-month billing aggregates (per-workspace + per-tag-key, list-price
+# MAGIC USD — the same join `09_discover_billing` uses), matched per budget. Correct for
+# MAGIC **account-wide**, **workspace-only**, and **single-tag (IN/NOT_IN)** filters;
+# MAGIC complex shapes (multi-tag, tag+workspace) are left NULL (n/a) rather than guessed.
+# MAGIC Fails open to n/a if billing isn't readable.
+
+# COMMAND ----------
+
+_COST = "ROUND(SUM(u.usage_quantity * COALESCE(lp.pricing.effective_list.default, lp.pricing.default, 0)), 2)"
+_FROM = """FROM system.billing.usage u
+  LEFT JOIN system.billing.list_prices lp
+    ON u.sku_name = lp.sku_name AND u.cloud = lp.cloud AND u.usage_unit = lp.usage_unit AND lp.price_end_time IS NULL
+  WHERE u.usage_date >= date_trunc('MONTH', current_date())"""
+_KEY_RE = re.compile(r"^[A-Za-z0-9_.\-]+$")
+
+
+def _referenced_tag_keys(budgets):
+    """Distinct, safe tag keys referenced by budget filters, top 20 by frequency
+    (bounds the number of aggregate queries)."""
+    keys = {}
+    for b in budgets:
+        for t in ((b.get("filter") or {}).get("tags") or []):
+            k = t.get("key", "")
+            if _KEY_RE.match(k):
+                keys[k] = keys.get(k, 0) + 1
+    return [k for k, _ in sorted(keys.items(), key=lambda kv: -kv[1])[:20]]
+
+
+def _billing_current_month(budgets):
+    """Bounded month-to-date cost aggregates. Returns (ws_cost, tag_cost, total, keys),
+    or (None, None, None, set()) if billing isn't readable (→ consumption = n/a)."""
+    try:
+        ws_rows = spark.sql(
+            f"SELECT CAST(u.workspace_id AS STRING) AS ws, {_COST} AS cost {_FROM} "
+            "AND u.workspace_id IS NOT NULL GROUP BY u.workspace_id"
+        ).collect()
+        ws_cost = {r["ws"]: float(r["cost"] or 0) for r in ws_rows}
+        # Account-wide / NOT_IN spend uses `total`, which must include usage with a
+        # NULL workspace_id (account-level SKUs) — so compute it separately rather than
+        # summing the workspace-filtered ws_cost (which would under-count).
+        total_rows = spark.sql(f"SELECT {_COST} AS cost {_FROM}").collect()
+        total = round(float(total_rows[0]["cost"] or 0) if total_rows else 0.0, 2)
+        keys = _referenced_tag_keys(budgets)
+        tag_cost = {}
+        for k in keys:
+            tr = spark.sql(
+                f"SELECT u.custom_tags['{k}'] AS v, {_COST} AS cost {_FROM} "
+                f"AND u.custom_tags['{k}'] IS NOT NULL GROUP BY u.custom_tags['{k}']"
+            ).collect()
+            for r in tr:
+                tag_cost[(k, str(r["v"]))] = float(r["cost"] or 0)
+        print(f"  billing: {len(ws_cost)} workspaces, month-to-date ${total:,.0f}, tag keys={keys}")
+        return ws_cost, tag_cost, total, set(keys)
+    except Exception as exc:
+        print(f"  WARNING: billing aggregate failed ({type(exc).__name__}: {exc}) — consumption = n/a")
+        return None, None, None, set()
+
+
+def _compute_spent(b, ws_cost, tag_cost, total, keys):
+    """Month-to-date spend for one budget, or None (n/a) if its filter shape isn't
+    supported by the bounded aggregates (account-wide / workspace-only / single-tag)."""
+    if ws_cost is None:
+        return None
+    filt = b.get("filter") or {}
+    tags = filt.get("tags") or []
+    ws = (filt.get("workspace_id") or {}).get("values") or []
+    if not tags and not ws:                      # account-wide
+        return total
+    if not tags and ws:                          # workspace-only
+        return round(sum(ws_cost.get(str(w), 0.0) for w in ws), 2)
+    if len(tags) == 1 and not ws:                # single-tag
+        t = tags[0]
+        k = t.get("key", "")
+        if k not in keys:
+            return None
+        val = t.get("value") or {}
+        vals = {str(v) for v in (val.get("values") or [])}
+        matched = round(sum(c for (kk, vv), c in tag_cost.items() if kk == k and vv in vals), 2)
+        return round(max(total - matched, 0.0), 2) if val.get("operator") == "NOT_IN" else matched
+    return None                                  # multi-tag / tag+workspace → don't guess
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Write Delta table
+
+# COMMAND ----------
+
+now = datetime.now(timezone.utc)
+raw = _load_budgets()
+budgets = [b for b in raw if b.get("budget_configuration_id")]
+rows = [_to_row(b) for b in budgets]
+
+ws_cost, tag_cost, total_cost, cost_keys = _billing_current_month(budgets) if budgets else (None, None, None, set())
+for b, r in zip(budgets, rows):
+    spent = _compute_spent(b, ws_cost, tag_cost, total_cost, cost_keys)
+    r["spent_usd"] = Decimal(str(round(spent, 2))) if spent is not None else None
+    cap = float(r["max_threshold_usd"]) if r["max_threshold_usd"] is not None else 0.0
+    r["pct_used"] = round(100.0 * spent / cap, 1) if (spent is not None and cap > 0) else None
+
+if rows:
+    tuples = [
+        (
+            r["budget_id"], r["account_id"], r["display_name"],
+            r["enforce"], r["alerting"], r["min_threshold_usd"], r["max_threshold_usd"],
+            r["time_period"], r["filter_summary"], r["is_ai"],
+            r["spent_usd"], r["pct_used"], now,
+        )
+        for r in rows
+    ]
+    spark.createDataFrame(tuples, BUDGET_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(BUDGET_TABLE)
+else:
+    spark.createDataFrame([], BUDGET_SCHEMA).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(BUDGET_TABLE)
+
+computed = sum(1 for r in rows if r["spent_usd"] is not None)
+print(f"✅ Wrote {len(rows)} budgets to {BUDGET_TABLE} ({computed} with computed spend)")
+
+# COMMAND ----------
+
+result = {
+    "status": "success",
+    "budget_rows": len(rows),
+    "enforcing": sum(1 for r in rows if r["enforce"]),
+    "ai_budgets": sum(1 for r in rows if r["is_ai"]),
+    "spend_computed": computed,
+    "account_creds": bool(SP_SECRET_SCOPE),
+    "discovered_at": now.isoformat(),
+}
+print(json.dumps(result, indent=2))
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/14_discover_endpoint_inventory.py
+++ b/workflows/14_discover_endpoint_inventory.py
@@ -1,0 +1,102 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Endpoint Inventory Discovery (account-wide, read-only)
+# MAGIC
+# MAGIC Queries `system.serving.served_entities` (account-scoped) and writes a
+# MAGIC flat, **account-wide** inventory of every current served entity across all
+# MAGIC workspaces in the metastore — the fleet view the per-workspace serving API
+# MAGIC (`serving_endpoints.list()`) can't give.
+# MAGIC
+# MAGIC **Read-only:** live management (ACL/config edits) stays per-workspace via the
+# MAGIC serving API — this table is inventory only.
+# MAGIC
+# MAGIC **Table written:** `serving_endpoints_inventory`
+# MAGIC
+# MAGIC **Data flow:** system.serving.served_entities → Delta → Lakebase (sync task) → app reads
+
+# COMMAND ----------
+
+import json
+from datetime import datetime, timezone
+
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name")
+dbutils.widgets.text("schema", "", "Schema name")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+TABLE = f"{CATALOG}.{SCHEMA}.serving_endpoints_inventory"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Build the inventory
+# MAGIC One row per current served entity (latest endpoint config version, not deleted).
+
+# COMMAND ----------
+
+rows = 0
+try:
+    spark.sql(f"""
+        CREATE OR REPLACE TABLE {TABLE} AS
+        WITH latest AS (
+            SELECT *,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY endpoint_id, served_entity_id
+                       ORDER BY endpoint_config_version DESC, change_time DESC
+                   ) AS rn
+            FROM system.serving.served_entities
+            WHERE endpoint_delete_time IS NULL
+        )
+        SELECT
+            served_entity_id,
+            endpoint_id,
+            endpoint_name,
+            CAST(workspace_id AS STRING)          AS workspace_id,
+            served_entity_name,
+            entity_type,
+            entity_name,
+            entity_version,
+            external_model_config.provider        AS provider,
+            task,
+            created_by,
+            endpoint_config_version,
+            change_time,
+            current_timestamp()                   AS discovered_at
+        FROM latest
+        WHERE rn = 1
+    """)
+    rows = spark.table(TABLE).count()
+    print(f"✅ Wrote {rows} served entities to {TABLE}")
+except Exception as exc:
+    # Fail open to an empty table so the sync/app degrade gracefully (e.g. if
+    # system.serving.served_entities isn't readable at this principal's scope).
+    print(f"WARNING: served_entities query failed ({type(exc).__name__}: {exc}) — writing empty table")
+    spark.sql(f"""
+        CREATE OR REPLACE TABLE {TABLE} (
+            served_entity_id STRING, endpoint_id STRING, endpoint_name STRING,
+            workspace_id STRING, served_entity_name STRING, entity_type STRING,
+            entity_name STRING, entity_version STRING, provider STRING, task STRING,
+            created_by STRING, endpoint_config_version INT, change_time TIMESTAMP,
+            discovered_at TIMESTAMP
+        )
+    """)
+
+# COMMAND ----------
+
+result = {
+    "status": "success",
+    "endpoint_rows": rows,
+    "discovered_at": datetime.now(timezone.utc).isoformat(),
+}
+print(json.dumps(result, indent=2))
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/15_discover_model_services.py
+++ b/workflows/15_discover_model_services.py
@@ -1,0 +1,106 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Model Services Discovery (v3 Unity Gateway — account-wide, read-only)
+# MAGIC
+# MAGIC Lists v3 Unity Gateway **UC model services** via the UC REST API
+# MAGIC (`GET /api/2.1/unity-catalog/model-services`) and writes a metastore-wide
+# MAGIC inventory to Delta for the sync task to mirror into Lakebase.
+# MAGIC
+# MAGIC **Why a workflow:** the list endpoint requires metastore-admin-level access,
+# MAGIC which the app's runtime identities (OBO token / app SP) don't reliably have.
+# MAGIC The workflow runs as its **run-as identity** (a metastore admin), so it can
+# MAGIC enumerate account-wide. The app then reads the cached inventory from Lakebase;
+# MAGIC per-service **grants** stay live in the app (UC-enforced).
+# MAGIC
+# MAGIC **Table written:** `model_services_inventory`
+# MAGIC
+# MAGIC **Data flow:** UC model-services REST → Delta → Lakebase (sync task) → app reads
+
+# COMMAND ----------
+
+# MAGIC %pip install databricks-sdk --upgrade
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import json
+from datetime import datetime, timezone
+
+import requests
+from databricks.sdk import WorkspaceClient
+from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType, StructField, StringType, TimestampType
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+dbutils.widgets.text("catalog", "", "Unity Catalog name")
+dbutils.widgets.text("schema", "", "Schema name")
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+if not CATALOG or not SCHEMA:
+    raise ValueError(f"catalog and schema required (got {CATALOG!r}, {SCHEMA!r})")
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {CATALOG}.{SCHEMA}")
+TABLE = f"{CATALOG}.{SCHEMA}.model_services_inventory"
+
+SCHEMA_T = StructType([
+    StructField("full_name", StringType(), False),
+    StructField("owner", StringType(), True),
+    StructField("supported_api_types", StringType(), True),  # comma-joined
+    StructField("create_time", StringType(), True),
+    StructField("discovered_at", TimestampType(), False),
+])
+
+# COMMAND ----------
+
+def _load_model_services():
+    """List UC model services via REST (run-as identity). Paginated. Fail-open to []."""
+    try:
+        w = WorkspaceClient()
+        host = w.config.host.rstrip("/")
+        token = w.config.authenticate().get("Authorization", "").replace("Bearer ", "")
+        headers = {"Authorization": f"Bearer {token}"}
+        out, page_token = [], None
+        while True:
+            params = {"page_token": page_token} if page_token else {}
+            r = requests.get(f"{host}/api/2.1/unity-catalog/model-services", headers=headers, params=params, timeout=60)
+            r.raise_for_status()
+            body = r.json()
+            out.extend(body.get("model_services", []))
+            page_token = body.get("next_page_token")
+            if not page_token:
+                break
+        print(f"  Loaded {len(out)} model services")
+        return out
+    except Exception as exc:
+        print(f"  WARNING: model-services list failed ({type(exc).__name__}: {exc}) — writing empty table")
+        return []
+
+# COMMAND ----------
+
+now = datetime.now(timezone.utc)
+raw = _load_model_services()
+rows = [
+    (
+        (s.get("name", "") or "").replace("model-services/", ""),
+        s.get("effective_owner", ""),
+        ",".join(s.get("supported_api_types", []) or []),
+        s.get("create_time"),
+        now,
+    )
+    for s in raw if s.get("name")
+]
+
+if rows:
+    spark.createDataFrame(rows, SCHEMA_T).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TABLE)
+else:
+    spark.createDataFrame([], SCHEMA_T).write.mode("overwrite").option("overwriteSchema", "true").saveAsTable(TABLE)
+print(f"✅ Wrote {len(rows)} model services to {TABLE}")
+
+# COMMAND ----------
+
+result = {"status": "success", "model_service_rows": len(rows), "discovered_at": now.isoformat()}
+print(json.dumps(result, indent=2))
+dbutils.notebook.exit(json.dumps(result))

--- a/workflows/databricks.yml
+++ b/workflows/databricks.yml
@@ -21,6 +21,9 @@ variables:
     description: Lakebase endpoint path for Autoscaling credential generation (e.g. projects/<name>/branches/<branch>/endpoints/<endpoint>). Leave empty for Provisioned.
   account_id:
     description: Databricks account ID for cross-workspace operations (find in your workspace URL or account console)
+  account_host:
+    default: "https://accounts.cloud.databricks.com"
+    description: "Account console host for the Budgets API (AWS default; use accounts.azuredatabricks.net or accounts.gcp.databricks.com on other clouds)."
   warehouse_id:
     description: SQL warehouse ID for system table queries
   trace_retention_days:
@@ -170,10 +173,41 @@ resources:
               schema: ${var.schema}
           environment_key: default
 
+        - task_key: discover_budgets
+          description: "Read the account Budgets API (/api/2.1/accounts/{id}/budgets) → Delta (uag_budget_status). Read-only config inventory: cap thresholds, enforce (BLOCK_USAGE) vs alert-only, filter, AI-relevance. Needs account-SP creds in discovery_sp_secret_scope; degrades to empty otherwise."
+          notebook_task:
+            notebook_path: ./13_discover_budgets.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              account_id: ${var.account_id}
+              account_host: ${var.account_host}
+              discovery_sp_secret_scope: ${var.discovery_sp_secret_scope}
+          environment_key: default
+
+        - task_key: discover_endpoint_inventory
+          description: "Account-wide served-entity inventory from system.serving.served_entities → Delta (serving_endpoints_inventory). Read-only fleet view across all workspaces in the metastore."
+          notebook_task:
+            notebook_path: ./14_discover_endpoint_inventory.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+          environment_key: default
+
+        - task_key: discover_model_services
+          description: "v3 Unity Gateway UC model services via UC REST (run-as metastore admin — the list endpoint the app's OBO/SP identities can't reach) → Delta (model_services_inventory)."
+          notebook_task:
+            notebook_path: ./15_discover_model_services.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+          environment_key: default
+
         - task_key: sync_to_lakebase
           description: "Sync all discovery data (Delta → Lakebase) + system table billing"
           depends_on:
             - task_key: discover_agents
+            - task_key: discover_endpoint_inventory
             - task_key: discover_observability
             - task_key: discover_knowledge_bases
             - task_key: discover_user_analytics
@@ -182,6 +216,8 @@ resources:
             - task_key: discover_gateway_inference_logs
             - task_key: discover_billing
             - task_key: discover_ai_gateway_usage
+            - task_key: discover_budgets
+            - task_key: discover_model_services
           notebook_task:
             notebook_path: ./02_sync_to_lakebase.py
             base_parameters:


### PR DESCRIPTION
## Summary

Rolls up two unreleased sessions of work since `0.1.2` into a **0.1.3** patch release. Grows the **Unity Gateway** (v3) read-only story and moves the app's read layer onto cached Lakebase tables where it was still doing live per-load calls.

## Added
- **Budget status + consumption (F5)** — fleet-wide native-budget inventory (caps, enforce vs alert-only, filter, AI-relevance) + month-to-date spend vs cap (%-used), sortable/paginated. New `13_discover_budgets` → `uag_budget_status`. Read-only; enforcement stays platform-side.
- **Account-wide endpoint inventory** — read-only served-entity fleet view from `system.serving.served_entities`. New `14_discover_endpoint_inventory` → `serving_endpoints_inventory`.
- **v3 Unity Gateway UC model services (read-only)** — metastore-wide list via UC REST (workflow run-as metastore admin) + live per-service grant reads. New `15_discover_model_services` → `model_services_inventory`.
- **Model Registry version cache** — all versions per model cached to `mlflow_model_versions`; `/mlflow/models/{name}/versions` reads cache-first, live only on cold cache.
- **MLflow trace-detail write-through** — SP-fetched trace details persisted to `observability_trace_details` on cache miss.

## Changed
- **AI Gateway page reorganized + rebranded "Unity Gateway"** (Beta/version labels removed); v1 views consolidated into a **Legacy AI Gateway** tab; Budgets moved beside Unity Gateway; Requests/Tokens-per-day charts under the KPI cards.
- **Tools → MCP Usage** sortable + paginated.
- **Budget list uncapped** (`/gateway/uag-budget-status` returns all rows; frontend paginates).

## Removed
- Dead tabs pruned: Observability **Gateway Requests** / **Quality & Evals**, Governance **Guardrails**.

## Fixed
- `10_smoke_check_lakebase` `authenticate()` crash.
- Budget month-to-date total includes NULL-workspace (account-level) usage.
- Model-versions discovery orders by `last_updated_timestamp DESC` (cap keeps newest, with retry-without-order_by fallback), escapes single quotes in the name filter, and no longer wipes the cached table on a transient full-enumeration failure.

## Security
- **Trace-detail write-through scoped to SP-authority fetches only.** `observability_trace_details` is a shared cache served to all app users without a per-user authz recheck; persisting a user-scoped (OBO) fetch could expose a trace to users who can't see it. Write-through now fires only for SP fetches, keeping the cache ⊆ SP-visible data. Cross-workspace detail (always OBO) stays live-per-request.

## Verification
Deployed to a sandbox (app deploy SUCCEEDED, discovery job 15/15 SUCCESS, smoke PASS); model-version cache = 561 rows / 241 models.

This pull request and its description were written by Isaac.